### PR TITLE
Adjust codecov to not fail when coverage drops < 10%

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,4 @@
+comment: false
 coverage:
   status:
     project:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # this allows a 10% drop from the previous base commit coverage
+        threshold: 10%


### PR DESCRIPTION
Disable PR comments in favor of less noisy GH status checks