### PR TITLE
Fix links to examples in Docs/UKI

### DIFF
--- a/docs/src/unscented_kalman_inversion.md
+++ b/docs/src/unscented_kalman_inversion.md
@@ -165,4 +165,4 @@ The solution of the unscented Kalman inversion algorithm is a Gaussian distribut
 sigma = ukiobj.process.uu_cov[end]
 ```
 
-There are two examples: [Lorenz96](examples/Lorenz_example) and [Cloudy](examples/Cloudy_example)
+There are two examples: [Lorenz96](../examples/Lorenz_example) and [Cloudy](../examples/Cloudy_example).


### PR DESCRIPTION
Relative path needs to be one level up.