### PR TITLE
Initial move of source files and runtests from CalibrateEmulateSample

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,14 @@ uuid = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 authors = ["CLIMA contributors <clima-software@caltech.edu>"]
 version = "0.1.0"
 
+[deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/DataStorage.jl
+++ b/src/DataStorage.jl
@@ -1,0 +1,116 @@
+module DataStorage
+
+## Imports
+import Base: size #must import to add a definition to size
+
+##Exports
+export DataContainer, PairedDataContainer
+export size
+export get_data, get_inputs, get_outputs
+
+## Objects
+"""
+    struct DataContainer{FT <: Real}
+
+struct to store data samples as columns in an array
+"""
+struct DataContainer{FT <: Real}
+    #stored data, each piece of data is a column [data dimension × number samples]
+    stored_data::Array{FT,2}    
+    #constructor with 2D arrays
+    function DataContainer(
+        stored_data::Array{FT,2};
+        data_are_columns=true) where {FT <: Real}
+
+        if data_are_columns
+            new{FT}(stored_data)
+        else
+            new{FT}(permutedims(stored_data,(2,1)))
+        end
+    end
+end
+
+"""
+    PairedDataContainer{FT <: Real}
+
+stores input - output pairs as data containers, there must be an equal number of inputs and outputs
+"""
+struct PairedDataContainer{FT <: Real}
+    # container for inputs and ouputs, each Container holds an array
+    # size [data/parameter dimension × number samples]
+    inputs::DataContainer{FT} 
+    outputs::DataContainer{FT}
+
+    #constructor with 2D Arrays
+    function PairedDataContainer(
+        inputs::Array{FT,2},
+        outputs::Array{FT,2};
+        data_are_columns=true) where {FT <: Real}
+
+        sample_dim = data_are_columns ? 2 : 1
+        if !(size(inputs,sample_dim) == size(outputs,sample_dim))
+                throw(DimensionMismatch("There must be the same number of samples of both inputs and outputs"))
+        end
+        
+        stored_inputs = DataContainer(inputs; data_are_columns=data_are_columns)
+        stored_outputs = DataContainer(outputs; data_are_columns=data_are_columns)
+        new{FT}(stored_inputs,stored_outputs)
+        
+    end
+    #constructor with DataContainers
+    function PairedDataContainer(
+        inputs::DataContainer,
+        outputs::DataContainer)
+
+        if !(size(inputs,2) == size(outputs,2))
+            throw(DimensionMismatch("There must be the same number of samples of both inputs and outputs"))    
+        else
+            FT = eltype(get_data(inputs))
+            new{FT}(inputs,outputs)
+        end
+    end
+    
+end
+
+## functions
+"""
+    size(dc::DataContainer,idx::IT) where {IT <: Integer}
+
+returns the size of the stored data (if idx provided, it returns the size along dimension idx) 
+"""
+function size(dc::DataContainer)
+    return size(dc.stored_data)
+end
+
+function size(dc::DataContainer,idx::IT) where {IT <: Integer}
+    return size(dc.stored_data,idx)
+end
+
+function size(pdc::PairedDataContainer)
+    return size(pdc.inputs), size(pdc.outputs)
+end
+"""
+    size(pdc::PairedDataContainer,idx::IT) where {IT <: Integer}
+
+returns the sizes of the inputs and ouputs along dimension idx (if provided)
+"""
+function size(pdc::PairedDataContainer,idx::IT) where {IT <: Integer}
+    return size(pdc.inputs,idx), size(pdc.outputs,idx)
+end
+
+function get_data(dc::DataContainer)
+    return dc.stored_data
+end
+function get_data(pdc::PairedDataContainer)
+    return get_inputs(pdc), get_outputs(pdc)
+end
+
+function get_inputs(pdc::PairedDataContainer)
+    return get_data(pdc.inputs)
+end
+function get_outputs(pdc::PairedDataContainer)
+    return get_data(pdc.outputs)
+end
+
+
+end

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -1,0 +1,339 @@
+module EnsembleKalmanProcessModule
+
+
+using ..ParameterDistributionStorage
+using ..DataStorage
+
+using Random
+using Statistics
+using Distributions
+using LinearAlgebra
+using DocStringExtensions
+
+export EnsembleKalmanProcess, Inversion, Sampler
+export get_u, get_g
+export get_u_prior, get_u_final, get_g_final, get_N_iterations, get_error
+export construct_initial_ensemble
+export compute_error!
+export update_ensemble!
+export find_ekp_stepsize
+
+
+abstract type Process end
+
+"""
+    Inversion <: Process
+
+An ensemble Kalman Inversion process
+"""
+struct Inversion <: Process end
+
+"""
+    Sampler{FT<:AbstractFloat,IT<:Int} <: Process
+
+An ensemble Kalman Sampler process
+"""
+struct Sampler{FT<:AbstractFloat} <: Process
+  ""
+  prior_mean::Vector{FT}
+  ""
+  prior_cov::Array{FT, 2}
+end
+
+"""
+    EnsembleKalmanProcess{FT<:AbstractFloat, IT<:Int}
+
+Structure that is used in Ensemble Kalman processes
+
+#Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct EnsembleKalmanProcess{FT<:AbstractFloat, IT<:Int, P<:Process}
+    "Array of stores for parameters (u), each of size [parameter_dim × N_ens]"
+    u::Array{DataContainer{FT}}
+    "vector of the observed vector size [data_dim]"
+    obs_mean::Vector{FT}
+    "covariance matrix of the observational noise, of size [data_dim × data_dim]"
+    obs_noise_cov::Array{FT, 2}
+    "ensemble size"
+    N_ens::IT
+    "Array of stores for forward model outputs, each of size  [data_dim × N_ens]"
+    g::Array{DataContainer{FT}}
+    "vector of errors"
+    err::Vector{FT}
+    "vector of timesteps used in each EK iteration"
+    Δt::Vector{FT}
+    "the particular EK process (`Inversion` or `Sampler`)"
+    process::P
+end
+
+# outer constructors
+function EnsembleKalmanProcess(params::Array{FT, 2},
+                               obs_mean,
+                               obs_noise_cov::Array{FT, 2},
+                               process::P;
+                               Δt=FT(1)) where {FT<:AbstractFloat, P<:Process}
+
+    #initial parameters stored as columns
+    init_params=DataContainer(params, data_are_columns=true)
+    # ensemble size
+    N_ens = size(init_params,2) #stored with data as columns
+    IT = typeof(N_ens)
+    #store for model evaluations
+    g=[] 
+    # error store
+    err = FT[]
+    # timestep store
+    Δt = Array([Δt])
+
+    EnsembleKalmanProcess{FT, IT, P}([init_params], obs_mean, obs_noise_cov, N_ens, g,
+                                     err, Δt, process)
+end
+
+
+
+"""
+    get_X(ekp::EnsembleKalmanProcess, iteration::IT; return_array=true) where {IT <: Integer}
+
+Get X=u or X=g for the EKI iteration. Returns a DataContainer object unless array is specified.
+"""
+function get_u(ekp::EnsembleKalmanProcess, iteration::IT; return_array=true) where {IT <: Integer}
+    return  return_array ? get_data(ekp.u[iteration]) : ekp.u[iteration]
+end
+
+function get_g(ekp::EnsembleKalmanProcess, iteration::IT; return_array=true) where {IT <: Integer}
+    return return_array ? get_data(ekp.g[iteration]) : ekp.g[iteration]
+end
+
+function get_u(ekp::EnsembleKalmanProcess; return_array=true) where {IT <: Integer}
+    N_stored_u = get_N_iterations(ekp)+1
+    return [get_u(ekp, it, return_array=return_array) for it in 1:N_stored_u]
+end
+
+function get_g(ekp::EnsembleKalmanProcess; return_array=true) where {IT <: Integer}
+    N_stored_g = get_N_iterations(ekp)
+    return [get_g(ekp, it, return_array=return_array) for it in 1:N_stored_g]
+end
+
+
+"""
+    get_u_final(ekp::EnsembleKalmanProcess, return_array=true)
+    get_u_prior(ekp::EnsembleKalmanProcess, return_array=true)
+    get_g_final(ekp::EnsembleKalmanProcess, return_array=true)
+
+Get the final or prior iteration of parameters or model ouputs, returns a DataContainer Object if return_array is false.
+"""
+function get_u_final(ekp::EnsembleKalmanProcess; return_array=true)
+    return return_array ? get_u(ekp,size(ekp.u)[1]) : ekp.u[end]
+end
+
+function get_u_prior(ekp::EnsembleKalmanProcess; return_array=true)
+    return return_array ? get_u(ekp,1) : ekp.u[1]
+end
+
+function get_g_final(ekp::EnsembleKalmanProcess; return_array=true)
+    return return_array ? get_g(ekp,size(ekp.g)[1]) : ekp.g[end]
+end
+
+"""
+    get_N_iterations(ekp::EnsembleKalmanProcess
+
+get number of times update has been called (equals size(g), or size(u)-1) 
+"""
+function get_N_iterations(ekp::EnsembleKalmanProcess)
+    return size(ekp.u)[1] - 1 
+end
+"""
+    construct_initial_ensemble(prior::ParameterDistribution, N_ens::IT; rng_seed=42) where {IT<:Int}
+
+Construct the initial parameters, by sampling N_ens samples from specified
+prior distribution. Returned with parameters as columns
+"""
+function construct_initial_ensemble(prior::ParameterDistribution, N_ens::IT; rng_seed=42) where {IT<:Int}
+    # Ensuring reproducibility of the sampled parameter values
+    Random.seed!(rng_seed)
+    parameters = sample_distribution(prior, N_ens) #of size [dim(param space) N_ens]
+    return parameters
+end
+
+function compute_error!(ekp::EnsembleKalmanProcess)
+    mean_g = dropdims(mean(get_g_final(ekp), dims=2), dims=2)
+    diff = ekp.obs_mean - mean_g
+    X = ekp.obs_noise_cov \ diff # diff: column vector
+    newerr = dot(diff, X)
+    push!(ekp.err, newerr)
+end
+
+function get_error(ekp::EnsembleKalmanProcess)
+    return ekp.err
+end
+
+"""
+   find_ekp_stepsize(ekp::EnsembleKalmanProcess{FT, IT, Inversion}, g::Array{FT, 2}; cov_threshold::FT=0.01) where {FT}
+Find largest stepsize for the EK solver that leads to a reduction of the determinant of the sample
+covariance matrix no greater than cov_threshold. 
+"""
+function find_ekp_stepsize(ekp::EnsembleKalmanProcess{FT, IT, Inversion}, g::Array{FT,2}; cov_threshold::FT=0.01) where {FT, IT}
+    accept_stepsize = false
+    if !isempty(ekp.Δt)
+        Δt = deepcopy(ekp.Δt[end])
+    else
+        Δt = FT(1)
+    end
+    # final_params [parameter_dim × N_ens]
+    cov_init = cov(get_u_final(ekp), dims=2)
+    while accept_stepsize == false
+        ekp_copy = deepcopy(ekp)
+        update_ensemble!(ekp_copy, g, Δt_new=Δt)
+        cov_new = cov(get_u_final(ekp_copy), dims=2)
+        if det(cov_new) > cov_threshold * det(cov_init)
+            accept_stepsize = true
+        else
+            Δt = Δt/2
+        end
+    end
+
+    return Δt
+
+end
+
+"""
+    update_ensemble!(ekp::EnsembleKalmanProcess{FT, IT, <:Process}, g_in::Array{FT,2} cov_threshold::FT=0.01, Δt_new=nothing) where {FT, IT}
+
+Updates the ensemble according to which type of Process we have. Model outputs g_in need to be a output_dim × n_samples array (i.e data are columms)
+"""
+function update_ensemble!(ekp::EnsembleKalmanProcess{FT, IT, Inversion}, g_in::Array{FT,2}; cov_threshold::FT=0.01, Δt_new=nothing) where {FT, IT}
+
+    #catch works when g non-square
+    if !(size(g_in)[2] == ekp.N_ens) 
+         throw(DimensionMismatch("ensemble size in EnsembleKalmanProcess and g_in do not match, try transposing g_in or check ensemble size"))
+    end
+
+    # We enforce that data are rows here...
+    # u: N_ens × parameter_dim
+    # g: N_ens × data_dim
+    u_old = get_u_final(ekp)
+    u_old = permutedims(u_old,(2,1))    
+    u = u_old
+    g = permutedims(g_in,(2,1))
+    
+           
+    cov_init = cov(u, dims=1)
+
+    u_bar = fill(FT(0), size(u)[2])
+    # g: N_ens × data_dim
+    g_bar = fill(FT(0), size(g)[2])
+
+    cov_ug = fill(FT(0), size(u)[2], size(g)[2])
+    cov_gg = fill(FT(0), size(g)[2], size(g)[2])
+
+    if !isnothing(Δt_new)
+        push!(ekp.Δt, Δt_new)
+    elseif isnothing(Δt_new) && isempty(ekp.Δt)
+        push!(ekp.Δt, FT(1))
+    else
+        push!(ekp.Δt, ekp.Δt[end])
+    end
+
+    # update means/covs with new param/observation pairs u, g
+    for j = 1:ekp.N_ens
+
+        u_ens = u[j, :]
+        g_ens = g[j, :]
+
+        # add to mean
+        u_bar += u_ens
+        g_bar += g_ens
+
+        #add to cov
+        cov_ug += u_ens * g_ens' # cov_ug is [parameter_dim × data_dim]
+        cov_gg += g_ens * g_ens'
+    end
+
+    u_bar = u_bar / ekp.N_ens
+    g_bar = g_bar / ekp.N_ens
+    cov_ug = cov_ug / ekp.N_ens - u_bar * g_bar'
+    cov_gg = cov_gg / ekp.N_ens - g_bar * g_bar'
+
+    # Update the parameters (with additive noise too)
+    noise = rand(MvNormal(zeros(size(g)[2]),
+                          ekp.obs_noise_cov/ekp.Δt[end]), ekp.N_ens) # data_dim × N_ens
+    # Add obs_mean (data_dim) to each column of noise (data_dim × N_ens), then
+    # transpose into N_ens × data_dim
+    y = (ekp.obs_mean .+ noise)'
+    # data_dim × data_dim \ [N_ens × data_dim - N_ens × data_dim]'
+    # --> tmp is data_dim × N_ens
+    tmp = (cov_gg + ekp.obs_noise_cov) \ (y - g)'
+    u += (cov_ug * tmp)' # N_ens × parameter_dim
+
+    # store new parameters (and model outputs)
+    push!(ekp.u, DataContainer(u, data_are_columns=false))
+    push!(ekp.g, DataContainer(g, data_are_columns=false))
+    # u_old is N_ens × parameter_dim, g is N_ens × data_dim,
+    # but stored in data container with N_ens as the 2nd dim
+    
+    compute_error!(ekp)
+
+    # Check convergence
+    cov_new = cov(get_u_final(ekp), dims=2)
+    cov_ratio = det(cov_new) / det(cov_init)
+    if cov_ratio < cov_threshold
+        @warn string("New ensemble covariance determinant is less than ",
+                     cov_threshold, " times its previous value.",
+                     "\nConsider reducing the EK time step.")
+    end
+end
+
+function update_ensemble!(ekp::EnsembleKalmanProcess{FT, IT, Sampler{FT}}, g_in::Array{FT,2}) where {FT, IT}
+
+    #catch works when g_in non-square 
+    if !(size(g_in)[2] == ekp.N_ens) 
+         throw(DimensionMismatch("ensemble size in EnsembleKalmanProcess and g_in do not match, try transposing or check ensemble size"))
+    end
+
+    # u: N_ens × parameter_dim
+    # g: N_ens × data_dim
+    u_old = get_u_final(ekp)
+    u_old = permutedims(u_old,(2,1))
+    u = u_old
+    g = permutedims(g_in, (2,1))
+   
+    # u_mean: parameter_dim × 1
+    u_mean = mean(u', dims=2)
+    # g_mean: data_dim × 1
+    g_mean = mean(g', dims=2)
+    # g_cov: data_dim × data_dim
+    g_cov = cov(g, corrected=false)
+    # u_cov: parameter_dim × parameter_dim
+    u_cov = cov(u, corrected=false)
+
+    # Building tmp matrices for EKS update:
+    E = g' .- g_mean
+    R = g' .- ekp.obs_mean
+    # D: N_ens × N_ens
+    D = (1/ekp.N_ens) * (E' * (ekp.obs_noise_cov \ R))
+
+    Δt = 1/(norm(D) + 1e-8)
+
+    noise = MvNormal(u_cov)
+
+    implicit = (1 * Matrix(I, size(u)[2], size(u)[2]) + Δt * (ekp.process.prior_cov' \ u_cov')') \
+                  (u'
+                    .- Δt * ( u' .- u_mean) * D
+                    .+ Δt * u_cov * (ekp.process.prior_cov \ ekp.process.prior_mean)
+                  )
+
+    u = implicit' + sqrt(2*Δt) * rand(noise, ekp.N_ens)'
+
+    # store new parameters (and model outputs)
+    push!(ekp.u, DataContainer(u, data_are_columns=false))
+    push!(ekp.g, DataContainer(g, data_are_columns=false))
+    # u_old is N_ens × parameter_dim, g is N_ens × data_dim,
+    # but stored in data container with N_ens as the 2nd dim
+
+    compute_error!(ekp)
+
+end
+
+
+end # module

--- a/src/EnsembleKalmanProcesses.jl
+++ b/src/EnsembleKalmanProcesses.jl
@@ -1,7 +1,12 @@
 module EnsembleKalmanProcesses
 
-function hello()
-    "hello world"
-end
+using Distributions, Statistics, LinearAlgebra, DocStringExtensions
 
-end
+#auxilliaries
+include("ParameterDistribution.jl")
+include("DataStorage.jl")
+
+#updates:
+include("EnsembleKalmanProcess.jl")
+
+end # module

--- a/src/EnsembleKalmanProcesses.jl
+++ b/src/EnsembleKalmanProcesses.jl
@@ -5,6 +5,7 @@ using Distributions, Statistics, LinearAlgebra, DocStringExtensions
 #auxilliaries
 include("ParameterDistribution.jl")
 include("DataStorage.jl")
+include("Observations.jl")
 
 #updates:
 include("EnsembleKalmanProcess.jl")

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -1,0 +1,158 @@
+module Observations
+
+using DocStringExtensions
+using LinearAlgebra
+using Statistics
+
+export Obs
+
+"""
+    Obs{FT<:AbstractFloat}
+
+Structure that contains the observations
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct Obs{FT<:AbstractFloat}
+    "vector of observational samples, each of length sample_dim"
+    samples::Vector{Vector{FT}}
+    "covariance of the observational noise (assumed to be normally 
+    distributed); sample_dim x sample_dim (where sample_dim is the number of 
+    elements in each sample), or a scalar if the sample dim is 1. If not 
+    supplied, obs_noise_cov is set to a diagonal matrix whose non-zero elements 
+    are the variances of the samples, or to a scalar variance in the case of 
+    1d samples. obs_noise_cov is set to nothing if only a single sample is 
+    provided."
+    obs_noise_cov::Union{Array{FT, 2}, FT, Nothing}
+    "sample mean"
+    mean::Union{Vector{FT}, FT}
+    "names of the data"
+    data_names::Union{Vector{String}, String}
+end
+
+# Constructors
+function Obs(samples::Vector{Vector{FT}},
+             data_names::Union{Vector{String}, String}) where {FT<:AbstractFloat}
+
+    N_samples = length(samples)
+    # convert to N_samples x sample_dim to determine sample covariance
+
+    if N_samples == 1
+        # only one sample - this requires a bit more data massaging
+        temp1 = convert(Array, reshape(hcat(samples...)', N_samples, :))
+        temp = dropdims(temp1, dims=1)
+        samplemean = vec(mean(temp, dims=2))
+        obs_noise_cov = nothing
+    else
+        temp = convert(Array, reshape(hcat(samples...)', N_samples, :))
+        if size(temp, 2) == 1
+            # We have 1D samples, so the sample mean and covariance (which in
+            # this case is actually the covariance) are scalars
+            samplemean = mean(temp)
+            obs_noise_cov = var(temp)
+        else
+            samplemean = vec(mean(temp, dims=1))
+            obs_noise_cov = cov(temp)
+        end
+    end
+    Obs(samples, obs_noise_cov, samplemean, data_names)
+end
+
+function Obs(samples::Array{FT, 2},
+             data_names::Union{Vector{String}, String}) where {FT<:AbstractFloat}
+
+    # samples is of size sample_dim x N_samples
+    sample_dim, N_samples = size(samples)
+
+    if N_samples == 1
+        # Only one sample, so there is no covariance to be computed and the 
+        # sample mean equals the sample itself
+        obs_noise_cov = nothing
+        samplemean = vec(samples)
+        samples_vec = vec([vec(samples)])
+
+    else
+        # convert matrix of samples to a vector of vectors
+        samples_vec = [samples[:, i] for i in 1:N_samples]
+        if sample_dim == 1
+            # We have 1D samples, so the sample mean and covariance (which in 
+            # this case is actually the variance) are scalars
+            samplemean = mean(samples)
+            obs_noise_cov = var(samples)
+        else
+            samplemean = vec(mean(samples, dims=2))
+            obs_noise_cov = cov(samples, dims=2)
+        end
+    end
+    Obs(samples_vec, obs_noise_cov, samplemean, data_names)
+end
+
+function Obs(samples::Vector{Vector{FT}},
+             obs_noise_cov::Array{FT, 2},
+             data_names::Union{Vector{String}, String}) where {FT<:AbstractFloat}
+
+    N_samples = length(samples)
+    sample_dim = length(samples[1])
+    # convert to N_samples x sample_dim to determine sample covariance
+
+    if N_samples == 1
+        # only one sample - this requires a bit more data massaging
+        temp1 = convert(Array, reshape(hcat(samples...)', N_samples, :))
+        temp = dropdims(temp1, dims=1)
+        samplemean = vec(mean(temp, dims=2))
+    else
+        if sample_dim == 1
+            # We have 1D samples, so the sample mean and covariance (which in
+            # this case is actually the covariance) are scalars
+            samplemean = mean(temp)
+            err = ("When sample_dim is 1, obs_cov_noise must be a scalar.
+                   \tsample_dim: number of elements per observation sample")
+            @assert(ndims(obs_noise_cov) == 0, err)
+        else
+            temp = convert(Array, reshape(hcat(samples...)', N_samples, :))
+            samplemean = vec(mean(temp, dims=1))
+            err = ("obs_cov_noise must be of size sample_dim x sample_dim.
+                   \tsample_dim: number of elements per observation sample")
+            @assert(size(obs_noise_cov) == (sample_dim, sample_dim), err)
+        end
+    end
+
+
+    Obs(samples, obs_noise_cov, samplemean, data_names)
+end
+
+function Obs(samples::Array{FT, 2},
+             obs_noise_cov::Union{Array{FT, 2}, Nothing},
+             data_names::Union{Vector{String}, String})where {FT<:AbstractFloat}
+
+    # samples is of size N_samples x sample_dim
+    sample_dim, N_samples = size(samples)
+    if N_samples == 1
+        # Only one sample, so there is no covariance to be computed and the 
+        # sample mean equals the sample itself
+        obs_noise_cov = nothing
+        samplemean = vec(samples)
+        samples_vec = vec([vec(samples)])
+    else
+        # convert matrix of samples to a vector of vectors
+        samples_vec = [samples[:, i] for i in 1:N_samples]
+        if sample_dim == 1
+            # We have 1D samples, so the sample mean and covariance (which in 
+            # this case is actually the variance) are scalars
+            samplemean = mean(samples)
+            err = ("When sample_dim is 1, obs_cov_noise must be a scalar.
+                   \tsample_dim: number of elements per observation sample")
+            @assert(ndims(obs_noise_cov) == 0, err)
+        else
+            samplemean = vec(mean(samples, dims=2))
+            err = ("obs_cov_noise must be of size sample_dim x sample_dim.
+                   \tsample_dim: number of elements per observation sample")
+            @assert(size(obs_noise_cov) == (sample_dim, sample_dim), err)
+        end
+    end
+
+    Obs(samples_vec, obs_noise_cov, samplemean, data_names)
+end
+
+end # module Observations

--- a/src/ParameterDistribution.jl
+++ b/src/ParameterDistribution.jl
@@ -1,0 +1,412 @@
+module ParameterDistributionStorage
+
+## Imports
+using Distributions
+using Statistics
+using StatsBase
+using Random
+
+## Exports
+
+#types
+
+export ParameterDistributionType
+#objects
+export Parameterized, Samples
+export ParameterDistribution
+export Constraint
+
+#functions
+export get_name, get_distribution, get_total_dimension, get_dimensions, get_all_constraints, get_n_samples
+export sample_distribution
+export no_constraint, bounded_below, bounded_above, bounded
+export transform_constrained_to_unconstrained, transform_unconstrained_to_constrained
+export get_logpdf, get_cov, get_var, get_mean, batch
+    
+## Objects
+# for the Distribution
+abstract type ParameterDistributionType end
+
+"""
+    struct Parameterized <: ParameterDistributionType
+    
+A distribution constructed from a parametrized formula (e.g Julia Distributions.jl)
+"""
+struct Parameterized <: ParameterDistributionType
+    distribution::Distribution
+end
+
+"""
+    struct Samples{FT<:Real} <: ParameterDistributionType
+
+A distribution comprised of only samples, stored as columns of parameters
+"""
+struct Samples{FT<:Real} <: ParameterDistributionType
+    distribution_samples::Array{FT,2} #parameters are columns
+    Samples(distribution_samples::Array{FT,2}; params_are_columns=true) where {FT <: Real} = params_are_columns ? new{FT}(distribution_samples) : new{FT}(permutedims(distribution_samples,(2,1)))
+    #Distinguish 1 sample of an ND parameter or N samples of 1D parameter, and store as 2D array  
+    Samples(distribution_samples::Array{FT,1}; params_are_columns=true) where {FT <: Real} = params_are_columns ? new{FT}(reshape(distribution_samples,1,:)) : new{FT}(reshape(distribution_samples,:,1))
+    
+end 
+
+
+# For the transforms
+abstract type ConstraintType end
+"""
+    struct Constraint <: ConstraintType
+
+Contains two functions to map between constrained and unconstrained spaces.
+"""
+
+struct Constraint <: ConstraintType
+    constrained_to_unconstrained::Function
+    unconstrained_to_constrained::Function
+end
+
+
+"""
+    function no_constraint()
+
+Constructs a Constraint with no constraints, enforced by maps x -> x and x -> x.
+"""
+function no_constraint()
+    c_to_u = (x -> x)
+    u_to_c = (x -> x)
+    return Constraint(c_to_u,u_to_c)
+end
+    
+"""
+    function bounded_below(lower_bound::FT) where {FT <: Real}
+
+Constructs a Constraint with provided lower bound, enforced by maps x -> log(x - lower_bound) and x -> exp(x) + lower_bound.
+"""
+function bounded_below(lower_bound::FT) where {FT <: Real}
+    c_to_u = ( x -> log(x - lower_bound) )
+    u_to_c = ( x -> exp(x) + lower_bound ) 
+    return Constraint(c_to_u, u_to_c)
+end
+
+"""
+    function bounded_above(upper_bound::FT) where {FT <: Real} 
+
+Constructs a Constraint with provided upper bound, enforced by maps x -> log(upper_bound - x) and x -> upper_bound - exp(x).
+"""
+function bounded_above(upper_bound::FT) where {FT<:Real}
+    c_to_u = ( x -> log(upper_bound - x) )
+    u_to_c = ( x -> upper_bound - exp(x) ) 
+    return Constraint(c_to_u, u_to_c)
+end
+    
+
+"""
+    function bounded(lower_bound::FT, upper_bound::FT) where {FT <: Real} 
+
+Constructs a Constraint with provided upper and lower bounds, enforced by maps
+x -> log((x - lower_bound) / (upper_bound - x))
+and
+x -> (upper_bound * exp(x) + lower_bound) / (exp(x) + 1)
+
+"""
+function bounded(lower_bound::FT, upper_bound::FT) where {FT <: Real}
+    if (upper_bound <= lower_bound)
+        throw(DomainError("upper bound must be greater than lower bound"))
+    end
+    c_to_u = ( x -> log( (x - lower_bound) / (upper_bound - x)) )
+    u_to_c = ( x -> (upper_bound * exp(x) + lower_bound) / (exp(x) + 1) )
+    return Constraint(c_to_u, u_to_c)
+end
+
+"""
+    function len(c::Array{CType})
+
+The number of constraints, each constraint has length 1.
+"""
+function len(c::CType) where {CType <: ConstraintType}
+    return 1
+end
+
+function len(carray::Array{CType}) where {CType <: ConstraintType}
+    return size(carray)[1]
+end
+
+"""
+    function get_dimensions(d<:ParametrizedDistributionType)
+
+The number of dimensions of the parameter space
+"""
+function dimension(d::Parameterized) 
+    return length(d.distribution)
+end
+
+function dimension(d::Samples)
+    return size(d.distribution_samples)[1]
+end
+
+"""
+    function n_samples(d::Samples)
+
+The number of samples in the array
+"""
+function n_samples(d::Samples)
+    return size(d.distribution_samples)[2]
+end
+function n_samples(d::Parameterized)
+    return "Distribution stored in Parameterized form, draw samples using `sample_distribution` function" 
+end
+
+"""
+    struct ParameterDistribution
+
+Structure to hold a parameter distribution, always stored as an array of distributions
+"""
+struct ParameterDistribution{PDType <: ParameterDistributionType, CType <: ConstraintType, ST <: AbstractString}
+    distributions::Array{PDType}
+    constraints::Array{CType}
+    names::Array{ST}
+
+    function ParameterDistribution(parameter_distributions::Union{PDType,Array{PDType}},
+                                   constraints::Union{CType, Array{CType}, Array},
+                                   names::Union{ST, Array{ST}}) where {PDType <: ParameterDistributionType,
+                                                                       CType <: ConstraintType,
+                                                                       ST <: AbstractString}
+        
+        parameter_distributions = isa(parameter_distributions, PDType) ? [parameter_distributions] : parameter_distributions
+        n_parameters_per_dist = [dimension(pd) for pd in parameter_distributions]
+        constraints = isa(constraints, Union{<:ConstraintType,Array{<:ConstraintType}}) ? [constraints] : constraints #to calc n_constraints_per_dist
+        names = isa(names, ST) ? [names] : names
+            
+        n_constraints_per_dist = [len(c) for c in constraints]
+        n_dists = length(parameter_distributions)
+        n_names = length(names)
+        if !(n_parameters_per_dist == n_constraints_per_dist)
+            throw(DimensionMismatch("There must be one constraint per parameter in a distribution, use NoConstraint() type if no constraint is required"))
+        elseif !(n_dists == n_names)
+            throw(DimensionMismatch("There must be one name per parameter distribution"))
+        else            
+            constraints = cat(constraints...,dims=1)
+            
+            new{PDType,ConstraintType,ST}(parameter_distributions, constraints, names)
+        end
+    end
+    
+end
+    
+
+
+## Functions
+
+"""
+    function get_name(pd::ParameterDistribution)
+
+Returns a list of ParameterDistribution names
+"""
+function get_name(pd::ParameterDistribution)
+    return pd.names
+end
+
+"""
+    function get_dimensions(pd::ParameterDistribution)
+
+The number of dimensions of the parameter space
+"""
+function get_dimensions(pd::ParameterDistribution)
+    return [dimension(d) for d in pd.distributions]
+end
+function get_total_dimension(pd::ParameterDistribution)
+    return sum(dimension(d) for d in pd.distributions)
+end
+
+"""
+    function get_n_samples(pd::ParameterDistribution)
+
+The number of samples in a Samples distribution
+"""
+function get_n_samples(pd::ParameterDistribution)
+    return Dict{String,Any}(pd.names[i] => n_samples(d) for (i,d) in enumerate(pd.distributions))
+end
+
+"""
+    function get_all_constraints(pd::ParameterDistribution)
+
+returns the (flattened) array of constraints of the parameter distribution
+"""
+function get_all_constraints(pd::ParameterDistribution)
+    return pd.constraints 
+end
+
+"""
+    function batch(pd:ParameterDistribution)
+
+Returns a list of contiguous [collect(1:i), collect(i+1:j),... ] used to split parameter arrays by distribution dimensions
+"""
+function batch(pd::ParameterDistribution)
+    #chunk xarray to give to the different distributions.
+    d_dim = get_dimensions(pd) #e.g [4,1,2]
+    d_dim_tmp = Array{Int64}(undef,size(d_dim)[1]+1)
+    d_dim_tmp[1] = 0
+    for i = 2:size(d_dim)[1]+1
+        d_dim_tmp[i] = sum(d_dim[1:i-1]) # e.g [0,4,5,7]
+    end
+    
+    return [collect(d_dim_tmp[i]+1:d_dim_tmp[i+1]) for i = 1:size(d_dim)[1]] # e.g [1:4, 5:5, 6:7]
+end
+
+"""
+    function get_distribution(pd::ParameterDistribution)
+
+Returns a `Dict` of `ParameterDistribution` distributions, with the parameter names as dictionary keys. For parameters represented by `Samples`, the samples are returned as a 2D (parameter_dimension x n_samples) array
+"""
+function get_distribution(pd::ParameterDistribution)
+    return Dict{String,Any}(pd.names[i] => get_distribution(d) for (i,d) in enumerate(pd.distributions))
+end
+
+function get_distribution(d::Samples)
+    return d.distribution_samples
+end
+function get_distribution(d::Parameterized)
+    return d.distribution
+end
+
+"""
+    function sample_distribution(pd::ParameterDistribution)
+
+Draws samples from the parameter distributions returns an array, with parameters as columns
+"""
+function sample_distribution(pd::ParameterDistribution)
+    return sample_distribution(pd,1)
+end
+
+function sample_distribution(pd::ParameterDistribution, n_draws::IT) where {IT <: Integer}
+    return cat([sample_distribution(d,n_draws) for d in pd.distributions]...,dims=1)
+end
+
+function sample_distribution(d::Samples, n_draws::IT)  where {IT <: Integer}
+    n_stored_samples = n_samples(d)
+    samples_idx = StatsBase.sample(collect(1:n_stored_samples), n_draws)
+    if dimension(d) == 1
+        return reshape(d.distribution_samples[:,samples_idx],:,n_draws) #columns are parameters
+    else
+        return d.distribution_samples[:,samples_idx]
+    end
+end
+
+function sample_distribution(d::Parameterized, n_draws::IT) where {IT <: Integer}
+    if dimension(d) == 1
+        return reshape(rand(d.distribution,n_draws), :, n_draws) #columns are parameters
+    else
+        return rand(d.distribution, n_draws)
+    end
+end
+
+"""
+    function logpdf(pd::ParameterDistribution, xarray::Array{<:Real,1})
+
+Obtains the independent logpdfs of the parameter distributions at xarray (non-Samples Distributions only), and returns their sum.
+"""
+function get_logpdf(d::Parameterized, xarray::Array{FT,1}) where {FT <: Real}
+    return logpdf.(d.distribution, xarray)
+end
+
+function get_logpdf(pd::ParameterDistribution, xarray::Array{FT,1}) where {FT <: Real}
+    #first check we don't have sampled distribution
+    for d in pd.distributions
+        if typeof(d) <: Samples
+            throw(ErrorException("Cannot compute get_logpdf of Samples distribution. Consider using a Parameterized type for your prior."))
+        end
+    end
+    #assert xarray correct dim/length
+    if size(xarray)[1] != get_total_dimension(pd)
+        throw(DimensionMismatch("xarray must have dimension equal to the parameter space"))
+    end
+    
+    # get the index of xarray chunks to give to the different distributions.
+    batches = batch(pd)
+
+    # perform the logpdf of each of the distributions, and returns their sum    
+    return sum(cat([get_logpdf(d, xarray[batches[i]]) for (i,d) in enumerate(pd.distributions)]...,dims=1))
+end
+
+"""
+    function get_cov(pd::ParameterDistribution)
+
+returns a blocked covariance of the distributions
+"""
+function get_cov(d::Parameterized)
+    return cov(d.distribution)
+end
+
+function get_cov(d::Samples)
+    return cov(d.distribution_samples, dims=2) #parameters are columns
+end
+
+function get_var(d::Parameterized)
+    return var(d.distribution)
+end
+
+function get_var(d::Samples)
+    return var(d.distribution_samples)
+end
+
+
+function get_cov(pd::ParameterDistribution)
+    #first check we don't have sampled distribution
+    
+    d_dims = get_dimensions(pd)
+    
+    # create each block (co)variance
+    block_cov = Array{Any}(undef,size(d_dims)[1]) 
+    for (i,dimension) in enumerate(d_dims)
+        if dimension == 1
+            block_cov[i] = get_var(pd.distributions[i]) 
+        else
+            block_cov[i] = get_cov(pd.distributions[i])
+        end
+    end
+   
+    return cat(block_cov...,dims=(1,2)) #build the block diagonal (dense) matrix
+    
+end
+"""
+    function get_mean(pd::ParameterDistribution)
+
+returns a mean of the distirbutions
+"""
+
+function get_mean(d::Parameterized)
+    return mean(d.distribution)
+end
+
+function get_mean(d::Samples)
+    return mean(d.distribution_samples, dims=2) #parameters are columns
+end
+
+function get_mean(pd::ParameterDistribution)
+    return reshape(cat([get_mean(d) for d in pd.distributions]...,dims=1),:,1)
+end
+
+
+#apply transforms
+
+"""
+    function transform_constrained_to_unconstrained(pd::ParameterDistribution, x::Array{<:Real})
+
+Apply the transformation to map (possibly constrained) parameters `xarray` into the unconstrained space
+"""
+function transform_constrained_to_unconstrained(pd::ParameterDistribution, xarray::Array{FT}) where {FT <: Real}
+    return cat([c.constrained_to_unconstrained(xarray[i]) for (i,c) in enumerate(pd.constraints)]...,dims=1)
+end
+
+"""
+    function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{Real})
+
+Apply the transformation to map parameters `xarray` from the unconstrained space into (possibly constrained) space
+"""
+function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{FT}) where {FT <: Real}
+    return cat([c.unconstrained_to_constrained(xarray[i]) for (i,c) in enumerate(pd.constraints)]...,dims=1)
+end
+
+
+
+
+
+end # of module

--- a/test/DataStorage/runtests.jl
+++ b/test/DataStorage/runtests.jl
@@ -1,0 +1,43 @@
+using Test
+using Distributions
+using Random
+
+using EnsembleKalmanProcesses.DataStorage
+
+@testset "DataStorage" begin
+    seed=2021
+    Random.seed!(seed)
+        
+    parameter_samples = rand(MvNormal(2,0.1),10) #10 samples of 4D params
+    data_samples = rand(MvNormal(12,2),10) #10 samples of 12D data
+    data_samples_short = data_samples[:,1:end-1]
+
+    new_parameter_samples = rand(MvNormal(2,0.1),10) #10 samples of 4D params
+    new_data_samples = rand(MvNormal(12,2),10) #10 samples of 12D data
+    new_data_samples_short = new_data_samples[:,1:end-1]
+
+    #test DataContainer
+    parameter_samples_T = permutedims(parameter_samples, (2,1))
+    idata = DataContainer(parameter_samples)
+    idata_T = DataContainer(parameter_samples_T, data_are_columns=false)
+
+    @test get_data(idata) == parameter_samples
+    @test get_data(idata_T) == parameter_samples
+    @test size(idata) == size(parameter_samples)
+
+    #test Paired Container
+    idata = DataContainer(parameter_samples)
+    odata = DataContainer(data_samples)
+    odata_short = DataContainer(data_samples_short)
+    
+    @test_throws DimensionMismatch PairedDataContainer(parameter_samples, data_samples_short)
+    iopairs = PairedDataContainer(parameter_samples,data_samples)
+
+    @test_throws DimensionMismatch PairedDataContainer(idata,odata_short)
+    iopairs2 = PairedDataContainer(idata,odata)
+    
+    @test get_data(iopairs) == get_data(iopairs2)
+    @test get_inputs(iopairs) == parameter_samples
+    @test get_outputs(iopairs) == data_samples
+    
+end

--- a/test/EnsembleKalmanProcessModule/runtests.jl
+++ b/test/EnsembleKalmanProcessModule/runtests.jl
@@ -1,0 +1,161 @@
+using Distributions
+using LinearAlgebra
+using Random
+using Test
+
+using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
+using EnsembleKalmanProcesses.ParameterDistributionStorage
+@testset "EnsembleKalmanProcessModule" begin
+
+    # Seed for pseudo-random number generator
+    rng_seed = 41
+    Random.seed!(rng_seed)
+
+    ### Generate data from a linear model: a regression problem with n_par parameters
+    ### and n_obs. G(u) = A \times u, where A : R^n_par -> R
+    n_obs = 10                  # Number of synthetic observations from G(u)
+    n_par =  2                  # Number of parameteres
+    u_star = [-1., 2.]          # True parameters
+    noise_level = .1            # Defining the observation noise level
+    Γy = noise_level * Matrix(I, n_obs, n_obs) # Independent noise for synthetic observations
+    noise = MvNormal(zeros(n_obs), Γy)
+
+    C = [1 -.9; -.9 1]          # Correlation structure for linear operator
+    A = rand(MvNormal(zeros(2,), C), n_obs)'    # Linear operator in R^{n_obs \times n_par}
+
+    @test size(A) == (n_obs, n_par)
+
+    y_star = A * u_star
+    y_obs  = y_star + rand(noise)
+
+    @test size(y_star) == (n_obs,)
+
+    #### Define linear model
+    function G(u)
+        A * u
+    end
+
+    @test norm(y_star - G(u_star)) < n_obs * noise_level^2
+
+    #### Define prior information on parameters
+    prior_distns = [Parameterized(Normal(1., sqrt(2))),
+              Parameterized(Normal(1., sqrt(2)))]
+    constraints = [[no_constraint()], [no_constraint()]]
+    prior_names = ["u1","u2"]
+    prior = ParameterDistribution(prior_distns, constraints, prior_names)
+    
+    prior_mean = reshape(get_mean(prior),:)
+
+    # Assuming independence of u1 and u2
+    prior_cov = get_cov(prior)#convert(Array, Diagonal([sqrt(2.), sqrt(2.)]))
+
+    ###
+    ###  Calibrate (1): Ensemble Kalman Inversion
+    ###
+
+    N_ens = 50 # number of ensemble members
+    N_iter = 20 # number of EKI iterations
+    initial_ensemble = EnsembleKalmanProcessModule.construct_initial_ensemble(prior,N_ens;
+                                                    rng_seed=rng_seed)
+    @test size(initial_ensemble) == (n_par, N_ens)
+
+    ekiobj = EnsembleKalmanProcessModule.EnsembleKalmanProcess(initial_ensemble,
+                       y_obs, Γy, Inversion())
+
+    # Find EKI timestep
+    g_ens = G(get_u_final(ekiobj))
+    @test size(g_ens) == (n_obs, N_ens)
+    # as the columns of g are the data, this should throw an error
+    g_ens_t = permutedims(g_ens, (2,1))
+    @test_throws DimensionMismatch find_ekp_stepsize(ekiobj, g_ens_t)
+    Δ = find_ekp_stepsize(ekiobj, g_ens)
+    @test Δ ≈ 0.0625
+    
+    # EKI iterations
+    params_i_vec = []
+    g_ens_vec = []
+    for i in 1:N_iter
+        params_i = get_u_final(ekiobj)
+        push!(params_i_vec,params_i)
+        g_ens = G(params_i)
+        push!(g_ens_vec, g_ens)
+        if i == 1
+            g_ens_t = permutedims(g_ens, (2,1))
+            @test_throws DimensionMismatch EnsembleKalmanProcessModule.update_ensemble!(ekiobj, g_ens_t)
+        end
+        EnsembleKalmanProcessModule.update_ensemble!(ekiobj, g_ens)
+    end
+    push!(params_i_vec,get_u_final(ekiobj))
+    
+    @test get_u_prior(ekiobj) == params_i_vec[1]
+    @test get_u(ekiobj) == params_i_vec
+    @test get_g(ekiobj) == g_ens_vec
+    @test get_g_final(ekiobj) == g_ens_vec[end]
+    @test get_error(ekiobj) == ekiobj.err
+    
+    # EKI results: Test if ensemble has collapsed toward the true parameter 
+    # values
+    eki_final_result = vec(mean(get_u_final(ekiobj), dims=2))
+    # @test norm(u_star - eki_final_result) < 0.5
+
+    # Plot evolution of the EKI particles
+    eki_final_result = vec(mean(get_u_final(ekiobj), dims=2))
+    
+    if TEST_PLOT_OUTPUT
+        gr()
+        p = plot(get_u_prior(ekiobj)[1,:], get_u_prior(ekiobj)[2,:], seriestype=:scatter)
+        plot!(get_u_final(ekiobj)[1, :],  get_u_final(ekiobj)[2,:], seriestype=:scatter)
+        plot!([u_star[1]], xaxis="u1", yaxis="u2", seriestype="vline",
+            linestyle=:dash, linecolor=:red)
+        plot!([u_star[2]], seriestype="hline", linestyle=:dash, linecolor=:red)
+        savefig(p, "EKI_test.png")
+    end
+
+    ###
+    ###  Calibrate (2): Ensemble Kalman Sampleer
+    ###
+    eksobj = EnsembleKalmanProcessModule.EnsembleKalmanProcess(initial_ensemble,
+                      y_obs, Γy,
+                      Sampler(prior_mean, prior_cov))
+
+    # EKS iterations
+    for i in 1:N_iter
+        params_i = get_u_final(eksobj)
+        g_ens = G(params_i)
+        if i == 1
+            g_ens_t = permutedims(g_ens, (2,1))
+            @test_throws DimensionMismatch EnsembleKalmanProcessModule.update_ensemble!(eksobj, g_ens_t)
+        end
+
+        EnsembleKalmanProcessModule.update_ensemble!(eksobj, g_ens)
+    end
+
+    # Plot evolution of the EKS particles
+    eks_final_result = vec(mean(get_u_final(eksobj), dims=2))
+    
+    if TEST_PLOT_OUTPUT
+        gr()
+        p = plot(get_u_prior(eksobj)[1,:], get_u_prior(eksobj)[2,:], seriestype=:scatter)
+        plot!(get_u_final(eksobj)[1, :],  get_u_final(eksobj)[2,:], seriestype=:scatter)
+        plot!([u_star[1]], xaxis="u1", yaxis="u2", seriestype="vline",
+            linestyle=:dash, linecolor=:red)
+        plot!([u_star[2]], seriestype="hline", linestyle=:dash, linecolor=:red)
+        savefig(p, "EKS_test.png")
+    end
+
+    posterior_cov_inv = (A' * (Γy\A) + 1 * Matrix(I, n_par, n_par)/prior_cov)
+    ols_mean          = (A'*(Γy\A)) \ (A'*(Γy\y_obs))
+    posterior_mean    = posterior_cov_inv \ ( (A'*(Γy\A)) * ols_mean  + (prior_cov\prior_mean))
+
+    #### This tests correspond to:
+    # EKI provides a solution closer to the ordinary Least Squares estimate
+    @test norm(ols_mean - eki_final_result) < norm(ols_mean - eks_final_result)
+    # EKS provides a solution closer to the posterior mean
+    @test norm(posterior_mean - eks_final_result) < norm(posterior_mean - eki_final_result)
+
+    ##### I expect this test to make sense:
+    # In words: the ensemble covariance is still a bit ill-dispersed since the
+    # algorithm employed still does not include the correction term for finite-sized
+    # ensembles.
+    @test abs(sum(diag(posterior_cov_inv\cov(get_u_final(eksobj),dims=2))) - n_par) > 1e-5
+end

--- a/test/Observations/runtests.jl
+++ b/test/Observations/runtests.jl
@@ -1,0 +1,57 @@
+using Test
+using Random
+using Statistics
+
+using EnsembleKalmanProcesses.Observations
+
+@testset "Observations" begin
+
+    # Generate samples as vector of vectors
+    sample_dim = 3  # sample dimension, i.e., number of elements per sample
+    n_samples = 5   # number of samples
+    samples = [vec(i*ones(sample_dim)) for i in 1:n_samples]
+    data_names = ["d$(string(i))" for i in 1:sample_dim]
+    obs = Obs(samples, data_names)
+    @test obs.data_names == data_names
+    @test obs.mean == [3.0, 3.0, 3.0]
+    @test obs.obs_noise_cov == 2.5 * ones(3, 3)
+
+    # Generate samples as vector of vectors, pass a covariance to Obs
+
+    covar = ones(sample_dim, sample_dim)
+    obs = Obs(samples, covar, data_names)
+    @test obs.obs_noise_cov == covar
+    covar_wrong_dims = ones(sample_dim, sample_dim-1)
+    @test_throws AssertionError Obs(samples, covar_wrong_dims, data_names)
+
+    # Generate samples as a 2d-array (each row corresponds to 1 sample)
+    samples_t = vcat([i*ones(sample_dim)' for i in 1:n_samples]...)
+    samples = permutedims(samples_t, (2,1))
+    obs = Obs(samples, data_names)
+    @test obs.mean == [3.0, 3.0, 3.0]
+    @test obs.obs_noise_cov == 2.5 * ones(3, 3)
+
+    # Generate samples as a 2d-array (each row corresponds to 1 sample), 
+    # pass a covariance to Obs
+    obs = Obs(samples, covar, data_names)
+    @test obs.obs_noise_cov == covar
+    @test_throws AssertionError Obs(samples, covar_wrong_dims, data_names)
+    @test_throws AssertionError Obs(samples_t, covar, data_names) #as default is data are columns
+
+
+    # Generate a single sample (a column vector)
+    sample = reshape([1.0, 2.0, 3.0], 3, 1)
+    data_name = "d1"
+    obs = Obs(sample, data_name)
+    @test obs.mean == vec(sample)
+    @test obs.obs_noise_cov == nothing
+
+    # Generate 1D-samples (data are columns of the row vector) -- this should result in scalar
+    # values for the mean and obs_nosie_cov
+    sample = reshape([1.0, 2.0, 3.0], 1, 3)
+    data_name = "d1"
+    obs = Obs(sample, data_name)
+    @test obs.mean == 2.0
+    @test obs.obs_noise_cov == 1.0
+end
+

--- a/test/ParameterDistribution/runtests.jl
+++ b/test/ParameterDistribution/runtests.jl
@@ -1,0 +1,254 @@
+using Test
+using Distributions
+using StatsBase
+using Random
+
+using EnsembleKalmanProcesses.ParameterDistributionStorage
+
+@testset "ParameterDistributionStorage" begin
+    @testset "ParameterDistributionType" begin
+        # Tests for the ParameterDistributionType
+        d = Parameterized(Gamma(2.0, 0.8))
+        @test d.distribution == Gamma(2.0,0.8)
+        
+        d = Samples([1 2 3; 4 5 6])
+        @test d.distribution_samples == [1 2 3; 4 5 6]
+        d = Samples([1 4; 2 5; 3 6]; params_are_columns=false)
+        @test d.distribution_samples == [1 2 3; 4 5 6]
+        d = Samples([1, 2, 3, 4, 5, 6])
+        @test d.distribution_samples == [1 2 3 4 5 6]
+        d = Samples([1, 2, 3, 4, 5, 6]; params_are_columns=false)
+        @test d.distribution_samples == reshape([1, 2, 3, 4, 5, 6],:,1)
+        
+    end
+    @testset "ConstraintType" begin
+        # Tests for the ConstraintType
+        # The predefined transforms
+        c1 = bounded_below(0.2)
+        @test isapprox(c1.constrained_to_unconstrained(1.0) - (log(1.0 - 0.2)), 0)
+        @test isapprox(c1.unconstrained_to_constrained(0.0) - (exp(0.0) + 0.2), 0)
+            
+        c2 = bounded_above(0.2)
+        @test isapprox(c2.constrained_to_unconstrained(-1.0) - (log(0.2 - -1.0)), 0) 
+        @test isapprox(c2.unconstrained_to_constrained(10.0) - (0.2 - exp(10.0)), 0)
+
+        
+        c3 = bounded(-0.1,0.2)
+        @test isapprox(c3.constrained_to_unconstrained(0.0) - (log( (0.0 - -0.1) / (0.2 - 0.0))) , 0 )
+        @test isapprox(c3.unconstrained_to_constrained(1.0) - ((0.2 * exp(1.0) + -0.1) / (exp(1.0) + 1)) , 0)
+        @test_throws DomainError bounded(0.2,-0.1)
+
+        #an example with user defined invertible transforms
+        c_to_u = (x -> 3 * x + 14)
+        u_to_c = (x -> (x - 14) / 3) 
+        
+        c4 = Constraint(c_to_u, u_to_c)
+        @test isapprox( c4.constrained_to_unconstrained(5.0) - c_to_u(5.0) , 0)
+        @test isapprox( c4.unconstrained_to_constrained(5.0) - u_to_c(5.0) , 0)
+        
+
+    end
+
+    @testset "ParameterDistribution" begin
+
+        d = Parameterized(Normal(0,1))
+        c = no_constraint()
+        name = "unconstrained_normal"
+        u = ParameterDistribution(d,c,name)
+        @test u.distributions == [d]
+        @test u.constraints == [c]
+        @test u.names == [name]
+
+        # Tests for the ParameterDistribution
+        d = Parameterized(MvNormal(4,0.1))
+        c = [no_constraint(),
+             bounded_below(-1.0),
+             bounded_above(0.4),
+             bounded(-0.1,0.2)]
+      
+        name = "constrained_mvnormal"
+        u = ParameterDistribution(d,c,name)
+        @test u.distributions == [d]
+        @test u.constraints == c
+        @test u.names == [name]
+        @test_throws DimensionMismatch ParameterDistribution(d,c[1:3],name)
+        @test_throws DimensionMismatch ParameterDistribution(d,c, [name,"extra_name"])
+        
+        # Tests for the ParameterDistribution
+        d1 = Parameterized(MvNormal(4,0.1))
+        c1 = [no_constraint(),
+              bounded_below(-1.0),
+              bounded_above(0.4),
+              bounded(-0.1,0.2)]
+        name1 = "constrained_mvnormal"
+        u1 = ParameterDistribution(d1,c1,name1)
+        
+        d2 = Samples([1.0 3.0 5.0 7.0; 9.0 11.0 13.0 15.0])
+        c2 = [bounded(10,15),
+              no_constraint()]
+        name2 = "constrained_sampled"
+        u2 = ParameterDistribution(d2,c2,name2)
+        
+        u = ParameterDistribution([d1,d2], [c1,c2], [name1,name2])
+        @test u.distributions == [d1,d2]
+        @test u.constraints == cat([c1,c2]...,dims=1)
+        @test u.names == [name1,name2]
+    end
+
+    @testset "getter functions" begin
+        # setup for the tests:
+        d1 = Parameterized(MvNormal(4,0.1))
+        c1 = [no_constraint(),
+              bounded_below(-1.0),
+              bounded_above(0.4),
+              bounded(-0.1,0.2)]
+        name1 = "constrained_mvnormal"
+        u1 = ParameterDistribution(d1,c1,name1)
+        
+        d2 = Samples([1 2 3 4])
+        c2 = [bounded(10,15)]
+        name2 = "constrained_sampled"
+        u2 = ParameterDistribution(d2,c2,name2)
+        
+        u = ParameterDistribution([d1,d2], [c1,c2], [name1,name2])
+
+        # Test for get_dimension(s)
+        @test get_total_dimension(u1) == 4
+        @test get_total_dimension(u2) == 1
+        @test get_total_dimension(u) == 5
+        @test get_dimensions(u1) == [4]
+        @test get_dimensions(u2) == [1]
+        @test get_dimensions(u) == [4,1]
+        
+        # Tests for get_name
+        @test get_name(u1) == [name1]
+        @test get_name(u) == [name1, name2]
+
+        # Tests for get_n_samples
+        @test typeof(get_n_samples(u)[name1]) <: String
+        @test get_n_samples(u)[name2] == 4
+        
+        # Tests for get_distribution
+        @test get_distribution(d1) == MvNormal(4,0.1)
+        @test get_distribution(u1)[name1] == MvNormal(4,0.1)
+        @test typeof(get_distribution(d2)) == Array{Int64, 2}
+        @test typeof(get_distribution(u2)[name2]) == Array{Int64, 2}
+        
+        d = get_distribution(u)
+        @test d[name1] == MvNormal(4,0.1)
+        @test typeof(d[name2]) == Array{Int64, 2}
+
+        # Test for get_all_constraints
+        @test get_all_constraints(u) == cat([c1,c2]...,dims=1)
+    end
+
+    @testset "statistics functions" begin
+
+        # setup for the tests:
+        d1 = Parameterized(MvNormal(4,0.1))
+        c1 = [no_constraint(),
+              bounded_below(-1.0),
+              bounded_above(0.4),
+              bounded(-0.1,0.2)]
+        name1 = "constrained_mvnormal"
+        u1 = ParameterDistribution(d1,c1,name1)
+
+        d2 = Samples([1 2 3 4])
+        c2 = [bounded(10,15)]
+        name2 = "constrained_sampled"
+        u2 = ParameterDistribution(d2,c2,name2)
+        
+        d3 = Parameterized(Beta(2,2))
+        c3 = [no_constraint()]
+        name3 = "unconstrained_beta"
+        u3 = ParameterDistribution(d3,c3,name3)
+
+        u = ParameterDistribution([d1,d2],[c1,c2],[name1,name2])
+
+        d4 = Samples([1 2 3 4 5 6 7 8; 8 7 6 5 4 3 2 1])
+        c4 = [no_constraint(),
+              no_constraint()]
+        name4 = "constrained_MVsampled"
+        v = ParameterDistribution([d1,d2,d3,d4],[c1,c2,c3,c4],[name1,name2,name3,name4])
+        
+        # Tests for sample distribution
+        seed=2020
+        Random.seed!(seed)
+        s1 = rand(MvNormal(4,0.1),1)
+        Random.seed!(seed)
+        @test sample_distribution(u1) == s1
+
+        Random.seed!(seed)
+        s1 = rand(MvNormal(4,0.1),3)
+        Random.seed!(seed)
+        @test sample_distribution(u1,3) == s1
+        
+        Random.seed!(seed)
+        idx = StatsBase.sample(collect(1:size(d2.distribution_samples)[2]),1) 
+        s2 = d2.distribution_samples[:, idx]
+        Random.seed!(seed)
+        @test sample_distribution(u2) == s2
+
+        Random.seed!(seed)
+        idx = StatsBase.sample(collect(1:size(d2.distribution_samples)[2]), 3) 
+        s2 = d2.distribution_samples[:, idx]
+        Random.seed!(seed)
+        @test sample_distribution(u2,3) == s2
+        
+        Random.seed!(seed)
+        s1 = sample_distribution(u1,3)
+        s2 = sample_distribution(u2,3)
+        Random.seed!(seed)
+        s = sample_distribution(u,3)
+        @test s == cat([s1,s2]...,dims=1)
+
+        #Test for get_logpdf
+        @test_throws ErrorException get_logpdf(u,zeros(get_total_dimension(u))) 
+        x_in_bd = [0.5]
+        Random.seed!(seed)
+        lpdf3 = logpdf.(Beta(2,2),x_in_bd)[1] #throws deprecated warning without "."
+        Random.seed!(seed)
+        @test isapprox(get_logpdf(u3,x_in_bd) - lpdf3 , 0.0; atol=1e-6)
+        @test_throws DimensionMismatch get_logpdf(u3, [0.5,0.5])
+
+        #Test for get_cov, get_var        
+        block_cov = cat([get_cov(d1),get_var(d2),get_var(d3),get_cov(d4)]..., dims=(1,2)) 
+        @test isapprox(get_cov(v) - block_cov, zeros(get_total_dimension(v),get_total_dimension(v)); atol=1e-6)
+        #Test for get_mean
+        means = reshape(cat([get_mean(d1), get_mean(d2), get_mean(d3), get_mean(d4)]...,dims=1),:,1)
+        @test isapprox(get_mean(v) - means, zeros(get_total_dimension(v)); atol=1e-6)
+        
+    end
+
+    @testset "transform functions" begin
+        #setup for the tests
+        d1 = Parameterized(MvNormal(4,0.1))
+        c1 = [no_constraint(),
+              bounded_below(-1.0),
+              bounded_above(0.4),
+              bounded(-0.1,0.2)]
+        name1 = "constrained_mvnormal"
+        u1 = ParameterDistribution(d1,c1,name1)
+        
+        d2 = Samples([1.0 3.0 5.0 7.0; 9.0 11.0 13.0 15.0])
+        c2 = [bounded(10,15),
+              no_constraint()]
+        name2 = "constrained_sampled"
+        u2 = ParameterDistribution(d2,c2,name2)
+        
+        u = ParameterDistribution([d1,d2], [c1,c2], [name1,name2])
+
+        x_unbd = rand(MvNormal(6,3), 1000)  #6 x 1000 
+        # Tests for transforms
+        x_real_constrained1 = mapslices(x -> transform_unconstrained_to_constrained(u1,x), x_unbd[1:4,:]; dims=1)
+        @test isapprox(x_unbd[1:4,:] - mapslices(x -> transform_constrained_to_unconstrained(u1,x), x_real_constrained1; dims=1), zeros(size(x_unbd[1:4,:])); atol=1e-8)
+        x_real_constrained2 = mapslices(x -> transform_unconstrained_to_constrained(u2,x), x_unbd[5:6,:]; dims=1) 
+        @test isapprox(x_unbd[5:6,:] -  mapslices(x -> transform_constrained_to_unconstrained(u2,x), x_real_constrained2; dims=1), zeros(size(x_unbd[5:6,:])); atol=1e-8)
+        
+        x_real = mapslices(x -> transform_unconstrained_to_constrained(u,x), x_unbd; dims=1)
+        x_unbd_tmp = mapslices(x -> transform_constrained_to_unconstrained(u,x), x_real; dims=1)
+        @test isapprox(x_unbd - x_unbd_tmp,zeros(size(x_unbd)); atol=1e-8)
+        
+    end
+    
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ end
 
     for submodule in ["DataStorage",
                       "ParameterDistribution",
+                      "Observations",
                       "EnsembleKalmanProcessModule"]
 
         if all_tests || has_submodule(submodule) || "EnsembleKalmanProcesses" in ARGS

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,45 @@
 using Test
-using EnsembleKalmanProcesses
 
-@testset "Hello" begin
-    @test EnsembleKalmanProcesses.hello() == "hello world"
+TEST_PLOT_OUTPUT = !isempty(get(ENV, "CES_TEST_PLOT_OUTPUT", ""))
+
+if TEST_PLOT_OUTPUT
+    using Plots
 end
+
+function include_test(_module)
+    println("Starting tests for $_module")
+    t = @elapsed include(joinpath(_module, "runtests.jl"))
+    println("Completed tests for $_module, $(round(Int, t)) seconds elapsed")
+    return nothing
+end
+
+@testset "EnsembleKalmanProcesses" begin
+    all_tests = isempty(ARGS) || "all" in ARGS ? true : false
+
+    function has_submodule(sm)
+        any(ARGS) do a
+            a == sm && return true
+	    first(split(a, '/')) == sm && return true
+	    return false
+        end
+    end
+
+    for submodule in ["DataStorage",
+                      "ParameterDistribution",
+                      "EnsembleKalmanProcessModule"]
+
+        if all_tests || has_submodule(submodule) || "EnsembleKalmanProcesses" in ARGS
+            include_test(submodule)
+        end
+    end	
+end
+
+
+
+
+
+
+
+
+
 


### PR DESCRIPTION
## Purpose
Resolves some of #1 

## Contains
We move the following modules from CES
- `EnsembleKalmanProcesses`, renamed `EnsembleKalmanProcessModule` (for obvious name clash)
- `Observations`
- `DataStorage`
- `ParameterDistributionStorage`

I also have moved over all unit tests for these modules. and updated the Project toml