### PR TITLE
Remove unnecessary calls and inputs in UKI.

### DIFF
--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -76,7 +76,6 @@ update_freq::IT : set to 0 when the inverse problem is not identifiable,
 function Unscented(
     u0_mean::Array{FT, 1}, 
     uu0_cov::Array{FT, 2},
-    N_y::IT,
     α_reg::FT,
     update_freq::IT;
     modified_uscented_transform::Bool = true,
@@ -125,9 +124,7 @@ function Unscented(
     r = u0_mean
     iter = 0
 
-    Unscented(u_mean, uu_cov,  obs_pred, c_weights, mean_weights, cov_weights, Σ_ω, Σ_ν_scale, α_reg, r, update_freq, iter)
-    
-    
+    Unscented(u_mean, uu_cov, obs_pred, c_weights, mean_weights, cov_weights, Σ_ω, Σ_ν_scale, α_reg, r, update_freq, iter)
 end
 
 
@@ -248,7 +245,6 @@ function update_ensemble_analysis!(uki::EnsembleKalmanProcess{FT, IT,Unscented},
     obs_mean = uki.obs_mean
     Σ_ν = uki.process.Σ_ν_scale * uki.obs_noise_cov
     
-    N_u, N_y, N_ens = length(uki.process.u_mean[1]), length(uki.obs_mean), uki.N_ens
     ############# Prediction step:
     
     u_p_mean = construct_mean(uki, u_p) 
@@ -266,7 +262,7 @@ function update_ensemble_analysis!(uki::EnsembleKalmanProcess{FT, IT,Unscented},
     uu_cov =  uu_p_cov - tmp*ug_cov' 
     
     
-    ########### Save resutls
+    ########### Save results
     push!(uki.process.obs_pred, g_mean) # N_ens x N_data
     push!(uki.process.u_mean, u_mean) # N_ens x N_params
     push!(uki.process.uu_cov, uu_cov) # N_ens x N_data

--- a/test/EnsembleKalmanProcessModule/runtests.jl
+++ b/test/EnsembleKalmanProcessModule/runtests.jl
@@ -104,7 +104,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     if TEST_PLOT_OUTPUT
         gr()
         p = plot(get_u_prior(ekiobj)[1,:], get_u_prior(ekiobj)[2,:], seriestype=:scatter)
-        plot!(get_u_final(ekiobj)[1, :],  get_u_final(ekiobj)[2,:], seriestype=:scatter)
+        plot!(get_u_final(ekiobj)[1, :], get_u_final(ekiobj)[2,:], seriestype=:scatter)
         plot!([u_star[1]], xaxis="u1", yaxis="u2", seriestype="vline",
             linestyle=:dash, linecolor=:red)
         plot!([u_star[2]], seriestype="hline", linestyle=:dash, linecolor=:red)
@@ -136,7 +136,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     if TEST_PLOT_OUTPUT
         gr()
         p = plot(get_u_prior(eksobj)[1,:], get_u_prior(eksobj)[2,:], seriestype=:scatter)
-        plot!(get_u_final(eksobj)[1, :],  get_u_final(eksobj)[2,:], seriestype=:scatter)
+        plot!(get_u_final(eksobj)[1, :], get_u_final(eksobj)[2,:], seriestype=:scatter)
         plot!([u_star[1]], xaxis="u1", yaxis="u2", seriestype="vline",
             linestyle=:dash, linecolor=:red)
         plot!([u_star[2]], seriestype="hline", linestyle=:dash, linecolor=:red)
@@ -168,7 +168,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     N_iter = 20 # number of UKI iterations
     α_reg =  1.0
     update_freq = 0
-    process = Unscented(prior_mean, prior_cov, length(y_star),  α_reg, update_freq)
+    process = Unscented(prior_mean, prior_cov, α_reg, update_freq)
     ukiobj = EnsembleKalmanProcessModule.EnsembleKalmanProcess(y_star, Γy, process)
 
     # UKI iterations
@@ -210,7 +210,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
         end
 
         ites = Array(LinRange(1, N_iter+1, N_iter+1))
-        p = plot(ites,grid=false, θ_mean_arr[1,:], yerror=3.0*θθ_std_arr[1,:],  label="u1")
+        p = plot(ites,grid=false, θ_mean_arr[1,:], yerror=3.0*θθ_std_arr[1,:], label="u1")
         plot!(ites, fill(u_star[1], N_iter+1), linestyle=:dash, linecolor=:grey,label=nothing)
         plot!(ites,grid=false, θ_mean_arr[2,:], yerror=3.0*θθ_std_arr[2,:], label="u2", xaxis="Iterations")
         plot!(ites, fill(u_star[2], N_iter+1), linestyle=:dash, linecolor=:grey,label=nothing)


### PR DESCRIPTION
This PR cleans up some unused calls and inputs in the Unscented Kalman constructor. Behavior is unchanged, except for the call to `Unscented`, which now has one argument less.