### PR TITLE
Add parameter transformers for additional structures.

### DIFF
--- a/src/ParameterDistribution.jl
+++ b/src/ParameterDistribution.jl
@@ -398,24 +398,56 @@ end
 #apply transforms
 
 """
-    function transform_constrained_to_unconstrained(pd::ParameterDistribution, x::Array{<:Real})
+    function transform_constrained_to_unconstrained(pd::ParameterDistribution, x::Array{<:Real,1})
 
-Apply the transformation to map (possibly constrained) parameters `xarray` into the unconstrained space
+Apply the transformation to map (possibly constrained) parameters `xarray` into the unconstrained space.
 """
-function transform_constrained_to_unconstrained(pd::ParameterDistribution, xarray::Array{FT}) where {FT <: Real}
+function transform_constrained_to_unconstrained(pd::ParameterDistribution, xarray::Array{FT,1}) where {FT <: Real}
     return cat([c.constrained_to_unconstrained(xarray[i]) for (i,c) in enumerate(pd.constraints)]...,dims=1)
 end
 
 """
-    function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{Real})
+    function transform_constrained_to_unconstrained(pd::ParameterDistribution, xarray::Array{<:Real,2})
 
-Apply the transformation to map parameters `xarray` from the unconstrained space into (possibly constrained) space
+Apply the transformation to map (possibly constrained) parameter samples `xarray` into the unconstrained space.
+Here, `xarray` contains parameters as columns and samples as rows.
 """
-function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{FT}) where {FT <: Real}
+function transform_constrained_to_unconstrained(pd::ParameterDistribution, xarray::Array{FT,2}) where {FT <: Real}
+    return Array(hcat([c.constrained_to_unconstrained.(xarray[i,:]) for (i,c) in enumerate(pd.constraints)]...)')
+end
+
+"""
+    function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{<:Real,1})
+
+Apply the transformation to map parameters `xarray` from the unconstrained space into (possibly constrained) space.
+"""
+function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{FT,1}) where {FT <: Real}
     return cat([c.unconstrained_to_constrained(xarray[i]) for (i,c) in enumerate(pd.constraints)]...,dims=1)
 end
 
+"""
+    function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{<:Real,2})
 
+Apply the transformation to map parameter samples `xarray` from the unconstrained space into (possibly constrained) space.
+Here, `xarray` contains parameters as columns and samples as rows.
+"""
+function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{FT,2}) where {FT <: Real}
+    return Array(hcat([c.unconstrained_to_constrained.(xarray[i,:]) for (i,c) in enumerate(pd.constraints)]...)')
+end
+
+"""
+    function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{Array{<:Real,2},1})
+
+Apply the transformation to map parameter sample ensembles `xarray` from the unconstrained space into (possibly constrained) space.
+Here, `xarray` contains parameters sample ensembles for different EKP iterations.
+"""
+function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{Array{FT,2},1}) where {FT <: Real}
+    transf_xarray = []
+    for elem in xarray
+           push!(transf_xarray, transform_unconstrained_to_constrained(pd, elem))
+       end
+    return transf_xarray
+end
 
 
 

--- a/test/ParameterDistribution/runtests.jl
+++ b/test/ParameterDistribution/runtests.jl
@@ -222,6 +222,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
 
     @testset "transform functions" begin
         #setup for the tests
+        tol = 1e-8
         d1 = Parameterized(MvNormal(4,0.1))
         c1 = [no_constraint(),
               bounded_below(-1.0),
@@ -240,15 +241,26 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
 
         x_unbd = rand(MvNormal(6,3), 1000)  #6 x 1000 
         # Tests for transforms
-        x_real_constrained1 = mapslices(x -> transform_unconstrained_to_constrained(u1,x), x_unbd[1:4,:]; dims=1)
-        @test isapprox(x_unbd[1:4,:] - mapslices(x -> transform_constrained_to_unconstrained(u1,x), x_real_constrained1; dims=1), zeros(size(x_unbd[1:4,:])); atol=1e-8)
+        x_real_constrained1 = mapslices(x -> transform_unconstrained_to_constrained(u1,x),x_unbd[1:4,:]; dims=1)
+        @test isapprox(x_unbd[1:4,:] - mapslices(x -> transform_constrained_to_unconstrained(u1,x),
+            x_real_constrained1; dims=1), zeros(size(x_unbd[1:4,:])); atol=tol)
+
         x_real_constrained2 = mapslices(x -> transform_unconstrained_to_constrained(u2,x), x_unbd[5:6,:]; dims=1) 
-        @test isapprox(x_unbd[5:6,:] -  mapslices(x -> transform_constrained_to_unconstrained(u2,x), x_real_constrained2; dims=1), zeros(size(x_unbd[5:6,:])); atol=1e-8)
+        @test isapprox(x_unbd[5:6,:] - mapslices(x -> transform_constrained_to_unconstrained(u2,x),
+            x_real_constrained2; dims=1), zeros(size(x_unbd[5:6,:])); atol=tol)
         
         x_real = mapslices(x -> transform_unconstrained_to_constrained(u,x), x_unbd; dims=1)
         x_unbd_tmp = mapslices(x -> transform_constrained_to_unconstrained(u,x), x_real; dims=1)
-        @test isapprox(x_unbd - x_unbd_tmp,zeros(size(x_unbd)); atol=1e-8)
+        @test isapprox(x_unbd - x_unbd_tmp,zeros(size(x_unbd)); atol=tol)
         
+        # Tests transforms for other input structures
+        @test isapprox(transform_unconstrained_to_constrained(u1,x_unbd[1:4,:]), x_real_constrained1; atol=tol)
+        @test isapprox(x_unbd[1:4,:] - transform_constrained_to_unconstrained(u1, x_real_constrained1),
+            zeros(size(x_unbd[1:4,:])); atol=tol)
+        @test isapprox(transform_unconstrained_to_constrained(u2,x_unbd[5:6,:]), x_real_constrained2; atol=tol)
+        @test isapprox(x_unbd[5:6,:] - transform_constrained_to_unconstrained(u2, x_real_constrained2),
+            zeros(size(x_unbd[5:6,:])); atol=tol)
+        @test isapprox(transform_unconstrained_to_constrained(u2,[x_unbd[5:6,:], x_unbd[5:6,:]]),
+            [x_real_constrained2, x_real_constrained2]; atol=tol)
     end
-    
 end


### PR DESCRIPTION
This PR adds additional element-wise parameter transformers that can take structures such as `Array{FT,2}` or `Array{Array{<:Real,2},1}`, often encountered in the parameter calibration process.