### PR TITLE
added a copy

### DIFF
--- a/src/DataStorage.jl
+++ b/src/DataStorage.jl
@@ -97,7 +97,7 @@ function size(pdc::PairedDataContainer, idx::IT) where {IT <: Integer}
 end
 
 function get_data(dc::DataContainer)
-    return copy(dc.stored_data)
+    return deepcopy(dc.stored_data)
 end
 function get_data(pdc::PairedDataContainer)
     return get_inputs(pdc), get_outputs(pdc)

--- a/src/DataStorage.jl
+++ b/src/DataStorage.jl
@@ -97,7 +97,7 @@ function size(pdc::PairedDataContainer, idx::IT) where {IT <: Integer}
 end
 
 function get_data(dc::DataContainer)
-    return dc.stored_data
+    return copy(dc.stored_data)
 end
 function get_data(pdc::PairedDataContainer)
     return get_inputs(pdc), get_outputs(pdc)


### PR DESCRIPTION
## Purpose
Resolves #71, when we load data from data storage we should always copy, as it is history and should not be overwritable

## Example
I was recently stung by the old mutability vs assignment:
```julia 
x=ones(10)
f() = return x
```
then 
```julia 
u1 =  f()
u1 += ones(10)
# u1 = 2*ones(10)
# x = ones(10)
```
and
```julia 
u2 = f()
u2 = 2*ones(10)
# u2 = 2*ones(10)
# x = ones(10)
```
But(!)
```julia 
u3 = f()
u3[:] = 2*ones(10)
# u2 = 2*ones(10)
# x = 2*ones(10)
```
let's not rely on people like me to remember this in e.g. the getters from storage `get_u`,`get_u_final`,`get_u_prior` etc.
 A copy in the `get_data` method of the `DataStorage` class resolves this
```julia 
x=ones(10)
g() = return copy(x)
u4 = g()
u4[:] = 2*ones(10)
# u4 = 2*ones(10)
# x = ones(10)
```
