### PR TITLE
initial gifs for priors

### DIFF
--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -53,7 +53,7 @@ title!("Transformed Normal(1,0.5)")
 ```
 The pdf of the Normal distribution, and its transform look like:
 ```@example zero_point_seven
-p = plot(p1,p2,legend=false) #hide
+p = plot(p1,p2,legend=false,size = (900,450)) #hide
 ```
 ## 1. The ParameterDistributionType
 

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -68,6 +68,133 @@ Users can also define their own transformations by directly creating a `Constrai
 
 This is simply an identifier for the parameters later on.
 
+## 4. The power of the normal distribution
+
+The combination of a normal distribution with these transforms provide a suprising breadth of prior distributions. We **highly** recommend users start with Normal distributions and provided transformations before moving on to others.
+
+The unbounded case
+
+```@example
+using Distributions
+using Plots
+N=50
+x_eval = collect(-10:20/200:10)
+mean_varying = collect(-3:6/(N+1):3)
+sd_varying = collect(0.1:2.9/(N+1):3)
+
+mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval)
+sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval)
+
+ p1 = plot(x_eval, mean0norm.(1))
+ p2 = plot(x_eval, sd1norm.(1))      
+ p = plot(p1,p2, layout=(1,2))
+ 
+anim_unbounded = @animate for n = 1:size(mean_varying)[1]
+   #set new y data
+   p[1][1][:y] = mean0norm(n)
+   p[1][1][:label] = "sd = " * string(sd_varying[n])
+   p[2][1][:y] = sd1norm(n)
+   p[2][1][:label] = "mean = " * string(mean_varying[n])   
+
+end
+
+gif(anim_unbounded, "anim_unbounded.gif", fps = 10)
+```
+bounded below by 0.0
+
+```@example
+using Distributions
+using Plots
+N=50
+x_eval = collect(-5:10/400:5)
+mean_varying = collect(-1:2/(N+1):3)
+sd_varying = collect(0.1:0.9/(N+1):3)
+
+#bounded below by 0.0
+unconstrained_to_constrained(x) = exp(x)  
+
+mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval)
+sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval)
+constrained_x_eval = unconstrained_to_constrained.(x_eval)
+ p1 = plot(constrained_x_eval, mean0norm.(1))
+ p2 = plot(constrained_x_eval, sd1norm.(1))      
+ p = plot(p1,p2, layout=(1,2))
+ 
+anim_bounded_below = @animate for n = 1:size(mean_varying)[1]
+   #set new y data
+   p[1][1][:y] = mean0norm(n)
+   p[1][1][:label] = "sd = " * string(sd_varying[n])
+   p[2][1][:y] = sd1norm(n)
+   p[2][1][:label] = "mean = " * string(mean_varying[n])   
+
+end
+
+gif(anim_bounded_below, "anim_bounded_below.gif", fps = 10)
+```
+
+bounded above by 10.0
+
+```@example
+using Distributions
+using Plots
+N=50
+x_eval = collect(-5:4/400:5)
+mean_varying = collect(-1:2/(N+1):3)
+sd_varying = collect(0.1:0.9/(N+1):3)
+
+#bounded above by 10.0
+unconstrained_to_constrained(x) = 10.0 - exp(x)  
+
+mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval)
+sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval)
+constrained_x_eval = unconstrained_to_constrained.(x_eval)
+ p1 = plot(constrained_x_eval, mean0norm.(1))
+ p2 = plot(constrained_x_eval, sd1norm.(1))      
+ p = plot(p1,p2, layout=(1,2))
+ 
+anim_bounded_above = @animate for n = 1:size(mean_varying)[1]
+   #set new y data
+   p[1][1][:y] = mean0norm(n)
+   p[1][1][:label] = "sd = " * string(sd_varying[n])
+   p[2][1][:y] = sd1norm(n)
+   p[2][1][:label] = "mean = " * string(mean_varying[n])   
+
+end
+
+gif(anim_bounded_above, "anim_bounded_above.gif", fps = 10)
+```
+
+bounded in [5,10]
+
+```@example
+using Distributions
+using Plots
+N=50
+x_eval = collect(-10:20/400:10)
+mean_varying = collect(-3:2/(N+1):3)
+sd_varying = collect(0.1:0.9/(N+1):10)
+
+#bounded in [5.0,10.0]
+unconstrained_to_constrained(x) = (10.0 * exp(x) + 5.0) / (exp(x) + 1)
+
+mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval)
+sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval)
+constrained_x_eval = unconstrained_to_constrained.(x_eval)
+ p1 = plot(constrained_x_eval, mean0norm.(1))
+ p2 = plot(constrained_x_eval, sd1norm.(1))      
+ p = plot(p1,p2, layout=(1,2))
+ 
+anim_bounded = @animate for n = 1:size(mean_varying)[1]
+   #set new y data
+   p[1][1][:y] = mean0norm(n)
+   p[1][1][:label] = "sd = " * string(sd_varying[n])
+   p[2][1][:y] = sd1norm(n)
+   p[2][1][:label] = "mean = " * string(mean_varying[n])   
+
+end
+
+gif(anim_bounded, "anim_bounded.gif", fps = 10)
+```
 ## A more involved example:
 
 We create a 6-dimensional parameter distribution from 2 triples.

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -16,9 +16,14 @@ Solution: We should use a Normal distribution with the predefined "bounded" cons
 
 Let's initialize the constraint first,
 ```julia
-constraint = [bounded(0,1)] # Sets up a logit-transformation into [0,1].
+constraint = [bounded(0,1)] 
 ```
-The prior is around 0.7, and the push forward of a normal distribution N(mean=1,sd=0.5) gives a prior with 95% of it's mass between [0.5,0.88].
+This sets up a logit transformation to and from the constrained space
+```julia
+unconstrained_to_constrained(x) = exp(x) / (exp(x) + 1)
+constrained_to_unconstrained(x) = log( x / (1 - x))
+```
+The prior is around 0.7 (constrained space), and the push-forward of an unconstrained normal distribution N(mean=1,sd=0.5) through the logit transformation gives a prior with 95% of it's mass between [0.5,0.88].
 ```julia
 distribution = Parameterized(Normal(1,0.5)) 
 ```
@@ -31,6 +36,21 @@ And the distribution is created by calling:
 prior = ParameterDistribution(distribution,constraint,name)
 ```
 
+```@setup zero_point_seven
+using Distributions 
+using Plots 
+N=50 
+x_eval = collect(-10:20/400:10) 
+#bounded in [0.0,1.0]
+unconstrained_to_constrained(x) = (1 * exp(x) + 0.0) / (exp(x) + 1)
+dist= pdf(Normal(1,0.5),x_eval) 
+constrained_x_eval = unconstrained_to_constrained.(x_eval) 
+```
+The push-forward of the pdf and the push-forward of the mean look like
+```@example zero_point_seven
+p = plot(constrained_x_eval, distplot, legend=false) # hide
+vline!([unconstrained_to_constrained(1.0)]) # hide
+```
 ## 1. The ParameterDistributionType
 
 The `ParameterDistributionType` has 2 flavours for building a distribution.

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -84,195 +84,218 @@ where:
 2. We fix the standard deviation to 1 and range over the mean value
 
 ### Without constraints: `constraint = [no_constraints()]`
-```@example
-using Distributions # hide
-using Plots # hide
-N = 50 # hide 
-x_eval = collect(-5:10/200:5) # hide
-mean_varying = collect(-3:6/(N+1):3) # hide
-sd_varying = collect(0.1:2.9/(N+1):3) # hide
+
+```@setup no_constraints
+using Distributions 
+using Plots 
+N = 50 
+x_eval = collect(-5:10/200:5) 
+mean_varying = collect(-3:6/(N+1):3) 
+sd_varying = collect(0.1:2.9/(N+1):3) 
 # no constraint 
 unconstrained_to_constrained(x) = x
 
-mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) # hide
-sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) # hide
-constrained_x_eval = unconstrained_to_constrained.(x_eval) # hide 
-p1 = plot(constrained_x_eval, mean0norm.(1)) # hide
-vline!([unconstrained_to_constrained(0)]) # hide
-p2 = plot(constrained_x_eval, sd1norm.(1)) # hide     
-vline!([unconstrained_to_constrained(mean_varying[1])]) # hide
+mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval)
+sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) 
+constrained_x_eval = unconstrained_to_constrained.(x_eval) 
+p1 = plot(constrained_x_eval, mean0norm.(1)) 
+vline!([unconstrained_to_constrained(0)]) 
+p2 = plot(constrained_x_eval, sd1norm.(1)) 
+vline!([unconstrained_to_constrained(mean_varying[1])]) 
 
-p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) # hide 
+p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) 
  
-anim_unbounded = @animate for n = 1:size(mean_varying)[1] # hide
-   #set new y data # hide
-   p[1][1][:y] = mean0norm(n) # hide
-#   p[1][1][:label] = "sd = " * string(round(sd_varying[n],digits=3)) # hide
-   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" # hide
-   p[2][1][:y] = sd1norm(n) # hide
-#   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide  
+anim_unbounded = @animate for n = 1:size(mean_varying)[1] 
+   #set new y data 
+   p[1][1][:y] = mean0norm(n) 
+   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" 
+   p[2][1][:y] = sd1norm(n) 
    p[2][2][:x] = [ unconstrained_to_constrained(mean_varying[n]),
                    unconstrained_to_constrained(mean_varying[n]),       
-                   unconstrained_to_constrained(mean_varying[n])] # hide       
+                   unconstrained_to_constrained(mean_varying[n])]
 
-   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)" # hide
-end # hide
+   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)"
+end 
+```
+```@example no_constraints
 gif(anim_unbounded, "anim_unbounded.gif", fps = 5) # hide
 ```
-The following commands generate the `Normal(0.5,1)` distribution with no constraint
+The following commands generate the transformed `Normal(0.5,1)` distribution
 
 ```@repl
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
 distribution = Parameterized(Normal(0.5,1)) 
 constraint = [no_constraint()]
-name = "normal_zero_one"
+name = "unbounded_parameter"
 prior = ParameterDistribution(distribution,constraint,name)
+```
+where `no_constraint()` automatically defines the constraint map
+```julia
+unconstrained_to_constrained(x) = x
 ```
 
 ### Bounded below by 0: `constraint = [bounded_below(0)]`
 
-```@example
-using Distributions  # hide
-using Plots # hide
-N=50 # hide
-x_eval = collect(-5:10/400:5) # hide
-mean_varying = collect(-1:5/(N+1):4) # hide
-sd_varying = collect(0.1:3.9/(N+1):4) # hide
+```@setup bounded_below
+using Distributions  
+using Plots 
+N=50 
+x_eval = collect(-5:10/400:5) 
+mean_varying = collect(-1:5/(N+1):4) 
+sd_varying = collect(0.1:3.9/(N+1):4) 
 
 #bounded below by 0
 unconstrained_to_constrained(x) = exp(x)  
 
-mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) # hide
-sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) # hide
-constrained_x_eval = unconstrained_to_constrained.(x_eval) # hide
-p1 = plot(constrained_x_eval, mean0norm.(1)) # hide
-vline!([unconstrained_to_constrained(0)]) # hide
-p2 = plot(constrained_x_eval, sd1norm.(1)) # hide
-vline!([unconstrained_to_constrained(mean_varying[1])]) # hide
+mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) 
+sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) 
+constrained_x_eval = unconstrained_to_constrained.(x_eval) 
+p1 = plot(constrained_x_eval, mean0norm.(1)) 
+vline!([unconstrained_to_constrained(0)]) 
+p2 = plot(constrained_x_eval, sd1norm.(1)) 
+vline!([unconstrained_to_constrained(mean_varying[1])]) 
 
-p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) # hide 
+p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false)  
  
-anim_bounded_below = @animate for n = 1:size(mean_varying)[1] # hide
-   #set new y data  # hide
-   p[1][1][:y] = mean0norm(n) # hide
-#   p[1][1][:label] = "sd = " * string(round(sd_varying[n],digits=3)) # hide
-   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" # hide
-   p[2][1][:y] = sd1norm(n) # hide
-#   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide  
+anim_bounded_below = @animate for n = 1:size(mean_varying)[1] 
+   #set new y data  
+   p[1][1][:y] = mean0norm(n) 
+   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" 
+   p[2][1][:y] = sd1norm(n) 
    p[2][2][:x] = [ unconstrained_to_constrained(mean_varying[n]),
                    unconstrained_to_constrained(mean_varying[n]),       
-                   unconstrained_to_constrained(mean_varying[n])] # hide       
-   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)" # hide
-end # hide
+                   unconstrained_to_constrained(mean_varying[n])]        
+   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)" 
+end 
+```
 
+```@example bounded_below
 gif(anim_bounded_below, "anim_bounded_below.gif", fps = 5) # hide
 ```
-The following commands generate the `Transformed(Normal(0.5,1))` distribution with a lower bound constraint
+The following commands generate the transformed `Normal(0.5,1)` distribution
+
 ```@repl
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
 distribution = Parameterized(Normal(0.5,1)) 
 constraint = [bounded_below(0)]
-name = "normal_zero_one"
+name = "bounded_below_parameter"
 prior = ParameterDistribution(distribution,constraint,name)
+```
+where `bounded_below(0)` automatically defines the constraint map
+```julia
+unconstrained_to_constrained(x) = exp(x)
 ```
 
 ### Bounded above by 10.0: `constraint = [bounded_above(10)]`
 
-```@example
-using Distributions # hide
-using Plots # hide
-N=50 # hide
-x_eval = collect(-5:4/400:5) # hide
-mean_varying = collect(-1:5/(N+1):4) # hide
-sd_varying = collect(0.1:3.9/(N+1):4) # hide
+```@setup bounded_above
+using Distributions 
+using Plots 
+N=50 
+x_eval = collect(-5:4/400:5) 
+mean_varying = collect(-1:5/(N+1):4) 
+sd_varying = collect(0.1:3.9/(N+1):4) 
 
 #bounded above by 10.0
 unconstrained_to_constrained(x) = 10.0 - exp(x)  
 
-mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) # hide
-sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) # hide
-constrained_x_eval = unconstrained_to_constrained.(x_eval) # hide
-p1 = plot(constrained_x_eval, mean0norm.(1)) # hide
-vline!([unconstrained_to_constrained(0)]) # hide
-p2 = plot(constrained_x_eval, sd1norm.(1)) # hide
-vline!([unconstrained_to_constrained(mean_varying[1])]) # hide
-p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) # hide 
+mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) 
+sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) 
+constrained_x_eval = unconstrained_to_constrained.(x_eval) 
+p1 = plot(constrained_x_eval, mean0norm.(1)) 
+vline!([unconstrained_to_constrained(0)]) 
+p2 = plot(constrained_x_eval, sd1norm.(1)) 
+vline!([unconstrained_to_constrained(mean_varying[1])]) 
+p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false)  
  
-anim_bounded_above = @animate for n = 1:size(mean_varying)[1] # hide
-  #set new y data  # hide
-   p[1][1][:y] = mean0norm(n) # hide
-#   p[1][1][:label] = "sd = " * string(round(sd_varying[n],digits=3)) # hide
-   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" # hide
-   p[2][1][:y] = sd1norm(n) # hide
-#   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide
+anim_bounded_above = @animate for n = 1:size(mean_varying)[1] 
+  #set new y data  
+   p[1][1][:y] = mean0norm(n) 
+   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" 
+   p[2][1][:y] = sd1norm(n) 
    p[2][2][:x] = [ unconstrained_to_constrained(mean_varying[n]),
                    unconstrained_to_constrained(mean_varying[n]),       
-                   unconstrained_to_constrained(mean_varying[n])] # hide       
-   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)" # hide 
+                   unconstrained_to_constrained(mean_varying[n])]        
+   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)"  
 
-end # hide
+end 
+```
 
+```@example bounded_above
 gif(anim_bounded_above, "anim_bounded_above.gif", fps = 5) # hide
 ```
-The following commands generate the `Transformed(Normal(0.5,1))` distribution with a upper bound constraint 10
+
+The following commands generate the transformed `Normal(0.5,1)` distribution
+
 ```@repl
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
 distribution = Parameterized(Normal(0.5,1)) 
 constraint = [bounded_above(10)]
-name = "normal_zero_one"
+name = "bounded_below_parameter"
 prior = ParameterDistribution(distribution,constraint,name)
 ```
+where `bounded_above(10)` automatically defines the constraint map
+```julia
+unconstrained_to_constrained(x) = 10 - exp(x)
+```
+
 ### Bounded in  between 5 and 10: `constraint = [bounded(5,10)]`
 
-```@example
-using Distributions # hide
-using Plots # hide
-N=50 # hide
-x_eval = collect(-10:20/400:10) # hide
-mean_varying = collect(-3:2/(N+1):3) # hide
-sd_varying = collect(0.1:0.9/(N+1):10) # hide
+```@setup bounded
+using Distributions 
+using Plots 
+N=50 
+x_eval = collect(-10:20/400:10) 
+mean_varying = collect(-3:2/(N+1):3) 
+sd_varying = collect(0.1:0.9/(N+1):10) 
 
 #bounded in [5.0,10.0]
 unconstrained_to_constrained(x) = (10.0 * exp(x) + 5.0) / (exp(x) + 1)
 
-mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) # hide
-sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) # hide
-constrained_x_eval = unconstrained_to_constrained.(x_eval) # hide
-p1 = plot(constrained_x_eval, mean0norm.(1)) # hide
-vline!([unconstrained_to_constrained(0)]) # hide
-p2 = plot(constrained_x_eval, sd1norm.(1)) # hide
-vline!([unconstrained_to_constrained(mean_varying[1])]) # hide
-p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) # hide 
+mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) 
+sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) 
+constrained_x_eval = unconstrained_to_constrained.(x_eval) 
+p1 = plot(constrained_x_eval, mean0norm.(1)) 
+vline!([unconstrained_to_constrained(0)]) 
+p2 = plot(constrained_x_eval, sd1norm.(1)) 
+vline!([unconstrained_to_constrained(mean_varying[1])]) 
+p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false)  
  
-anim_bounded = @animate for n = 1:size(mean_varying)[1] # hide
-   #set new y data  # hide
-   p[1][1][:y] = mean0norm(n) # hide
-#   p[1][1][:label] = "sd = " * string(round(sd_varying[n],digits=3)) # hide
-   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" # hide
-   p[2][1][:y] = sd1norm(n) # hide
-#   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide
+anim_bounded = @animate for n = 1:size(mean_varying)[1] 
+   #set new y data  
+   p[1][1][:y] = mean0norm(n) 
+   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" 
+   p[2][1][:y] = sd1norm(n) 
    p[2][2][:x] = [ unconstrained_to_constrained(mean_varying[n]),
                    unconstrained_to_constrained(mean_varying[n]),       
-                   unconstrained_to_constrained(mean_varying[n])] # hide       
+                   unconstrained_to_constrained(mean_varying[n])]        
    
-   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)" # hide  
+   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)"   
 
-end # hide
+end 
+```
 
+```@example bounded
 gif(anim_bounded, "anim_bounded.gif", fps = 10) # hide
 ```
-The following commands generate the `Transformed(Normal(0.5,1))` distribution with a bounded constraint between 5 and 10
+The following commands generate the transformed `Normal(0.5,1)` distribution
+
 ```@repl
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
 distribution = Parameterized(Normal(0.5,1)) 
 constraint = [bounded(5,10)]
-name = "normal_zero_one"
+name = "bounded_below_parameter"
 prior = ParameterDistribution(distribution,constraint,name)
 ```
+where `bounded(5,10)` automatically defines the constraint map
+```julia
+unconstrained_to_constrained(x) = (10 * exp(x) + 5) / (exp(x) + 1)
+```
+
 ## A more involved example:
 
 We create a 6-dimensional parameter distribution from 2 triples.

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -98,7 +98,10 @@ mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) # hide
 sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) # hide
 constrained_x_eval = unconstrained_to_constrained.(x_eval) # hide 
 p1 = plot(constrained_x_eval, mean0norm.(1)) # hide
+vline!([unconstrained_to_constrained(0)]) # hide
 p2 = plot(constrained_x_eval, sd1norm.(1)) # hide     
+vline!([unconstrained_to_constrained(mean_varying[1])]) # hide
+
 p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) # hide 
  
 anim_unbounded = @animate for n = 1:size(mean_varying)[1] # hide
@@ -108,10 +111,25 @@ anim_unbounded = @animate for n = 1:size(mean_varying)[1] # hide
    p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" # hide
    p[2][1][:y] = sd1norm(n) # hide
 #   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide  
+   p[2][2][:x] = [ unconstrained_to_constrained(mean_varying[n]),
+                   unconstrained_to_constrained(mean_varying[n]),       
+                   unconstrained_to_constrained(mean_varying[n])] # hide       
+
    p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)" # hide
 end # hide
-gif(anim_unbounded, "anim_unbounded.gif", fps = 10) # hide
+gif(anim_unbounded, "anim_unbounded.gif", fps = 5) # hide
 ```
+The following commands generate the `Normal(0.5,1)` distribution with no constraint
+
+```@repl
+using EnsembleKalmanProcesses.ParameterDistributionStorage
+using Distributions 
+distribution = Parameterized(Normal(0.5,1)) 
+constraint = [no_constraint()]
+name = "normal_zero_one"
+prior = ParameterDistribution(distribution,constraint,name)
+```
+
 ### Bounded below by 0: `constraint = [bounded_below(0)]`
 
 ```@example
@@ -129,7 +147,10 @@ mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) # hide
 sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) # hide
 constrained_x_eval = unconstrained_to_constrained.(x_eval) # hide
 p1 = plot(constrained_x_eval, mean0norm.(1)) # hide
+vline!([unconstrained_to_constrained(0)]) # hide
 p2 = plot(constrained_x_eval, sd1norm.(1)) # hide
+vline!([unconstrained_to_constrained(mean_varying[1])]) # hide
+
 p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) # hide 
  
 anim_bounded_below = @animate for n = 1:size(mean_varying)[1] # hide
@@ -139,10 +160,22 @@ anim_bounded_below = @animate for n = 1:size(mean_varying)[1] # hide
    p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" # hide
    p[2][1][:y] = sd1norm(n) # hide
 #   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide  
+   p[2][2][:x] = [ unconstrained_to_constrained(mean_varying[n]),
+                   unconstrained_to_constrained(mean_varying[n]),       
+                   unconstrained_to_constrained(mean_varying[n])] # hide       
    p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)" # hide
 end # hide
 
-gif(anim_bounded_below, "anim_bounded_below.gif", fps = 10) # hide
+gif(anim_bounded_below, "anim_bounded_below.gif", fps = 5) # hide
+```
+The following commands generate the `Transformed(Normal(0.5,1))` distribution with a lower bound constraint
+```@repl
+using EnsembleKalmanProcesses.ParameterDistributionStorage
+using Distributions 
+distribution = Parameterized(Normal(0.5,1)) 
+constraint = [bounded_below(0)]
+name = "normal_zero_one"
+prior = ParameterDistribution(distribution,constraint,name)
 ```
 
 ### Bounded above by 10.0: `constraint = [bounded_above(10)]`
@@ -162,7 +195,9 @@ mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) # hide
 sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) # hide
 constrained_x_eval = unconstrained_to_constrained.(x_eval) # hide
 p1 = plot(constrained_x_eval, mean0norm.(1)) # hide
+vline!([unconstrained_to_constrained(0)]) # hide
 p2 = plot(constrained_x_eval, sd1norm.(1)) # hide
+vline!([unconstrained_to_constrained(mean_varying[1])]) # hide
 p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) # hide 
  
 anim_bounded_above = @animate for n = 1:size(mean_varying)[1] # hide
@@ -171,14 +206,25 @@ anim_bounded_above = @animate for n = 1:size(mean_varying)[1] # hide
 #   p[1][1][:label] = "sd = " * string(round(sd_varying[n],digits=3)) # hide
    p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" # hide
    p[2][1][:y] = sd1norm(n) # hide
-#   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide  
+#   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide
+   p[2][2][:x] = [ unconstrained_to_constrained(mean_varying[n]),
+                   unconstrained_to_constrained(mean_varying[n]),       
+                   unconstrained_to_constrained(mean_varying[n])] # hide       
    p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)" # hide 
 
 end # hide
 
-gif(anim_bounded_above, "anim_bounded_above.gif", fps = 10) # hide
+gif(anim_bounded_above, "anim_bounded_above.gif", fps = 5) # hide
 ```
-
+The following commands generate the `Transformed(Normal(0.5,1))` distribution with a upper bound constraint 10
+```@repl
+using EnsembleKalmanProcesses.ParameterDistributionStorage
+using Distributions 
+distribution = Parameterized(Normal(0.5,1)) 
+constraint = [bounded_above(10)]
+name = "normal_zero_one"
+prior = ParameterDistribution(distribution,constraint,name)
+```
 ### Bounded in  between 5 and 10: `constraint = [bounded(5,10)]`
 
 ```@example
@@ -195,8 +241,10 @@ unconstrained_to_constrained(x) = (10.0 * exp(x) + 5.0) / (exp(x) + 1)
 mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) # hide
 sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) # hide
 constrained_x_eval = unconstrained_to_constrained.(x_eval) # hide
- p1 = plot(constrained_x_eval, mean0norm.(1)) # hide
- p2 = plot(constrained_x_eval, sd1norm.(1)) # hide
+p1 = plot(constrained_x_eval, mean0norm.(1)) # hide
+vline!([unconstrained_to_constrained(0)]) # hide
+p2 = plot(constrained_x_eval, sd1norm.(1)) # hide
+vline!([unconstrained_to_constrained(mean_varying[1])]) # hide
 p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) # hide 
  
 anim_bounded = @animate for n = 1:size(mean_varying)[1] # hide
@@ -205,12 +253,25 @@ anim_bounded = @animate for n = 1:size(mean_varying)[1] # hide
 #   p[1][1][:label] = "sd = " * string(round(sd_varying[n],digits=3)) # hide
    p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" # hide
    p[2][1][:y] = sd1norm(n) # hide
-#   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide  
+#   p[2][1][:label] = "mean = " * string(round(mean_varying[n],digits=3)) # hide
+   p[2][2][:x] = [ unconstrained_to_constrained(mean_varying[n]),
+                   unconstrained_to_constrained(mean_varying[n]),       
+                   unconstrained_to_constrained(mean_varying[n])] # hide       
+   
    p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)" # hide  
 
 end # hide
 
 gif(anim_bounded, "anim_bounded.gif", fps = 10) # hide
+```
+The following commands generate the `Transformed(Normal(0.5,1))` distribution with a bounded constraint between 5 and 10
+```@repl
+using EnsembleKalmanProcesses.ParameterDistributionStorage
+using Distributions 
+distribution = Parameterized(Normal(0.5,1)) 
+constraint = [bounded(5,10)]
+name = "normal_zero_one"
+prior = ParameterDistribution(distribution,constraint,name)
 ```
 ## A more involved example:
 

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -53,7 +53,7 @@ title!("Transformed Normal(1,0.5)")
 ```
 The pdf of the Normal distribution, and its transform look like:
 ```@example zero_point_seven
-p = plot(p1,p2,legend=false)
+p = plot(p1,p2,legend=false) #hide
 ```
 ## 1. The ParameterDistributionType
 

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -18,12 +18,12 @@ Let's initialize the constraint first,
 ```julia
 constraint = [bounded(0,1)] 
 ```
-This sets up a logit transformation to and from the constrained space
+This *automatically* sets up the following transformations to the  constrained space and back
 ```julia
 unconstrained_to_constrained(x) = exp(x) / (exp(x) + 1)
 constrained_to_unconstrained(x) = log( x / (1 - x))
 ```
-The prior is around 0.7 (constrained space), and the push-forward of an unconstrained normal distribution N(mean=1,sd=0.5) through the logit transformation gives a prior with 95% of it's mass between [0.5,0.88].
+The prior should be around 0.7 (in the constrained space), and one can find that the push-forward of a particular normal distribution `unconstrained_to_constrained(Normal(mean=1,sd=0.5))` gives a prior pdf with 95% of its mass between [0.5,0.88].
 ```julia
 distribution = Parameterized(Normal(1,0.5)) 
 ```
@@ -71,7 +71,7 @@ In this section we call parameters are one-dimensional. Every parameter must hav
 
 ### Predefined ConstraintTypes
 
-We provide some ConstraintTypes, which apply different transformations internally to enforce bounds on physical parameter spaces. The types have the following constructors
+We provide some `ConstraintType`s, which apply different transformations internally to enforce bounds on physical parameter spaces. The types have the following constructors
 
  - `no_constraint()`, no transform is required for this parameter
  - `bounded_below(lower_bound)`, the physical parameter has a (provided) lower bound
@@ -93,9 +93,9 @@ This is simply an identifier for the parameters later on.
 The combination of different normal distributions with these predefined constraints, provides a suprising breadth of prior distributions.
 
 !!! note
-    We **highly** recommend users start with Normal distribution and predefined constraint: these offer the best computational benefits and clearest interpretation of the methods.
+    We **highly** recommend users start with Normal distribution and predefined `ConstraintType`: these offer the best computational benefits and clearest interpretation of the methods.
 
-For each for the predefined ConstraintTypes, we present animations of the resulting prior distribution for
+For each for the predefined `ConstraintType`s, we present animations of the resulting prior distribution for
 ```julia
 distribution = Parameterized(Normal(mean,sd))
 ```
@@ -140,9 +140,9 @@ end
 ```@example no_constraints
 gif(anim_unbounded, "anim_unbounded.gif", fps = 5) # hide
 ```
-The following commands generate the transformed `Normal(0.5,1)` distribution
+The following REPL commands generate the transformed `Normal(0.5,1)` distribution
 
-```@repl
+```julia
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
 distribution = Parameterized(Normal(0.5,1)) 
@@ -150,7 +150,7 @@ constraint = [no_constraint()]
 name = "unbounded_parameter"
 prior = ParameterDistribution(distribution,constraint,name)
 ```
-where `no_constraint()` automatically defines the constraint map
+where `no_constraint()` automatically defines the identity constraint map
 ```julia
 unconstrained_to_constrained(x) = x
 ```
@@ -193,9 +193,9 @@ end
 ```@example bounded_below
 gif(anim_bounded_below, "anim_bounded_below.gif", fps = 5) # hide
 ```
-The following commands generate the transformed `Normal(0.5,1)` distribution
+The following REPL commands generate the transformed `Normal(0.5,1)` distribution
 
-```@repl
+```julia
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
 distribution = Parameterized(Normal(0.5,1)) 
@@ -247,14 +247,14 @@ end
 gif(anim_bounded_above, "anim_bounded_above.gif", fps = 5) # hide
 ```
 
-The following commands generate the transformed `Normal(0.5,1)` distribution
+The following REPL commands generate the transformed `Normal(0.5,1)` distribution
 
-```@repl
+```julia
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
 distribution = Parameterized(Normal(0.5,1)) 
 constraint = [bounded_above(10)]
-name = "bounded_below_parameter"
+name = "bounded_above_parameter"
 prior = ParameterDistribution(distribution,constraint,name)
 ```
 where `bounded_above(10)` automatically defines the constraint map
@@ -301,14 +301,14 @@ end
 ```@example bounded
 gif(anim_bounded, "anim_bounded.gif", fps = 10) # hide
 ```
-The following commands generate the transformed `Normal(0.5,1)` distribution
+The following REPL commands generate the transformed `Normal(0.5,1)` distribution
 
-```@repl
+```julia
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
 distribution = Parameterized(Normal(0.5,1)) 
 constraint = [bounded(5,10)]
-name = "bounded_below_parameter"
+name = "bounded_parameter"
 prior = ParameterDistribution(distribution,constraint,name)
 ```
 where `bounded(5,10)` automatically defines the constraint map

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -48,7 +48,7 @@ constrained_x_eval = unconstrained_to_constrained.(x_eval)
 ```
 The push-forward of the pdf and the push-forward of the mean look like
 ```@example zero_point_seven
-p = plot(constrained_x_eval, distplot, legend=false) # hide
+p = plot(constrained_x_eval, dist, legend=false) # hide
 vline!([unconstrained_to_constrained(1.0)]) # hide
 ```
 ## 1. The ParameterDistributionType

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -72,7 +72,7 @@ This is simply an identifier for the parameters later on.
 
 The combination of different normal distributions with these predefined constraints, provides a suprising breadth of prior distributions.
 
-!!! Note
+!!! note
     We **highly** recommend users start with Normal distribution and predefined constraint: these offer the best computational benefits and clearest interpretation of the methods.
 
 For each for the predefined ConstraintTypes, we present animations of the resulting prior distribution for


### PR DESCRIPTION
Resolves #44 

Check out the parameter distributions section in the documentation

TODO:
- [x] Replace `@example` with `@setup` blocks, to avoid documenter bug 
- [x] slower gifs
- [x] include the building of the prior for each animated example.
- [x] added transform of normal distribution means
- [ ] added transform of normal distribution +/- sd