### PR TITLE
Generalize deps compat requirements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,9 +12,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Distributions = "v0.24.14 - v0.25.0, 0.25"
-DocStringExtensions = "v0.8.3"
-StatsBase = "v0.33.3"
+Distributions = "~0.24.14, ^0.25"
+DocStringExtensions = "^0.8"
+StatsBase = "^0.33"
 julia = "1.5"
 
 [extras]


### PR DESCRIPTION
This PR generalizes a bit the compatibility requirements of the various dependencies.

In particular, the PR will allow the use of the patch releases: DocStringExtensions v0.8.5, Distributions v0.25.18, and StatsBase.jl v0.33.11.