### PR TITLE
Fix typos and code formatting in Docs

### DIFF
--- a/docs/src/ensemble_kalman_inversion.md
+++ b/docs/src/ensemble_kalman_inversion.md
@@ -23,7 +23,7 @@ The parameter vector of the ``j``-th ensemble member at the ``n``-th iteration i
 \theta_{n+1}^{(j)} = \theta_{n}^{(j)} - \dfrac{\Delta t_n}{J}\sum_{k=1}^J \left \langle \mathcal{G}(\theta_n^{(k)}) - \bar{\mathcal{G}}_n \, , \, \Gamma_y^{-1} \left ( \mathcal{G}(\theta_n^{(j)}) - y \right ) \right \rangle \theta_{n}^{(k)} ,
 ```
 
-where the subscript ``n=1, \dots, N_{it}`` indicates the iteration, ``J`` is the number of
+where the subscript ``n=1, \dots, N_{\rm it}`` indicates the iteration, ``J`` is the number of
 members in the ensemble, ``\bar{\mathcal{G}}_n`` is the mean value of ``\mathcal{G}(\theta_n)``
 across ensemble members,
 
@@ -35,11 +35,11 @@ and angle brackets denote the Euclidean inner product. By multiplying with ``\Ga
 we render the inner product non-dimensional.
 
 The EKI algorithm is considered converged when the ensemble achieves sufficient consensus/collapse
-in parameter space. The final estimate ``\bar{\theta}_{N_{it}}`` is taken to be the ensemble
+in parameter space. The final estimate ``\bar{\theta}_{N_{\rm it}}`` is taken to be the ensemble
 mean at the final iteration,
 
 ```math
-\bar{\theta}_{N_{it}} = \dfrac{1}{J}\sum_{k=1}^J\theta_{N_{it}}^{(k)}.
+\bar{\theta}_{N_{\rm it}} = \dfrac{1}{J}\sum_{k=1}^J\theta_{N_{\rm it}}^{(k)}.
 ```
 
 For typical applications, a near-optimal solution ``\theta`` can be found after as few as 10 iterations of the algorithm. The obtained solution is optimal in the sense of the mean squared error loss, details can be found in [Iglesias et al (2013)](http://dx.doi.org/10.1088/0266-5611/29/4/045001). The algorithm performs better with larger ensembles. As a rule of thumb, the number of members in the ensemble should be larger than ``10p``, although the optimal ensemble size may depend on the problem setting and the computational power available.
@@ -52,14 +52,14 @@ The forward map ``\mathcal{G}`` maps the space of unconstrained parameters ``\th
 \mathcal{G} = \mathcal{H} \circ \Psi \circ \mathcal{T}^{-1},
 ```
 
-where ``\mathcal{H}: \mathbb{R}^o \rightarrow \mathbb{R}^d`` is the observation map and ``\mathcal{T}`` is the transformation map from constrained to unconstrained parameter spaces, such that ``\mathcal{T}(\phi)=\theta``. A family of standard transformation maps and their inverse are available in the `ParameterDistributionStorage` module.
+where ``\mathcal{H}: \mathbb{R}^o \rightarrow \mathbb{R}^d`` is the observation map and ``\mathcal{T}`` is the transformation map from constrained to unconstrained parameter spaces, such that ``\mathcal{T}(\phi) = \theta``. A family of standard transformation maps and their inverse are available in the `ParameterDistributionStorage` module.
 
 ### Creating the EKI Object
 
 An ensemble Kalman inversion object can be created using the `EnsembleKalmanProcess` constructor by specifying the `Inversion()` process type.
 
 Creating an ensemble Kalman inversion object requires as arguments:
- 1. An initial parameter ensemble, `Array{FT, 2}` of size `[p × J]`;
+ 1. An initial parameter ensemble, `Array{Float, 2}` of size `[p × J]`;
  2. The mean value of the observed outputs, a vector of size `[d]`;
  3. The covariance of the observational noise, a matrix of size `[d × d]`
  4. The `Inversion()` process type.
@@ -75,7 +75,7 @@ initial_ensemble = construct_initial_ensemble(prior, J) # Initialize ensemble fr
 ekiobj = EnsembleKalmanProcess(initial_ensemble, y, obs_noise_cov, Inversion())
 ```
 
-See the [Prior distributions](https://clima.github.io/EnsembleKalmanProcesses.jl/previews/PR21/parameter_distributions/) section to learn about the construction of priors in `EnsembleKalmanProcesses.jl`. The prior is assumed to be over the unconstrained parameter space where ``\theta`` is defined. For applications where enforcing parameter bounds is necessary, the `ParameterDistributionStorage` module provides functions to map from constrained to unconstrained space and viceversa. 
+See the [Prior distributions](../parameter_distributions/) section to learn about the construction of priors in EnsembleKalmanProcesses.jl. The prior is assumed to be over the unconstrained parameter space where ``\theta`` is defined. For applications where enforcing parameter bounds is necessary, the `ParameterDistributionStorage` module provides functions to map from constrained to unconstrained space and vice versa. 
 
 ### Updating the Ensemble
 
@@ -90,7 +90,7 @@ N_iter = 20 # Number of steps of the algorithm
 for n in 1:N_iter
     θ_n = get_u_final(ekiobj) # Get current ensemble
     ϕ_n = transform_unconstrained_to_constrained(prior, θ_n) # Transform parameters to physical/constrained space
-    G_n = [H(Ψ((ϕ_n[:,i])) for i in 1:J]
+    G_n = [H(Ψ((ϕ_n[:, i])) for i in 1:J]
     g_ens = hcat(G_n...) # Evaluate forward map
     
     update_ensemble!(ekiobj, g_ens) # Update ensemble

--- a/docs/src/ensemble_kalman_sampler.md
+++ b/docs/src/ensemble_kalman_sampler.md
@@ -13,25 +13,25 @@ The data ``y`` and parameter vector ``\theta`` are assumed to be related accordi
 ```math
     y = \mathcal{G}(\theta) + \eta,
 ```
-where ``\mathcal{G}:  \mathbb{R}^p \rightarrow \mathbb{R}^d`` denotes the forward map, ``y \in \mathbb{R}^d`` is the vector of observations, and ``\eta`` is the observational noise, which is assumed to be drawn from a d-dimensional Gaussian with distribution ``\mathcal{N}(0, \Gamma_y)``. The objective of the inverse problem is to compute the unknown parameters ``\theta`` given the observations ``y``, the known forward map ``\mathcal{G}``, and noise characteristics $\eta$ of the process. 
+where ``\mathcal{G}: \mathbb{R}^p \rightarrow \mathbb{R}^d`` denotes the forward map, ``y \in \mathbb{R}^d`` is the vector of observations, and ``\eta`` is the observational noise, which is assumed to be drawn from a d-dimensional Gaussian with distribution ``\mathcal{N}(0, \Gamma_y)``. The objective of the inverse problem is to compute the unknown parameters ``\theta`` given the observations ``y``, the known forward map ``\mathcal{G}``, and noise characteristics ``\eta`` of the process. 
 
 
 ### Ensemble Kalman Sampling Algorithm
 
 
-The ensemble Kalman sampler is based on the following update equation for the parameter vector $\theta^{(j)}$ of ensemble member $j$:
+The ensemble Kalman sampler is based on the following update equation for the parameter vector ``\theta^{(j)}`` of ensemble member ``j``:
 
 ```math
 \begin{aligned}
-\theta_{n+1}^{(*, j)} &= \theta_{n}^{(j)} - \dfrac{\Delta t_n}{J}\sum_{k=1}^J\langle \mathcal{G}(\theta_n^{(k)}) - \bar{\mathcal{G}}_n, \Gamma_y^{-1}(\mathcal{G}(\theta_n^{(j)}) - y) \rangle \theta_{n}^{(k)} - \Delta t_n \mathsf{C}(\Theta_n) \Gamma_{\theta}^{-1} \theta_{n + 1}^{(*, j)} \\
-\theta_{n + 1}^{j} &= \theta_{n+1}^{(*, j)} + \sqrt{2 \Delta t_n \mathsf{C}(\Theta_n)} \xi_n^{j}
+\theta_{n+1}^{(*, j)} &= \theta_{n}^{(j)} - \dfrac{\Delta t_n}{J}\sum_{k=1}^J\langle \mathcal{G}(\theta_n^{(k)}) - \bar{\mathcal{G}}_n, \Gamma_y^{-1}(\mathcal{G}(\theta_n^{(j)}) - y) \rangle \theta_{n}^{(k)} - \Delta t_n \mathsf{C}(\Theta_n) \Gamma_{\theta}^{-1} \theta_{n + 1}^{(*, j)},\\
+\theta_{n + 1}^{j} &= \theta_{n+1}^{(*, j)} + \sqrt{2 \Delta t_n \mathsf{C}(\Theta_n)} \xi_n^{j},
 \end{aligned}
 ```
 
-where the subscript ``n=1, \dots, N_{it}`` indicates the iteration, ``J`` is the ensemble size (i.e., the number of particles in the ensemble), ``\Delta t_n`` is an adaptive time step, ``\Gamma_{\theta}`` is the prior covariance, and ``\xi_n^{(j)} \sim \mathcal{N}(0, \mathrm{I})``. ``\bar{\mathcal{G}}_n`` is the ensemble mean of ``\mathcal{G}(\theta)``,
+where the subscript ``n=1, \dots, N_{\rm it}`` indicates the iteration, ``J`` is the ensemble size (i.e., the number of particles in the ensemble), ``\Delta t_n`` is an adaptive time step, ``\Gamma_{\theta}`` is the prior covariance, and ``\xi_n^{(j)} \sim \mathcal{N}(0, \mathrm{I})``. ``\bar{\mathcal{G}}_n`` is the ensemble mean of ``\mathcal{G}(\theta)``,
 
 ```math
-\bar{\mathcal{G}}_n = \dfrac{1}{J}\sum_{k=1}^J\mathcal{G}(\theta_n^{(k)})
+\bar{\mathcal{G}}_n = \dfrac{1}{J}\sum_{k=1}^J\mathcal{G}(\theta_n^{(k)}).
 ```
 
 The ``p \times p`` matrix ``\mathsf{C}(\Theta_n)``, where ``\Theta_n = \left\{\theta^{(j)}\right\}_{j=1}^{J}`` is the set of all ensemble particles in the nth iteration, denotes the empirical covariance between particles,
@@ -42,7 +42,7 @@ The ``p \times p`` matrix ``\mathsf{C}(\Theta_n)``, where ``\Theta_n = \left\{\t
 where ``\bar{\theta}`` is the ensemble mean of the particles,
 
 ```math
-\bar{\theta} = \dfrac{1}{J}\sum_{k=1}^J\theta^{(k)}
+\bar{\theta} = \dfrac{1}{J}\sum_{k=1}^J\theta^{(k)}.
 ```
 
 

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -1,22 +1,27 @@
 # Glossary
 
-The following list includes the names and symbols of recurring concepts in `EnsembleKalmanProcesses.jl`. Some of these variables do not appear in the codebase, which relies on array programming for performance.  Contributions to the codebase require following this notational convention. Similarly, if you find inconsistencies in the documentation or codebase, please report an issue on GitHub.
+The following list includes the names and symbols of recurring concepts in
+EnsembleKalmanProcesses.jl. Some of these variables do not appear in the codebase,
+which relies on array programming for performance.  Contributions to the codebase
+require following this notational convention. Similarly, if you find inconsistencies
+in the documentation or codebase, please report an [issue](https://github.com/CliMA/EnsembleKalmanProcesses.jl/issues)
+on GitHub.
 
 | Name        | Symbol (Theory/Docs) | Symbol (Code)    |
 | :---        |    :----:            |    :----:     |
-| Parameter vector, Parameters (unconstrained space) | $\theta$  | $\theta$ |
-| Parameter vector size, Number of parameters  | $p$  | N_par |
-| Ensemble size  | $J$  | N_ens |
-| Ensemble particles, members  | $\theta^{(j)}$  | |
-| Number of iterations  | $N_{it}$  | N_iter |
-| Observation vector, Observations, Data vector  | $y$  | y |
-| Observation vector size, Data vector size  | $d$  | N_obs |
-| Observational noise | $\eta$  | obs_noise |
-| Observational noise covariance | $\Gamma_y$  | obs\_noise\_cov |
-| Hilbert space inner product | $\langle \phi, \Gamma^{-1} \psi\rangle$ | |
-| Forward map | $\mathcal{G}$  | G |
-| Dynamical model | $\Psi$  | $\Psi$ |
-| Transform map (constrained to unconstrained) | $\mathcal{T}$  | T |
-| Observation map | $\mathcal{H}$  | H |
-| Prior covariance (unconstrained space) | $\Gamma_{\theta}$  | prior_cov |
-| Prior mean (unconstrained space) | $m_\theta$  | prior_mean |
+| Parameter vector, Parameters (unconstrained space) | ``\theta``  | `θ` |
+| Parameter vector size, Number of parameters  | ``p``  | `N_par` |
+| Ensemble size  | ``J``  | `N_ens` |
+| Ensemble particles, members  | ``\theta^{(j)}``  | |
+| Number of iterations  | ``N_{\rm it}``  | `N_iter` |
+| Observation vector, Observations, Data vector  | ``y``  | `y` |
+| Observation vector size, Data vector size  | ``d``  | `N_obs` |
+| Observational noise | ``\eta``  | obs_noise |
+| Observational noise covariance | ``\Gamma_y``  | `obs_noise_cov` |
+| Hilbert space inner product | ``\langle \phi , \Gamma^{-1} \psi \rangle`` | |
+| Forward map | ``\mathcal{G}``  | `G` |
+| Dynamical model | ``\Psi``  | `Ψ` |
+| Transform map (constrained to unconstrained) | ``\mathcal{T}``  | `T` |
+| Observation map | ``\mathcal{H}``  | `H` |
+| Prior covariance (unconstrained space) | ``\Gamma_{\theta}``  | `prior_cov` |
+| Prior mean (unconstrained space) | ``m_\theta``  | `prior_mean` |

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,10 @@
 # EnsembleKalmanProcesses
 
 `EnsembleKalmanProcesses.jl` (EKP) is a library of derivative-free Bayesian optimization techniques based on the Ensemble Kalman Filters, a well known family of approximate filters used for data assimilation. Currently, the following methods are implemented in the library:
- - Ensemble Kalman Inversion (EKI) - The traditional optimization technique based on the Ensemble Kalman Filter EnKF ([Iglesias, Law, Stuart 2013](http://dx.doi.org/10.1088/0266-5611/29/4/045001)),
- - Ensemble Kalman Sampler (EKS) - also obtains a Gaussian Approximation of the posterior distribution, through a Monte Carlo integration (Garbuno-Inigo, Hoffmann, Li, Stuart 2020),
- - Unscented Kalman Inversion (UKI) - also obtains a Gaussian Approximation of the posterior distribution, through a quadrature based integration approach (Huang Schneider Stuart 2020),
- - [coming soon] Sparsity preserving Ensemble Kalman Inversion (SEKI) - Additionally adds approximate ``L^0`` and ``L^1`` penalization to the EKI (Schneider, Stuart, Wu 2020).
+ - Ensemble Kalman Inversion (EKI) - The traditional optimization technique based on the Ensemble Kalman Filter EnKF ([Iglesias, Law, Stuart, 2013](http://dx.doi.org/10.1088/0266-5611/29/4/045001)),
+ - Ensemble Kalman Sampler (EKS) - also obtains a Gaussian Approximation of the posterior distribution, through a Monte Carlo integration ([Garbuno-Inigo, Hoffmann, Li, Stuart, 2020](https://doi.org/10.1137/19M1251655)),
+ - Unscented Kalman Inversion (UKI) - also obtains a Gaussian Approximation of the posterior distribution, through a quadrature based integration approach (Huang, Schneider, Stuart, 2020),
+ - [coming soon] Sparsity preserving Ensemble Kalman Inversion (SEKI) - Additionally adds approximate ``L^0`` and ``L^1`` penalization to the EKI (Schneider, Stuart, Wu, 2020).
 
 Module                                      | Purpose
 --------------------------------------------|--------------------------------------------------------

--- a/docs/src/observations.md
+++ b/docs/src/observations.md
@@ -1,7 +1,7 @@
 # Observations
 
 The `Observations` object is used to store the truth for convenience of the user. The ingredients are
-1. Samples of the data `Vector{Vector{Float}}` or `Array{Float,2}`. If provided as a 2D array, the samples must be provided as *columns*. They are stored internally as `Vector{Vector{Float}}`
+1. Samples of the data `Vector{Vector{Float}}` or `Array{Float, 2}`. If provided as a 2D array, the samples must be provided as *columns*. They are stored internally as `Vector{Vector{Float}}`
 2. An optional covariance matrix can be provided.
 3. The names of the data in this object as a `String` or `Vector{String}`
 
@@ -10,16 +10,14 @@ If a covariance matrix is not provided, then the empirical covariance is also ca
 
 ## A simple example:
 
-Here is a typical construction of the object
+Here is a typical construction of the object:
 ```julia
 μ = zeros(5)
-Γy = rand(5,5)
-Γy = Γy'*Γy
+Γy = rand(5, 5)
+Γy = Γy' * Γy
 yt = rand(MvNormal(μ, Γy), 100) # generate 100 samples
 name = "zero-mean mvnormal"
 
 true_data = Observations.Obs(yt, Γy, name)
 ```
-Currently, the data is retrieved by accessing the stored variables e.g the fifth data sample is given by `truth_data.samples[5]`,or the covariance matrix by `truth_data.cov`.
-
-
+Currently, the data is retrieved by accessing the stored variables, e.g the fifth data sample is given by `truth_data.samples[5]`, or the covariance matrix by `truth_data.cov`.

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -1,65 +1,70 @@
 # Prior distributions
 
-We provide a flexible setup for storing prior distribution with the `ParameterDistributionStorage` module found in `src/ParameterDistribution.jl` 
+We provide a flexible setup for storing prior distribution with the `ParameterDistributionStorage` module found in `src/ParameterDistribution.jl`.
 
-One can create a full parameter distribution using three inputs.
- 1. A Distribution, given as a `ParameterDistributionType` object
- 2. An array of Constraints, given as a `Array{ConstraintType}` object
- 3. A Name, given as a `String` 
+One can create a full parameter distribution using three inputs:
+ 1. A Distribution, given as a `ParameterDistributionType` object,
+ 2. An array of Constraints, given as a `Array{ConstraintType}` object,
+ 3. A Name, given as a `String`.
 
-One can also provide arrays of the triple (1.,2.,3.) to create more complex distributions
+One can also provide arrays of the triple (1., 2., 3.) to create more complex distributions.
 
 # A simple example:
-Task: We wish to create a prior for a one-dimensional parameter. Our problem dictates that this parameter is bounded between 0 and 1. Prior knowledge dictates it is around 0.7. The parameter is called "point_seven".
+Task: We wish to create a prior for a one-dimensional parameter. Our problem dictates that this parameter is bounded between 0 and 1. Prior knowledge dictates it is around 0.7. The parameter is called `point_seven`.
 
 Solution: We should use a Normal distribution with the predefined "bounded" constraint.
 
 Let's initialize the constraint first,
 ```julia
-constraint = [bounded(0,1)]
+constraint = [bounded(0, 1)]
 ```
 This **automatically** sets up the following transformation to the  constrained space (and also its inverse)
 ```julia
 transform_unconstrained_to_constrained(x) = exp(x) / (exp(x) + 1)
 ```
-The prior should be around 0.7 (in the constrained space), and one can find that the push-forward of a particular normal distribution, namely, `transform_unconstrained_to_constrained(Normal(mean=1,sd=0.5))` gives a prior pdf with 95% of its mass between [0.5,0.88].
+The prior should be around 0.7 (in the constrained space), and one can find that the push-forward of a particular normal distribution, namely, `transform_unconstrained_to_constrained(Normal(mean = 1, sd = 0.5))` gives a prior pdf with 95% of its mass between [0.5, 0.88].
 ```julia
-distribution = Parameterized(Normal(1,0.5)) 
+distribution = Parameterized(Normal(1, 0.5))
 ```
 Finally we attach the name
 ```julia
 name = "point_seven"
 ```
-And the distribution is created by calling:
+and the distribution is created by:
 ```julia
-prior = ParameterDistribution(distribution,constraint,name)
+prior = ParameterDistribution(distribution, constraint, name)
 ```
 
 ```@setup zero_point_seven
 using Distributions 
 using Plots 
-N=50 
+
+N=50
 x_eval = collect(-3:6/400:3) 
-#bounded in [0.0,1.0]
-transform_unconstrained_to_constrained(x) = (1 * exp(x) + 0.0) / (exp(x) + 1)
-dist= pdf(Normal(1,0.5),x_eval) 
+#bounded in [0.0, 1.0]
+transform_unconstrained_to_constrained(x) = exp(x) / (exp(x) + 1)
+dist= pdf(Normal(1, 0.5), x_eval) 
 constrained_x_eval = transform_unconstrained_to_constrained.(x_eval) 
+
 p1 = plot(x_eval, dist,) 
 vline!([1.0]) 
-title!("Normal(1,0.5)")
+title!("Normal(1, 0.5)")
+
 p2 = plot(constrained_x_eval, dist) 
 vline!([transform_unconstrained_to_constrained(1.0)]) 
-title!("Transformed Normal(1,0.5)")
+title!("Transformed Normal(1, 0.5)")
 ```
-The pdf of the Normal distribution, and its transform look like:
+
+The pdf of the Normal distribution and its transform look like:
 ```@example zero_point_seven
-p = plot(p1,p2,legend=false,size = (900,450)) #hide
+p = plot(p1, p2, legend=false, size = (900, 450)) #hide
 ```
+
 ## 1. The ParameterDistributionType
 
-The `ParameterDistributionType` has 2 flavours for building a distribution.
+The `ParameterDistributionType` has two flavours for building a distribution:
  - The `Parameterized` type is initialized using a Julia `Distributions.jl` object. Samples are drawn randomly from the distribution object
- - The `Samples` type is initialized using a two dimensional array. Samples are drawn randomly (with replacement) from the columns of the provided array
+ - The `Samples` type is initialized using a two dimensional array. Samples are drawn randomly (with replacement) from the columns of the provided array.
 
 One can use combinations of these distributions to construct a full parameter distribution.
 
@@ -75,12 +80,12 @@ In this section we call parameters are one-dimensional. Every parameter must hav
 
 ### Predefined ConstraintTypes
 
-We provide some `ConstraintType`s, which apply different transformations internally to enforce bounds on physical parameter spaces. The types have the following constructors
+We provide some `ConstraintType`s, which apply different transformations internally to enforce bounds on physical parameter spaces. The types have the following constructors:
 
- - `no_constraint()`, no transform is required for this parameter
- - `bounded_below(lower_bound)`, the physical parameter has a (provided) lower bound
- - `bounded_above(upper_bound)`, the physical parameter has a (provided) upper bound 
- - `bounded(lower_bound,upper_bound)`, the physical parameter has the (provided) bounds
+ - `no_constraint()`, no transform is required for this parameter,
+ - `bounded_below(lower_bound)`, the physical parameter has a (provided) lower bound,
+ - `bounded_above(upper_bound)`, the physical parameter has a (provided) upper bound,
+ - `bounded(lower_bound,upper_bound)`, the physical parameter has the (provided) bounds.
 
 Users can also define their own transformations by directly creating a `ConstraintType` object with their own mappings.
 
@@ -94,7 +99,7 @@ This is simply an identifier for the parameters later on.
 
 ## 4. The power of the normal distribution
 
-The combination of different normal distributions with these predefined constraints, provides a suprising breadth of prior distributions.
+The combination of different normal distributions with these predefined constraints, provides a surprising breadth of prior distributions.
 
 !!! note
     We **highly** recommend users start with Normal distribution and predefined `ConstraintType`: these offer the best computational benefits and clearest interpretation of the methods.
@@ -104,30 +109,33 @@ For each for the predefined `ConstraintType`s, we present animations of the resu
 distribution = Parameterized(Normal(mean,sd))
 ```
 where: 
-1. We fix the mean value to 0, and range over the standard deviation
-2. We fix the standard deviation to 1 and range over the mean value
+1. we fix the mean value to 0, and range over the standard deviation,
+2. we fix the standard deviation to 1 and range over the mean value.
 
 ### Without constraints: `constraint = [no_constraints()]`
 
 ```@setup no_constraints
 using Distributions 
 using Plots 
-N = 50 
+
+N = 50
 x_eval = collect(-5:10/200:5) 
 mean_varying = collect(-3:6/(N+1):3) 
 sd_varying = collect(0.1:2.9/(N+1):3) 
 # no constraint 
 transform_unconstrained_to_constrained(x) = x
 
-mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval)
-sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) 
+mean0norm(n) = pdf(Normal(0,sd_varying[n]), x_eval)
+sd1norm(n) = pdf(Normal(mean_varying[n], 1), x_eval) 
 constrained_x_eval = transform_unconstrained_to_constrained.(x_eval) 
+
 p1 = plot(constrained_x_eval, mean0norm.(1)) 
 vline!([transform_unconstrained_to_constrained(0)]) 
+
 p2 = plot(constrained_x_eval, sd1norm.(1)) 
 vline!([transform_unconstrained_to_constrained(mean_varying[1])]) 
 
-p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false) 
+p = plot(p1, p2, layout=(1, 2), size = (900, 450), legend=false) 
  
 anim_unbounded = @animate for n = 1:size(mean_varying)[1] 
    #set new y data 
@@ -141,14 +149,17 @@ anim_unbounded = @animate for n = 1:size(mean_varying)[1]
    p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)"
 end 
 ```
+
 ```@example no_constraints
 gif(anim_unbounded, "anim_unbounded.gif", fps = 5) # hide
 ```
-The following REPL commands generate the transformed `Normal(0.5,1)` distribution
+
+The following generates the transformed `Normal(0.5, 1)` distribution
 
 ```julia
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
+
 distribution = Parameterized(Normal(0.5,1)) 
 constraint = [no_constraint()]
 name = "unbounded_parameter"
@@ -164,7 +175,8 @@ transform_unconstrained_to_constrained(x) = x
 ```@setup bounded_below
 using Distributions  
 using Plots 
-N=50 
+
+N=50
 x_eval = collect(-5:10/400:5) 
 mean_varying = collect(-1:5/(N+1):4) 
 sd_varying = collect(0.1:3.9/(N+1):4) 
@@ -172,11 +184,13 @@ sd_varying = collect(0.1:3.9/(N+1):4)
 #bounded below by 0
 transform_unconstrained_to_constrained(x) = exp(x)  
 
-mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) 
-sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) 
+mean0norm(n) = pdf(Normal(0,sd_varying[n]), x_eval) 
+sd1norm(n) = pdf(Normal(mean_varying[n], 1), x_eval) 
 constrained_x_eval = transform_unconstrained_to_constrained.(x_eval) 
+
 p1 = plot(constrained_x_eval, mean0norm.(1)) 
 vline!([transform_unconstrained_to_constrained(0)]) 
+
 p2 = plot(constrained_x_eval, sd1norm.(1)) 
 vline!([transform_unconstrained_to_constrained(mean_varying[1])]) 
 
@@ -197,11 +211,13 @@ end
 ```@example bounded_below
 gif(anim_bounded_below, "anim_bounded_below.gif", fps = 5) # hide
 ```
-The following REPL commands generate the transformed `Normal(0.5,1)` distribution
+
+The following generates the transformed `Normal(0.5, 1)` distribution
 
 ```julia
 using EnsembleKalmanProcesses.ParameterDistributionStorage
 using Distributions 
+
 distribution = Parameterized(Normal(0.5,1)) 
 constraint = [bounded_below(0)]
 name = "bounded_below_parameter"
@@ -217,33 +233,36 @@ transform_unconstrained_to_constrained(x) = exp(x)
 ```@setup bounded_above
 using Distributions 
 using Plots 
-N=50 
-x_eval = collect(-5:4/400:5) 
-mean_varying = collect(-1:5/(N+1):4) 
-sd_varying = collect(0.1:3.9/(N+1):4) 
+
+N=50
+x_eval = collect(-5:4/400:5)
+mean_varying = collect(-1:5/(N+1):4)
+sd_varying = collect(0.1:3.9/(N+1):4)
 
 #bounded above by 10.0
-transform_unconstrained_to_constrained(x) = 10.0 - exp(x)  
+transform_unconstrained_to_constrained(x) = 10 - exp(x)
 
-mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) 
-sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) 
-constrained_x_eval = transform_unconstrained_to_constrained.(x_eval) 
-p1 = plot(constrained_x_eval, mean0norm.(1)) 
-vline!([transform_unconstrained_to_constrained(0)]) 
-p2 = plot(constrained_x_eval, sd1norm.(1)) 
-vline!([transform_unconstrained_to_constrained(mean_varying[1])]) 
-p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false)  
+mean0norm(n) = pdf(Normal(0, sd_varying[n]), x_eval)
+sd1norm(n) = pdf(Normal(mean_varying[n], 1), x_eval)
+constrained_x_eval = transform_unconstrained_to_constrained.(x_eval)
+
+p1 = plot(constrained_x_eval, mean0norm.(1))
+vline!([transform_unconstrained_to_constrained(0)])
+
+p2 = plot(constrained_x_eval, sd1norm.(1))
+vline!([transform_unconstrained_to_constrained(mean_varying[1])])
+
+p = plot(p1, p2, layout=(1, 2), size = (900, 450), legend=false)
  
-anim_bounded_above = @animate for n = 1:size(mean_varying)[1] 
-  #set new y data  
-   p[1][1][:y] = mean0norm(n) 
-   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" 
-   p[2][1][:y] = sd1norm(n) 
+anim_bounded_above = @animate for n = 1:size(mean_varying)[1]
+  #set new y data
+   p[1][1][:y] = mean0norm(n)
+   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")"
+   p[2][1][:y] = sd1norm(n)
    p[2][2][:x] = [ transform_unconstrained_to_constrained(mean_varying[n]),
-                   transform_unconstrained_to_constrained(mean_varying[n]),       
-                   transform_unconstrained_to_constrained(mean_varying[n])]        
-   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)"  
-
+                   transform_unconstrained_to_constrained(mean_varying[n]),
+                   transform_unconstrained_to_constrained(mean_varying[n])]
+   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)"
 end 
 ```
 
@@ -251,12 +270,13 @@ end
 gif(anim_bounded_above, "anim_bounded_above.gif", fps = 5) # hide
 ```
 
-The following REPL commands generate the transformed `Normal(0.5,1)` distribution
+The following generates the transformed `Normal(0.5, 1)` distribution
 
 ```julia
 using EnsembleKalmanProcesses.ParameterDistributionStorage
-using Distributions 
-distribution = Parameterized(Normal(0.5,1)) 
+using Distributions
+
+distribution = Parameterized(Normal(0.5, 1))
 constraint = [bounded_above(10)]
 name = "bounded_above_parameter"
 prior = ParameterDistribution(distribution,constraint,name)
@@ -266,56 +286,60 @@ where `bounded_above(10)` automatically defines the constraint map
 transform_unconstrained_to_constrained(x) = 10 - exp(x)
 ```
 
-### Bounded in  between 5 and 10: `constraint = [bounded(5,10)]`
+### Bounded in  between 5 and 10: `constraint = [bounded(5, 10)]`
 
 ```@setup bounded
 using Distributions 
 using Plots 
-N=50 
+
+N = 50
 x_eval = collect(-10:20/400:10) 
 mean_varying = collect(-3:2/(N+1):3) 
 sd_varying = collect(0.1:0.9/(N+1):10) 
 
-#bounded in [5.0,10.0]
-transform_unconstrained_to_constrained(x) = (10.0 * exp(x) + 5.0) / (exp(x) + 1)
+#bounded in [5.0, 10.0]
+transform_unconstrained_to_constrained(x) = (10 * exp(x) + 5) / (exp(x) + 1)
 
-mean0norm(n)= pdf(Normal(0,sd_varying[n]),x_eval) 
-sd1norm(n)= pdf(Normal(mean_varying[n],1),x_eval) 
-constrained_x_eval = transform_unconstrained_to_constrained.(x_eval) 
-p1 = plot(constrained_x_eval, mean0norm.(1)) 
-vline!([transform_unconstrained_to_constrained(0)]) 
-p2 = plot(constrained_x_eval, sd1norm.(1)) 
-vline!([transform_unconstrained_to_constrained(mean_varying[1])]) 
-p = plot(p1,p2, layout=(1,2), size = (900,450), legend=false)  
+mean0norm(n) = pdf(Normal(0, sd_varying[n]), x_eval)
+sd1norm(n) = pdf(Normal(mean_varying[n], 1), x_eval)
+constrained_x_eval = transform_unconstrained_to_constrained.(x_eval)
+
+p1 = plot(constrained_x_eval, mean0norm.(1))
+vline!([transform_unconstrained_to_constrained(0)])
+
+p2 = plot(constrained_x_eval, sd1norm.(1))
+vline!([transform_unconstrained_to_constrained(mean_varying[1])])
+
+p = plot(p1, p2, layout=(1, 2), size = (900, 450), legend=false)
  
-anim_bounded = @animate for n = 1:size(mean_varying)[1] 
-   #set new y data  
-   p[1][1][:y] = mean0norm(n) 
-   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")" 
-   p[2][1][:y] = sd1norm(n) 
+anim_bounded = @animate for n = 1:size(mean_varying)[1]
+   #set new y data
+   p[1][1][:y] = mean0norm(n)
+   p[1][:title] = "Transformed Normal(0," * string(round(sd_varying[n], digits=3)) * ")"
+   p[2][1][:y] = sd1norm(n)
    p[2][2][:x] = [ transform_unconstrained_to_constrained(mean_varying[n]),
-                   transform_unconstrained_to_constrained(mean_varying[n]),       
-                   transform_unconstrained_to_constrained(mean_varying[n])]        
+                   transform_unconstrained_to_constrained(mean_varying[n]),
+                   transform_unconstrained_to_constrained(mean_varying[n])]
    
-   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)"   
-
+   p[2][:title] = "Transformed Normal(" * string(round(mean_varying[n], digits=3)) * ", 1)"
 end 
 ```
 
 ```@example bounded
 gif(anim_bounded, "anim_bounded.gif", fps = 10) # hide
 ```
-The following REPL commands generate the transformed `Normal(0.5,1)` distribution
+The following generates the transformed `Normal(0.5, 1)` distribution
 
 ```julia
 using EnsembleKalmanProcesses.ParameterDistributionStorage
-using Distributions 
-distribution = Parameterized(Normal(0.5,1)) 
-constraint = [bounded(5,10)]
+using Distributions
+
+distribution = Parameterized(Normal(0.5, 1)) 
+constraint = [bounded(5, 10)]
 name = "bounded_parameter"
 prior = ParameterDistribution(distribution,constraint,name)
 ```
-where `bounded(5,10)` automatically defines the constraint map
+where `bounded(5, 10)` automatically defines the constraint map
 ```julia
 transform_unconstrained_to_constrained(x) = (10 * exp(x) + 5) / (exp(x) + 1)
 ```
@@ -326,18 +350,18 @@ We create a 6-dimensional parameter distribution from 2 triples.
 
 The first triple is a 4-dimensional distribution with the following constraints on parameters in physical space:
 ```julia
-c1 = [no_constraint(), # no constraints
+c1 = [no_constraint(),     # no constraints
       bounded_below(-1.0), # provide lower bound
-      bounded_above(0.4), # provide upper bound
-      bounded(-0.1,0.2)] # provide lower and upper bound
+      bounded_above(0.4),  # provide upper bound
+      bounded(-0.1, 0.2)]  # provide lower and upper bound
 ```
 We choose to use a multivariate normal to represent its distribution in the transformed (unbounded) space. Here we take a tridiagonal covariance matrix.
 ```julia
-diag_val = 0.5*ones(4)
-udiag_val = 0.25*ones(3)
+diag_val = 0.5 * ones(4)
+udiag_val = 0.25 * ones(3)
 mean = ones(4)
 covariance = SymTridiagonal(diagonal_val, udiag_val)
-d1 = Parameterized(MvNormal(mean,covariance)) # 4D multivariate normal
+d1 = Parameterized(MvNormal(mean, covariance)) # 4D multivariate normal
 ```
 We also provide a name
 ```julia
@@ -348,22 +372,21 @@ The second triple is a 2-dimensional one. It is only given by 4 samples in the t
 
 ```julia
 d2 = Samples([1.0 3.0; 5.0 7.0; 9.0 11.0; 13.0 15.0]) # 4 samples of 2D parameter space
-transform = (x -> 3*x + 14)
-inverse_transform = (x -> (x-14) / 3)
+transform = (x -> 3 * x + 14)
+inverse_transform = (x -> (x - 14) / 3)
 c2 = [bounded(10,15),
       Constraint(transform, inverse_transform)]
 name2 = "constrained_sampled"
 ```
-The full prior distribution for this setting is created with arrays of our two triples
+The full prior distribution for this setting is created with arrays of our two triples.
 
 ```julia
-u = ParameterDistribution([d1,d2],[c1,c2],[name1,name2])
+u = ParameterDistribution([d1, d2], [c1, c2], [name1, name2])
 ```
 ## Other functions
-These functions typically return a `Dict` with `ParameterDistribution.name` as a keys, or an `Array` if requested 
+These functions typically return a `Dict` with `ParameterDistribution.name` as a keys, or an `Array` if requested:
  - `get_name`: returns the names
  - `get_distribution`: returns the Julia Distribution object if it is `Parameterized`
  - `sample_distribution`: samples the Julia Distribution if `Parameterized`, or draws from the list of samples if `Samples`
-
  - `transform_unconstrained_to_constrained`: Apply the constraint mappings
  - `transform_constrained_to_unconstrained`: Apply the inverse constraint mappings 

--- a/docs/src/unscented_kalman_inversion.md
+++ b/docs/src/unscented_kalman_inversion.md
@@ -1,12 +1,12 @@
 # Unscented Kalman Inversion
 
-One of the ensemble Kalman processes implemented in `EnsembleKalmanProcesses.jl` is the unscented Kalman inversion ([Huang et al, 2021](https://arxiv.org/abs/2102.01580)). The unscented Kalman inversion (UKI) is a derivative-free ensemble optimization method that seeks to find the optimal parameters $\theta \in \mathbb{R}^p$ in the inverse problem
+One of the ensemble Kalman processes implemented in `EnsembleKalmanProcesses.jl` is the unscented Kalman inversion ([Huang et al, 2021](https://arxiv.org/abs/2102.01580)). The unscented Kalman inversion (UKI) is a derivative-free ensemble optimization method that seeks to find the optimal parameters ``\theta \in \mathbb{R}^p`` in the inverse problem
 ```math
  y = \mathcal{G}(\theta) + \eta
 ```
-where $\mathcal{G}$ denotes the forward map, $y \in \mathbb{R}^d$ is the vector of observations and $\eta \sim \mathcal{N}(0, \Gamma_y)$ is additive Gaussian observational noise. Note that $p$ is the size of the parameter vector $\theta$ and $d$ is taken to be the size of the observation vector $y$. The UKI algorithm has the following properties
+where ``\mathcal{G}`` denotes the forward map, ``y \in \mathbb{R}^d`` is the vector of observations and ``\eta \sim \mathcal{N}(0, \Gamma_y)`` is additive Gaussian observational noise. Note that ``p`` is the size of the parameter vector ``\theta`` and ``d`` is taken to be the size of the observation vector ``y``. The UKI algorithm has the following properties
 
-* UKI has a given ensemble size and requires only $2p + 1$ particles in general.
+* UKI has a given ensemble size and requires only ``2p + 1`` particles in general.
 * UKI has uncertainty quantification capability, it gives both mean and covariance approximation (no ensemble collapse and no empirical variance inflation) of the posterior distribution, the 3-sigma confidence interval covers the truth parameters for perfect models.
 
 ## Algorithm
@@ -19,8 +19,8 @@ The UKI applies unscented Kalman filter for the following stochastic dynamical s
   &\textrm{observation:}  &&y_{n+1} = \mathcal{G}(\theta_{n+1}) + \nu_{n+1}, &&\nu_{n+1} \sim \mathcal{N}(0,\Sigma_{\nu}).
 \end{aligned}
 ```
-The free parameters in the UKI are $\alpha, r, \Sigma_{\nu}, \Sigma_{\omega}$.
-The UKI updates both the mean $m_n$ and covariance $C_n$ estimations of the parameter vector $\theta$ as following
+The free parameters in the UKI are ``\alpha, r, \Sigma_{\nu}, \Sigma_{\omega}``.
+The UKI updates both the mean ``m_n`` and covariance ``C_n`` estimations of the parameter vector ``\theta`` as following
 
 * Prediction step :
 
@@ -59,30 +59,30 @@ The unscented transformation parameters are
     &\lambda = a^2 (N_\theta + \kappa) - N_\theta \quad a=\min\{\sqrt{\frac{4}{N_\theta + \kappa}},  1\}\quad  \kappa = 0\\
     \end{aligned}
 ```
-And $[\sqrt{C}]_j$ is the $j$th column of the Cholesky factor of $C$. 
+And ``[\sqrt{C}]_j`` is the ``j``-th column of the Cholesky factor of ``C``. 
     
     
 
 
 ## Choosing of free parameters
-The free parameters in the unscented Kalman inversion are $\alpha, r, \Sigma_{\nu}, \Sigma_{\omega}$, which are chosen based on theorems developed in [Huang et al, 2021](https://arxiv.org/abs/2102.01580)
+The free parameters in the unscented Kalman inversion are ``\alpha, r, \Sigma_{\nu}, \Sigma_{\omega}``, which are chosen based on theorems developed in [Huang et al, 2021](https://arxiv.org/abs/2102.01580)
 
-* the vector $r$ is set to be the prior mean
+* the vector ``r`` is set to be the prior mean
 
-* the scalar $\alpha \in (0,1]$ is a regularization parameter, which is used to overcome ill-posedness and overfitting. A practical guide is 
+* the scalar ``\alpha \in (0,1]`` is a regularization parameter, which is used to overcome ill-posedness and overfitting. A practical guide is 
 
-    * When the observation noise is negligible, and there are more observations than parameters (identifiable inverse problem) $\alpha = 1$ (no regularization)
-    * Otherwise $\alpha < 1$. The smaller $\alpha$ is, the closer UKI will converge to the prior mean.
+    * When the observation noise is negligible, and there are more observations than parameters (identifiable inverse problem) ``\alpha = 1`` (no regularization)
+    * Otherwise ``\alpha < 1``. The smaller ``\alpha`` is, the closer UKI will converge to the prior mean.
     
-* the matrix $\Sigma_{\nu}$ is the artificial observation error covariance. We set $\Sigma_{\nu} = 2 \Gamma_{y}$, which makes the inverse problem consistent. 
+* the matrix ``\Sigma_{\nu}`` is the artificial observation error covariance. We set ``\Sigma_{\nu} = 2 \Gamma_{y}``, which makes the inverse problem consistent. 
 
-* the matrix $\Sigma_{\omega}$ is the artificial evolution error covariance. We set $\Sigma_{\omega} = (2 - \alpha^2)\Lambda$. We choose $\Lambda$ as following
+* the matrix ``\Sigma_{\omega}`` is the artificial evolution error covariance. We set ``\Sigma_{\omega} = (2 - \alpha^2)\Lambda``. We choose ``\Lambda`` as following
 
-    * when there are more observations than parameters (identifiable inverse problem), $\Lambda = C_n$, which is updated as the estimated covariance $C_n$ in the $n$-thevery iteration . This guarantees the converged covariance matrix is a good approximation to the posterior covariance matrix with an uninformative prior.
+    * when there are more observations than parameters (identifiable inverse problem), ``\Lambda = C_n``, which is updated as the estimated covariance ``C_n`` in the ``n``-th every iteration. This guarantees the converged covariance matrix is a good approximation to the posterior covariance matrix with an uninformative prior.
     
-    * otherwise $\Lambda = C_0$, this allows that the converged covariance matrix is a weighted average between the posterior covariance matrix with an uninformative prior and $C_0$.
+    * otherwise ``\Lambda = C_0``, this allows that the converged covariance matrix is a weighted average between the posterior covariance matrix with an uninformative prior and ``C_0``.
 
-In a nutshell, users only need to change the $\alpha$ (`α_reg`), and the freqency to update the $\Lambda$ (`update_freq`). The user can first try `α_reg = 1.0` and `update_freq = 0`.
+In a nutshell, users only need to change the ``\alpha`` (`α_reg`), and the frequency to update the ``\Lambda`` (`update_freq`). The user can first try `α_reg = 1.0` and `update_freq = 0`.
 
 
 ## Implementation
@@ -134,7 +134,7 @@ Once the unscented Kalman inversion object `UKIobj` has been initialized, any nu
 
 A call to the inversion algorithm can be performed with the `update_ensemble!` function. This function takes as arguments the `UKIobj` and the evaluations of the forward map at each element of the current ensemble. The `update_ensemble!` function then stores the new updated ensemble and the inputted forward map evaluations in `UKIobj`.
 
-The forward map $\mathcal{G}$ maps the space of unconstrained parameters $\theta$ to the outputs $y\in \mathbb{R}^d$. In practice, the user may not have access to such a map directly. And the map is a composition of several functions. The `update_ensemble!` uses only the evalutaions `g_ens` but not the forward map  
+The forward map ``\mathcal{G}`` maps the space of unconstrained parameters ``\theta`` to the outputs ``y \in \mathbb{R}^d``. In practice, the user may not have access to such a map directly. And the map is a composition of several functions. The `update_ensemble!` uses only the evalutaions `g_ens` but not the forward map  
 
 For implementational reasons, the `update_ensemble` is performed by computing analysis stage first, followed by a prediction of the next sigma ensemble. And the first prediction is done in the initialization.
 
@@ -165,5 +165,4 @@ The solution of the unscented Kalman inversion algorithm is a Gaussian distribut
 sigma = ukiobj.process.uu_cov[end]
 ```
 
-
-There are two examples [Lorenz96](../../examples/Lorenz/Lorenz_example_ukp.jl) and [Cloudy](../../examples/Cloudy/Cloudy_example_ukp.jl)
+There are two examples: [Lorenz96](examples/Lorenz_example) and [Cloudy](examples/Cloudy_example)


### PR DESCRIPTION
This PR fixes some typos + punctuation in the docs and enhances the code formatting in the inline examples provided in the docs.