### PR TITLE
Better code format in docstrings to allow better rendering in Docs/API

### DIFF
--- a/src/DataStorage.jl
+++ b/src/DataStorage.jl
@@ -60,7 +60,7 @@ struct PairedDataContainer{FT <: Real}
     function PairedDataContainer(inputs::DataContainer, outputs::DataContainer)
 
         if !(size(inputs, 2) == size(outputs, 2))
-            throw(DimensionMismatch("There must be the same number of samples of both inputs and outputs"))
+            throw(DimensionMismatch("There must be the same number of samples of both inputs and outputs."))
         else
             FT = eltype(get_data(inputs))
             new{FT}(inputs, outputs)
@@ -73,7 +73,7 @@ end
 """
     size(dc::DataContainer, idx::IT) where {IT <: Integer}
 
-Returns the size of the stored data. if `idx` provided, it returns the size along dimension `idx`.
+Returns the size of the stored data. If `idx` provided, it returns the size along dimension `idx`.
 """
 function size(dc::DataContainer)
     return size(dc.stored_data)

--- a/src/DataStorage.jl
+++ b/src/DataStorage.jl
@@ -71,9 +71,9 @@ end
 
 ## functions
 """
-    size(dc::DataContainer,idx::IT) where {IT <: Integer}
+    size(dc::DataContainer, idx::IT) where {IT <: Integer}
 
-returns the size of the stored data (if idx provided, it returns the size along dimension idx) 
+Returns the size of the stored data. if `idx` provided, it returns the size along dimension `idx`.
 """
 function size(dc::DataContainer)
     return size(dc.stored_data)
@@ -86,10 +86,11 @@ end
 function size(pdc::PairedDataContainer)
     return size(pdc.inputs), size(pdc.outputs)
 end
-"""
-    size(pdc::PairedDataContainer,idx::IT) where {IT <: Integer}
 
-returns the sizes of the inputs and ouputs along dimension idx (if provided)
+"""
+    size(pdc::PairedDataContainer, idx::IT) where {IT <: Integer}
+
+Returns the sizes of the inputs and ouputs along dimension `idx` (if provided)
 """
 function size(pdc::PairedDataContainer, idx::IT) where {IT <: Integer}
     return size(pdc.inputs, idx), size(pdc.outputs, idx)
@@ -109,5 +110,4 @@ function get_outputs(pdc::PairedDataContainer)
     return get_data(pdc.outputs)
 end
 
-
-end
+end # module

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -8,7 +8,7 @@ An ensemble Kalman Inversion process
 struct Inversion <: Process end
 
 """
-   find_ekp_stepsize(ekp::EnsembleKalmanProcess{FT, IT, Inversion}, g::Array{FT, 2}; cov_threshold::FT=0.01) where {FT}
+    find_ekp_stepsize(ekp::EnsembleKalmanProcess{FT, IT, Inversion}, g::Array{FT, 2}; cov_threshold::FT=0.01) where {FT}
 
 Find largest stepsize for the EK solver that leads to a reduction of the determinant of the sample
 covariance matrix no greater than cov_threshold. 

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -44,7 +44,7 @@ end
 """
     update_ensemble!(ekp::EnsembleKalmanProcess{FT, IT, <:Inversion}, g::Array{FT,2} cov_threshold::FT=0.01, Δt_new=nothing) where {FT, IT}
 
-Updates the ensemble according to which type of Process we have. Model outputs g need to be a N_obs × N_ens array (i.e data are columms)
+Updates the ensemble according to which type of Process we have. Model outputs `g` need to be a `N_obs × N_ens` array (i.e data are columms).
 """
 function update_ensemble!(
     ekp::EnsembleKalmanProcess{FT, IT, Inversion},

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -32,15 +32,15 @@ Structure that is used in Ensemble Kalman processes
 $(DocStringExtensions.FIELDS)
 """
 struct EnsembleKalmanProcess{FT <: AbstractFloat, IT <: Int, P <: Process}
-    "Array of stores for parameters (u), each of size [N_par × N_ens]"
+    "Array of stores for parameters (`u`), each of size [`N_par × N_ens`]"
     u::Array{DataContainer{FT}}
-    "vector of the observed vector size [N_obs]"
+    "vector of the observed vector size [`N_obs`]"
     obs_mean::Vector{FT}
-    "covariance matrix of the observational noise, of size [N_obs × N_obs]"
+    "covariance matrix of the observational noise, of size [`N_obs × N_obs`]"
     obs_noise_cov::Array{FT, 2}
     "ensemble size"
     N_ens::IT
-    "Array of stores for forward model outputs, each of size  [N_obs × N_ens]"
+    "Array of stores for forward model outputs, each of size  [`N_obs × N_ens`]"
     g::Array{DataContainer{FT}}
     "vector of errors"
     err::Vector{FT}
@@ -97,7 +97,7 @@ end
 """
     get_u(ekp::EnsembleKalmanProcess; return_array=true)
 
-Get for the EKI iteration. Returns a DataContainer object unless array is specified.
+Get for the EKI iteration. Returns a `DataContainer` object unless array is specified.
 """
 function get_u(ekp::EnsembleKalmanProcess; return_array = true) where {IT <: Integer}
     N_stored_u = get_N_iterations(ekp) + 1
@@ -107,7 +107,7 @@ end
 """
     get_g(ekp::EnsembleKalmanProcess; return_array=true)
 
-Get for the EKI iteration. Returns a DataContainer object unless array is specified.
+Get for the EKI iteration. Returns a `DataContainer` object unless array is specified.
 """
 function get_g(ekp::EnsembleKalmanProcess; return_array = true) where {IT <: Integer}
     N_stored_g = get_N_iterations(ekp)
@@ -118,7 +118,7 @@ end
 """
     get_u_final(ekp::EnsembleKalmanProcess, return_array=true)
 
-Get the final or prior iteration of parameters or model ouputs, returns a DataContainer Object if return_array is false.
+Get the final or prior iteration of parameters or model ouputs, returns a `DataContainer` Object if `return_array` is false.
 """
 function get_u_final(ekp::EnsembleKalmanProcess; return_array = true)
     return return_array ? get_u(ekp, size(ekp.u)[1]) : ekp.u[end]
@@ -137,7 +137,7 @@ end
 """
     get_g_final(ekp::EnsembleKalmanProcess, return_array=true)
 
-Get the final or prior iteration of parameters or model ouputs, returns a DataContainer Object if return_array is false.
+Get the final or prior iteration of parameters or model ouputs, returns a DataContainer Object if `return_array` is false.
 """
 
 function get_g_final(ekp::EnsembleKalmanProcess; return_array = true)
@@ -147,7 +147,7 @@ end
 """
     get_N_iterations(ekp::EnsembleKalmanProcess
 
-get number of times update has been called (equals size(g), or size(u)-1) 
+Get number of times update has been called (equals `size(g)`, or `size(u)-1`).
 """
 function get_N_iterations(ekp::EnsembleKalmanProcess)
     return size(ekp.u)[1] - 1
@@ -156,8 +156,8 @@ end
 """
     construct_initial_ensemble(prior::ParameterDistribution, N_ens::IT; rng_seed=42) where {IT<:Int}
 
-Construct the initial parameters, by sampling N_ens samples from specified
-prior distribution. Returned with parameters as columns
+Construct the initial parameters, by sampling `N_ens` samples from specified
+prior distribution. Returned with parameters as columns.
 """
 function construct_initial_ensemble(prior::ParameterDistribution, N_ens::IT; rng_seed = 42) where {IT <: Int}
     # Ensuring reproducibility of the sampled parameter values
@@ -195,10 +195,5 @@ export Unscented
 export construct_initial_ensemble
 export Gaussian_2d
 include("UnscentedKalmanInversion.jl")
-
-
-
-
-
 
 end # module

--- a/src/EnsembleKalmanProcesses.jl
+++ b/src/EnsembleKalmanProcesses.jl
@@ -9,4 +9,5 @@ include("Observations.jl")
 
 #updates:
 include("EnsembleKalmanProcess.jl")
+
 end # module

--- a/src/EnsembleKalmanSampler.jl
+++ b/src/EnsembleKalmanSampler.jl
@@ -3,7 +3,7 @@
 """
     Sampler{FT<:AbstractFloat,IT<:Int} <: Process
 
-An ensemble Kalman Sampler process
+An ensemble Kalman Sampler process.
 """
 struct Sampler{FT <: AbstractFloat} <: Process
     ""

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -18,11 +18,11 @@ struct Obs{FT <: AbstractFloat}
     "vector of observational samples, each of length sample_dim"
     samples::Vector{Vector{FT}}
     "covariance of the observational noise (assumed to be normally 
-    distributed); sample_dim x sample_dim (where sample_dim is the number of 
+    distributed); `sample_dim x sample_dim` (where `sample_dim` is the number of 
     elements in each sample), or a scalar if the sample dim is 1. If not 
-    supplied, obs_noise_cov is set to a diagonal matrix whose non-zero elements 
+    supplied, `obs_noise_cov` is set to a diagonal matrix whose non-zero elements 
     are the variances of the samples, or to a scalar variance in the case of 
-    1d samples. obs_noise_cov is set to nothing if only a single sample is 
+    1d samples. `obs_noise_cov` is set to nothing if only a single sample is 
     provided."
     obs_noise_cov::Union{Array{FT, 2}, FT, Nothing}
     "sample mean"

--- a/src/ParameterDistribution.jl
+++ b/src/ParameterDistribution.jl
@@ -91,7 +91,7 @@ end
 """
     function bounded_above(upper_bound::FT) where {FT <: Real} 
 
-Constructs a Constraint with provided upper bound, enforced by maps x -> log(upper_bound - x) and x -> upper_bound - exp(x).
+Constructs a Constraint with provided upper bound, enforced by maps `x -> log(upper_bound - x)` and `x -> upper_bound - exp(x)`.
 """
 function bounded_above(upper_bound::FT) where {FT <: Real}
     c_to_u = (x -> log(upper_bound - x))
@@ -104,9 +104,9 @@ end
     function bounded(lower_bound::FT, upper_bound::FT) where {FT <: Real} 
 
 Constructs a Constraint with provided upper and lower bounds, enforced by maps
-x -> log((x - lower_bound) / (upper_bound - x))
+`x -> log((x - lower_bound) / (upper_bound - x))`
 and
-x -> (upper_bound * exp(x) + lower_bound) / (exp(x) + 1)
+`x -> (upper_bound * exp(x) + lower_bound) / (exp(x) + 1)`.
 
 """
 function bounded(lower_bound::FT, upper_bound::FT) where {FT <: Real}
@@ -240,7 +240,7 @@ end
 """
     function batch(pd:ParameterDistribution)
 
-Returns a list of contiguous [collect(1:i), collect(i+1:j),... ] used to split parameter arrays by distribution dimensions
+Returns a list of contiguous `[collect(1:i), collect(i+1:j),... ]`` used to split parameter arrays by distribution dimensions
 """
 function batch(pd::ParameterDistribution)
     #chunk xarray to give to the different distributions.

--- a/src/ParameterDistribution.jl
+++ b/src/ParameterDistribution.jl
@@ -9,8 +9,8 @@ using Random
 ## Exports
 
 #types
-
 export ParameterDistributionType
+
 #objects
 export Parameterized, Samples
 export ParameterDistribution
@@ -80,7 +80,8 @@ end
 """
     function bounded_below(lower_bound::FT) where {FT <: Real}
 
-Constructs a Constraint with provided lower bound, enforced by maps x -> log(x - lower_bound) and x -> exp(x) + lower_bound.
+Constructs a Constraint with provided lower bound, enforced by maps `x -> log(x - lower_bound)`
+and `x -> exp(x) + lower_bound`.
 """
 function bounded_below(lower_bound::FT) where {FT <: Real}
     c_to_u = (x -> log(x - lower_bound))
@@ -91,7 +92,8 @@ end
 """
     function bounded_above(upper_bound::FT) where {FT <: Real} 
 
-Constructs a Constraint with provided upper bound, enforced by maps `x -> log(upper_bound - x)` and `x -> upper_bound - exp(x)`.
+Constructs a Constraint with provided upper bound, enforced by maps `x -> log(upper_bound - x)`
+and `x -> upper_bound - exp(x)`.
 """
 function bounded_above(upper_bound::FT) where {FT <: Real}
     c_to_u = (x -> log(upper_bound - x))
@@ -105,8 +107,7 @@ end
 
 Constructs a Constraint with provided upper and lower bounds, enforced by maps
 `x -> log((x - lower_bound) / (upper_bound - x))`
-and
-`x -> (upper_bound * exp(x) + lower_bound) / (exp(x) + 1)`.
+and `x -> (upper_bound * exp(x) + lower_bound) / (exp(x) + 1)`.
 
 """
 function bounded(lower_bound::FT, upper_bound::FT) where {FT <: Real}
@@ -147,11 +148,12 @@ end
 """
     function n_samples(d::Samples)
 
-The number of samples in the array
+The number of samples in the array.
 """
 function n_samples(d::Samples)
     return size(d.distribution_samples)[2]
 end
+
 function n_samples(d::Parameterized)
     return "Distribution stored in Parameterized form, draw samples using `sample_distribution` function"
 end
@@ -159,7 +161,7 @@ end
 """
     struct ParameterDistribution
 
-Structure to hold a parameter distribution, always stored as an array of distributions
+Structure to hold a parameter distribution, always stored as an array of distributions.
 """
 struct ParameterDistribution{PDType <: ParameterDistributionType, CType <: ConstraintType, ST <: AbstractString}
     distributions::Array{PDType}
@@ -201,7 +203,7 @@ end
 """
     function get_name(pd::ParameterDistribution)
 
-Returns a list of ParameterDistribution names
+Returns a list of ParameterDistribution names.
 """
 function get_name(pd::ParameterDistribution)
     return pd.names
@@ -210,7 +212,7 @@ end
 """
     function get_dimensions(pd::ParameterDistribution)
 
-The number of dimensions of the parameter space
+The number of dimensions of the parameter space.
 """
 function get_dimensions(pd::ParameterDistribution)
     return [dimension(d) for d in pd.distributions]
@@ -240,7 +242,7 @@ end
 """
     function batch(pd:ParameterDistribution)
 
-Returns a list of contiguous `[collect(1:i), collect(i+1:j),... ]`` used to split parameter arrays by distribution dimensions.
+Returns a list of contiguous `[collect(1:i), collect(i+1:j),... ]` used to split parameter arrays by distribution dimensions.
 """
 function batch(pd::ParameterDistribution)
     #chunk xarray to give to the different distributions.
@@ -257,7 +259,9 @@ end
 """
     function get_distribution(pd::ParameterDistribution)
 
-Returns a `Dict` of `ParameterDistribution` distributions, with the parameter names as dictionary keys. For parameters represented by `Samples`, the samples are returned as a 2D (`parameter_dimension x n_samples`) array.
+Returns a `Dict` of `ParameterDistribution` distributions, with the parameter names
+as dictionary keys. For parameters represented by `Samples`, the samples are returned
+as a 2D (`parameter_dimension x n_samples`) array.
 """
 function get_distribution(pd::ParameterDistribution)
     return Dict{String, Any}(pd.names[i] => get_distribution(d) for (i, d) in enumerate(pd.distributions))
@@ -304,7 +308,8 @@ end
 """
     function logpdf(pd::ParameterDistribution, xarray::Array{<:Real,1})
 
-Obtains the independent logpdfs of the parameter distributions at xarray (non-Samples Distributions only), and returns their sum.
+Obtains the independent logpdfs of the parameter distributions at `xarray`
+(non-Samples Distributions only), and returns their sum.
 """
 function get_logpdf(d::Parameterized, xarray::Array{FT, 1}) where {FT <: Real}
     return logpdf.(d.distribution, xarray)

--- a/src/ParameterDistribution.jl
+++ b/src/ParameterDistribution.jl
@@ -231,7 +231,7 @@ end
 """
     function get_all_constraints(pd::ParameterDistribution)
 
-returns the (flattened) array of constraints of the parameter distribution
+Returns the (flattened) array of constraints of the parameter distribution.
 """
 function get_all_constraints(pd::ParameterDistribution)
     return pd.constraints
@@ -240,7 +240,7 @@ end
 """
     function batch(pd:ParameterDistribution)
 
-Returns a list of contiguous `[collect(1:i), collect(i+1:j),... ]`` used to split parameter arrays by distribution dimensions
+Returns a list of contiguous `[collect(1:i), collect(i+1:j),... ]`` used to split parameter arrays by distribution dimensions.
 """
 function batch(pd::ParameterDistribution)
     #chunk xarray to give to the different distributions.
@@ -257,7 +257,7 @@ end
 """
     function get_distribution(pd::ParameterDistribution)
 
-Returns a `Dict` of `ParameterDistribution` distributions, with the parameter names as dictionary keys. For parameters represented by `Samples`, the samples are returned as a 2D (parameter_dimension x n_samples) array
+Returns a `Dict` of `ParameterDistribution` distributions, with the parameter names as dictionary keys. For parameters represented by `Samples`, the samples are returned as a 2D (`parameter_dimension x n_samples`) array.
 """
 function get_distribution(pd::ParameterDistribution)
     return Dict{String, Any}(pd.names[i] => get_distribution(d) for (i, d) in enumerate(pd.distributions))
@@ -273,7 +273,7 @@ end
 """
     function sample_distribution(pd::ParameterDistribution)
 
-Draws samples from the parameter distributions returns an array, with parameters as columns
+Draws samples from the parameter distributions returns an array, with parameters as columns.
 """
 function sample_distribution(pd::ParameterDistribution)
     return sample_distribution(pd, 1)
@@ -332,7 +332,7 @@ end
 """
     function get_cov(pd::ParameterDistribution)
 
-returns a blocked covariance of the distributions
+Returns a blocked covariance of the distributions.
 """
 function get_cov(d::Parameterized)
     return cov(d.distribution)
@@ -373,7 +373,7 @@ end
 """
     get_mean(pd::Parameterized)
 
-returns a mean of parameterized distribution
+Returns a mean of parameterized distribution.
 """
 function get_mean(d::Parameterized)
     return mean(d.distribution)
@@ -382,7 +382,7 @@ end
 """
     get_mean(pd::Samples)
 
-returns a mean of the samples
+Returns a mean of the samples.
 """
 function get_mean(d::Samples)
     return mean(d.distribution_samples, dims = 2) #parameters are columns
@@ -391,7 +391,7 @@ end
 """
     function get_mean(pd::ParameterDistribution)
 
-returns a mean of the distributions
+Returns a mean of the distributions.
 """
 function get_mean(pd::ParameterDistribution)
     return cat([get_mean(d) for d in pd.distributions]..., dims = 1)
@@ -401,7 +401,7 @@ end
 #apply transforms
 
 """
-    function transform_constrained_to_unconstrained(pd::ParameterDistribution, x::Array{<:Real,1})
+    function transform_constrained_to_unconstrained(pd::ParameterDistribution, xarray::Array{<:Real,1})
 
 Apply the transformation to map (possibly constrained) parameters `xarray` into the unconstrained space.
 """

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -6,11 +6,11 @@
 An unscented Kalman Inversion process
 """
 mutable struct Unscented{FT <: AbstractFloat, IT <: Int} <: Process
-    "a vector of arrays of size N_parameters containing the mean of the parameters (in each uki iteration a new array of mean is added)"
+    "a vector of arrays of size `N_parameters` containing the mean of the parameters (in each `uki` iteration a new array of mean is added)"
     u_mean::Vector{Array{FT, 1}}
-    "a vector of arrays of size (N_parameters x N_parameters) containing the covariance of the parameters (in each uki iteration a new array of cov is added)"
+    "a vector of arrays of size (`N_parameters x N_parameters`) containing the covariance of the parameters (in each `uki` iteration a new array of `cov` is added)"
     uu_cov::Vector{Array{FT, 2}}
-    "a vector of arrays of size N_y containing the predicted observation (in each uki iteration a new array of predicted observation is added)"
+    "a vector of arrays of size `N_y` containing the predicted observation (in each `uki` iteration a new array of predicted observation is added)"
     obs_pred::Vector{Array{FT, 1}}
     "weights in UKI"
     c_weights::Array{FT, 1}
@@ -64,7 +64,7 @@ u0_mean::Array{FT} : prior mean
 uu0_cov::Array{FT, 2} : prior covariance
 obs_mean::Array{FT,1} : observation 
 obs_noise_cov::Array{FT, 2} : observation error covariance
-α_reg::FT : regularization parameter toward u0 (0 < α_reg <= 1), default should be 1, without regulariazion
+α_reg::FT : regularization parameter toward `u0` (0 < `α_reg` ≤ 1), default should be 1, without regulariazion
 update_freq::IT : set to 0 when the inverse problem is not identifiable, 
                   namely the inverse problem has multiple solutions, 
                   the covariance matrix will represent only the sensitivity of the parameters, 
@@ -144,8 +144,9 @@ end
 
 
 """
-construct_sigma_ensemble
-Construct the sigma ensemble, based on the mean x_mean, and covariance x_cov
+    construct_sigma_ensemble(process::Unscented, x_mean::Array{FT}, x_cov::Array{FT, 2}) where {FT <: AbstractFloat, IT <: Int}
+
+Construct the sigma ensemble based on the mean `x_mean` and covariance `x_cov`.
 """
 function construct_sigma_ensemble(
     process::Unscented,
@@ -172,7 +173,7 @@ end
 
 
 """
-construct_mean x_mean from ensemble x
+construct_mean `x_mean` from ensemble `x`.
 """
 function construct_mean(
     uki::EnsembleKalmanProcess{FT, IT, Unscented},
@@ -195,7 +196,7 @@ function construct_mean(
 end
 
 """
-construct_cov xx_cov from ensemble x and mean x_mean
+construct_cov `xx_cov` from ensemble `x` and mean `x_mean`.
 """
 function construct_cov(
     uki::EnsembleKalmanProcess{FT, IT, Unscented},
@@ -216,7 +217,7 @@ function construct_cov(
 end
 
 """
-construct_cov xy_cov from ensemble x and mean x_mean, ensemble obs_mean and mean y_mean
+construct_cov `xy_cov` from ensemble x and mean `x_mean`, ensemble `obs_mean` and mean `y_mean`.
 """
 function construct_cov(
     uki::EnsembleKalmanProcess{FT, IT, Unscented},
@@ -270,7 +271,7 @@ end
 
 """
 uki analysis step 
-g is the predicted observations  Ny  by N_ens matrix
+g is the predicted observations  `Ny x N_ens` matrix
 """
 function update_ensemble_analysis!(
     uki::EnsembleKalmanProcess{FT, IT, Unscented},


### PR DESCRIPTION
This PR adds code formatting in some docstrings (e.g., adds encloses code name variables in backticks) to allow better rendering in the Docs/API. This way a variable named `long_name` does not appear as: long _name_.