### PR TITLE
Fix get_mean() for PDs, fix installation docs

### DIFF
--- a/docs/src/installation_instructions.md
+++ b/docs/src/installation_instructions.md
@@ -3,8 +3,8 @@
 To build the top-level project, first clone the repository, then instantiate:
 
 ```
-cd CalibrateEmulateSample.jl
-julia --project -e 'using Pkg; Pkg.instantiate()
+cd EnsembleKalmanProcesses.jl
+julia --project -e 'using Pkg; Pkg.instantiate()'
 ```
 
 To test that the package is working:

--- a/examples/LossMinimization/loss_minimization.jl
+++ b/examples/LossMinimization/loss_minimization.jl
@@ -32,7 +32,7 @@ prior_distns = [Parameterized(Normal(0., sqrt(1))),
 constraints = [[no_constraint()], [no_constraint()]]
 prior_names = ["u1", "u2"]
 prior = ParameterDistribution(prior_distns, constraints, prior_names)
-prior_mean = reshape(get_mean(prior),:)
+prior_mean = get_mean(prior)
 prior_cov = get_cov(prior)
 
 # Calibrate
@@ -84,7 +84,7 @@ prior_distns = [Parameterized(Normal(0., sqrt(2))),
 constraints = [[no_constraint()], [no_constraint()]]
 prior_names = ["u1", "u2"]
 prior = ParameterDistribution(prior_distns, constraints, prior_names)
-prior_mean = reshape(get_mean(prior),:)
+prior_mean = get_mean(prior)
 prior_cov = get_cov(prior)
 
 # Calibrate

--- a/src/ParameterDistribution.jl
+++ b/src/ParameterDistribution.jl
@@ -388,10 +388,10 @@ end
 """
     function get_mean(pd::ParameterDistribution)
 
-returns a mean of the distirbutions
+returns a mean of the distributions
 """
 function get_mean(pd::ParameterDistribution)
-    return reshape(cat([get_mean(d) for d in pd.distributions]...,dims=1),:,1)
+    return cat([get_mean(d) for d in pd.distributions]...,dims=1)
 end
 
 

--- a/test/EnsembleKalmanProcessModule/runtests.jl
+++ b/test/EnsembleKalmanProcessModule/runtests.jl
@@ -44,7 +44,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     prior_names = ["u1","u2"]
     prior = ParameterDistribution(prior_distns, constraints, prior_names)
     
-    prior_mean = reshape(get_mean(prior),:)
+    prior_mean = get_mean(prior)
 
     # Assuming independence of u1 and u2
     prior_cov = get_cov(prior)#convert(Array, Diagonal([sqrt(2.), sqrt(2.)]))

--- a/test/ParameterDistribution/runtests.jl
+++ b/test/ParameterDistribution/runtests.jl
@@ -215,7 +215,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
         block_cov = cat([get_cov(d1),get_var(d2),get_var(d3),get_cov(d4)]..., dims=(1,2)) 
         @test isapprox(get_cov(v) - block_cov, zeros(get_total_dimension(v),get_total_dimension(v)); atol=1e-6)
         #Test for get_mean
-        means = reshape(cat([get_mean(d1), get_mean(d2), get_mean(d3), get_mean(d4)]...,dims=1),:,1)
+        means = cat([get_mean(d1), get_mean(d2), get_mean(d3), get_mean(d4)]...,dims=1)
         @test isapprox(get_mean(v) - means, zeros(get_total_dimension(v)); atol=1e-6)
         
     end


### PR DESCRIPTION
The current output of get_mean(ParameterDistribution) is an `Array{FT, 2}` that cannot be used as an input to the `Sampler()`. I did not see any instance of the code where this structure was useful, so I have changed the function to return an `Array{FT, 1}`. 

Note that this change simplifies every single use of get_mean(ParameterDistribution) in the tests and examples.

Apart from this, I have corrected the installation guide.