### PR TITLE
unpin Distributions version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Distributions = "v0.24.14"
+Distributions = "v0.24.14 - v0.25.0"
 DocStringExtensions = "v0.8.3"
 StatsBase = "v0.33.3"
 julia = "1.5"


### PR DESCRIPTION
The Distributions package pinned previously was incompatible with the new TC.jl environment. 