### PR TITLE
removed unsatisfiable assert, stopped overwriting of obs_noise_cov

### DIFF
--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -101,6 +101,7 @@ function Obs(samples::Vector{Vector{FT}},
         temp1 = convert(Array, reshape(hcat(samples...)', N_samples, :))
         temp = dropdims(temp1, dims=1)
         samplemean = vec(mean(temp, dims=2))
+        obsnoisecov=obs_noise_cov
     else
         if sample_dim == 1
             # We have 1D samples, so the sample mean and covariance (which in
@@ -108,18 +109,20 @@ function Obs(samples::Vector{Vector{FT}},
             samplemean = mean(temp)
             err = ("When sample_dim is 1, obs_cov_noise must be a scalar.
                    \tsample_dim: number of elements per observation sample")
-            @assert(ndims(obs_noise_cov) == 0, err)
+            @assert(size(obs_noise_cov) == (1,1), err)
+            obsnoisecov=obs_noise_cov[1]
         else
             temp = convert(Array, reshape(hcat(samples...)', N_samples, :))
             samplemean = vec(mean(temp, dims=1))
             err = ("obs_cov_noise must be of size sample_dim x sample_dim.
                    \tsample_dim: number of elements per observation sample")
             @assert(size(obs_noise_cov) == (sample_dim, sample_dim), err)
+            obsnoisecov=obs_noise_cov
         end
     end
 
 
-    Obs(samples, obs_noise_cov, samplemean, data_names)
+    Obs(samples, obsnoisecov, samplemean, data_names)
 end
 
 function Obs(samples::Array{FT, 2},
@@ -131,7 +134,7 @@ function Obs(samples::Array{FT, 2},
     if N_samples == 1
         # Only one sample, so there is no covariance to be computed and the 
         # sample mean equals the sample itself
-        obs_noise_cov = nothing
+        obsnoisecov = nothing
         samplemean = vec(samples)
         samples_vec = vec([vec(samples)])
     else
@@ -141,18 +144,21 @@ function Obs(samples::Array{FT, 2},
             # We have 1D samples, so the sample mean and covariance (which in 
             # this case is actually the variance) are scalars
             samplemean = mean(samples)
+            obsnoisecov=obs_noise_cov[1]
             err = ("When sample_dim is 1, obs_cov_noise must be a scalar.
                    \tsample_dim: number of elements per observation sample")
-            @assert(ndims(obs_noise_cov) == 0, err)
+            @assert(size(obs_noise_cov) == (1,1), err)
+            obsnoisecov=obs_noise_cov[1]
         else
             samplemean = vec(mean(samples, dims=2))
             err = ("obs_cov_noise must be of size sample_dim x sample_dim.
                    \tsample_dim: number of elements per observation sample")
             @assert(size(obs_noise_cov) == (sample_dim, sample_dim), err)
+            obsnoisecov=obs_noise_cov
         end
     end
 
-    Obs(samples_vec, obs_noise_cov, samplemean, data_names)
+    Obs(samples_vec, obsnoisecov, samplemean, data_names)
 end
 
 end # module Observations

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -103,6 +103,7 @@ function Obs(samples::Vector{Vector{FT}},
         samplemean = vec(mean(temp, dims=2))
         obsnoisecov=obs_noise_cov
     else
+        temp = convert(Array, reshape(hcat(samples...)', N_samples, :))
         if sample_dim == 1
             # We have 1D samples, so the sample mean and covariance (which in
             # this case is actually the covariance) are scalars
@@ -112,7 +113,6 @@ function Obs(samples::Vector{Vector{FT}},
             @assert(size(obs_noise_cov) == (1,1), err)
             obsnoisecov=obs_noise_cov[1]
         else
-            temp = convert(Array, reshape(hcat(samples...)', N_samples, :))
             samplemean = vec(mean(temp, dims=1))
             err = ("obs_cov_noise must be of size sample_dim x sample_dim.
                    \tsample_dim: number of elements per observation sample")
@@ -132,9 +132,8 @@ function Obs(samples::Array{FT, 2},
     # samples is of size N_samples x sample_dim
     sample_dim, N_samples = size(samples)
     if N_samples == 1
-        # Only one sample, so there is no covariance to be computed and the 
         # sample mean equals the sample itself
-        obsnoisecov = nothing
+        obsnoisecov = obs_noise_cov
         samplemean = vec(samples)
         samples_vec = vec([vec(samples)])
     else

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -36,7 +36,7 @@ function Obs(samples::Vector{Vector{FT}},
              data_names::Union{Vector{String}, String}) where {FT<:AbstractFloat}
 
     N_samples = length(samples)
-    # convert to N_samples x sample_dim to determine sample covariance
+    # convert to sample_dim x N_samples to determine sample covariance
 
     if N_samples == 1
         # only one sample - this requires a bit more data massaging
@@ -94,7 +94,7 @@ function Obs(samples::Vector{Vector{FT}},
 
     N_samples = length(samples)
     sample_dim = length(samples[1])
-    # convert to N_samples x sample_dim to determine sample covariance
+    # convert to sample_dim x N_samples to determine sample covariance
 
     if N_samples == 1
         # only one sample - this requires a bit more data massaging
@@ -108,8 +108,7 @@ function Obs(samples::Vector{Vector{FT}},
             # We have 1D samples, so the sample mean and covariance (which in
             # this case is actually the covariance) are scalars
             samplemean = mean(temp)
-            err = ("When sample_dim is 1, obs_cov_noise must be a scalar.
-                   \tsample_dim: number of elements per observation sample")
+            err = ("When sample_dim is 1, obs_cov_noise must be a 1x1 matrix")
             @assert(size(obs_noise_cov) == (1,1), err)
             obsnoisecov=obs_noise_cov[1]
         else
@@ -129,7 +128,7 @@ function Obs(samples::Array{FT, 2},
              obs_noise_cov::Union{Array{FT, 2}, Nothing},
              data_names::Union{Vector{String}, String})where {FT<:AbstractFloat}
 
-    # samples is of size N_samples x sample_dim
+    # samples is of size sample_dim x N_samples
     sample_dim, N_samples = size(samples)
     if N_samples == 1
         # sample mean equals the sample itself
@@ -143,9 +142,7 @@ function Obs(samples::Array{FT, 2},
             # We have 1D samples, so the sample mean and covariance (which in 
             # this case is actually the variance) are scalars
             samplemean = mean(samples)
-            obsnoisecov=obs_noise_cov[1]
-            err = ("When sample_dim is 1, obs_cov_noise must be a scalar.
-                   \tsample_dim: number of elements per observation sample")
+            err = ("When sample_dim is 1, obs_cov_noise must be a 1x1 matrix")
             @assert(size(obs_noise_cov) == (1,1), err)
             obsnoisecov=obs_noise_cov[1]
         else

--- a/test/Observations/runtests.jl
+++ b/test/Observations/runtests.jl
@@ -37,22 +37,51 @@ using EnsembleKalmanProcesses.Observations
     @test_throws AssertionError Obs(samples, covar_wrong_dims, data_names)
     @test_throws AssertionError Obs(samples_t, covar, data_names) #as default is data are columns
 
-
-    # Generate a single sample (a column vector)
+    ## Edge cases:
+    # Generating a single sample (a column vector)
     sample = reshape([1.0, 2.0, 3.0], 3, 1)
     data_name = "d1"
     obs = Obs(sample, data_name)
     @test obs.mean == vec(sample)
     @test obs.obs_noise_cov == nothing
 
-    # Generate 1D-samples (data are columns of the row vector) -- this should result in scalar
-    # values for the mean and obs_noise_cov
+    #Generating a single sample (vector of vector)
+    sample = [[1.0, 2.0, 3.0]]
+    data_name = "d1"
+    obs = Obs(sample, data_name)
+    @test obs.mean == sample[1]
+    @test obs.obs_noise_cov == nothing
+
+    # Generating a single sample with cov (a column vector)
+    sample = reshape([1.0, 2.0, 3.0], 3, 1)
+    obs_noise_cov = ones(3,3)
+    data_name = "d1"
+    obs = Obs(sample, obs_noise_cov, data_name)
+    @test obs.mean == vec(sample)
+    @test obs.obs_noise_cov == obs_noise_cov
+
+    #Generating a single sample with cov (vector of vector)
+    sample = [[1.0, 2.0, 3.0]]
+    obs_noise_cov = ones(3,3)
+    data_name = "d1"
+    obs = Obs(sample, obs_noise_cov, data_name)
+    @test obs.mean == sample[1]
+    @test obs.obs_noise_cov == obs_noise_cov
+
+    # Generate 1D-samples (data are columns of the row vector) -- this should result in scalar values for the mean and obs_noise_cov
     sample = reshape([1.0, 2.0, 3.0], 1, 3)
     data_name = "d1"
     obs = Obs(sample, data_name)
     @test obs.mean == 2.0
     @test obs.obs_noise_cov == 1.0
 
+    # Generate 1D-samples (Vector of vector)
+    sample = [[1.0], [2.0], [3.0]]
+    data_name = "d1"
+    obs = Obs(sample, data_name)
+    @test obs.mean == 2.0
+    @test obs.obs_noise_cov == 1.0
+    
     # Generate 1D-samples, but also passing a known "1x1 covarince matrix" (stored as a variance)
     # (data are columns of the row vector)
     # this should result in scalar values for the mean and obs_noise_cov
@@ -63,6 +92,14 @@ using EnsembleKalmanProcesses.Observations
     @test obs.mean == 2.0
     @test obs.obs_noise_cov == 3.0
 
+    # Generate 1D-samples, but also passing a known "1x1 covarince matrix"
+    # (data are vector of vectors)
+    sample = [[1.0], [2.0], [3.0]]
+    obs_noise_cov = reshape([3.0],1,1) #needs to be of type Array{,2}
+    data_name = "d1"
+    obs = Obs(sample, obs_noise_cov, data_name)
+    @test obs.mean == 2.0
+    @test obs.obs_noise_cov == 3.0
     
 end
 

--- a/test/Observations/runtests.jl
+++ b/test/Observations/runtests.jl
@@ -17,7 +17,6 @@ using EnsembleKalmanProcesses.Observations
     @test obs.obs_noise_cov == 2.5 * ones(3, 3)
 
     # Generate samples as vector of vectors, pass a covariance to Obs
-
     covar = ones(sample_dim, sample_dim)
     obs = Obs(samples, covar, data_names)
     @test obs.obs_noise_cov == covar
@@ -47,11 +46,23 @@ using EnsembleKalmanProcesses.Observations
     @test obs.obs_noise_cov == nothing
 
     # Generate 1D-samples (data are columns of the row vector) -- this should result in scalar
-    # values for the mean and obs_nosie_cov
+    # values for the mean and obs_noise_cov
     sample = reshape([1.0, 2.0, 3.0], 1, 3)
     data_name = "d1"
     obs = Obs(sample, data_name)
     @test obs.mean == 2.0
     @test obs.obs_noise_cov == 1.0
+
+    # Generate 1D-samples, but also passing a known "1x1 covarince matrix" (stored as a variance)
+    # (data are columns of the row vector)
+    # this should result in scalar values for the mean and obs_noise_cov
+    sample = reshape([1.0, 2.0, 3.0], 1, 3)
+    obs_noise_cov = reshape([3.0],1,1) #needs to be of type Array{,2}
+    data_name = "d1"
+    obs = Obs(sample, obs_noise_cov, data_name)
+    @test obs.mean == 2.0
+    @test obs.obs_noise_cov == 3.0
+
+    
 end
 


### PR DESCRIPTION
Fixes #34 by 
- changing the assert 
- also prevents `obs_noise_cov` modifications in `Observations`,
- added runtests for the scalar noise case (and the other edge cases too)