### PR TITLE
modified EKI/EKS runtest

### DIFF
--- a/src/EnsembleKalmanSampler.jl
+++ b/src/EnsembleKalmanSampler.jl
@@ -56,6 +56,7 @@ function update_ensemble!(ekp::EnsembleKalmanProcess{FT, IT, Sampler{FT}}, g_in:
     # store new parameters (and model outputs)
     push!(ekp.u, DataContainer(u, data_are_columns = false))
     push!(ekp.g, DataContainer(g, data_are_columns = false))
+    push!(ekp.Δt, Δt)
     # u_old is N_ens × N_par, g is N_ens × N_obs,
     # but stored in data container with N_ens as the 2nd dim
 

--- a/test/EnsembleKalmanProcessModule/runtests.jl
+++ b/test/EnsembleKalmanProcessModule/runtests.jl
@@ -18,7 +18,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     u_star = [-1.0, 2.0]          # True parameters
     noise_level = 0.05            # Defining the observation noise level (std) 
     Γy = noise_level^2 * Matrix(I, n_obs, n_obs) # Independent noise for synthetic observations
-    noise = MvNormal(zeros(n_obs), Γy) 
+    noise = MvNormal(zeros(n_obs), Γy)
     C = [1 -.9; -.9 1]          # Correlation structure for linear operator
     A = rand(MvNormal(zeros(2,), C), n_obs)'    # Linear operator in R^{n_par x n_obs}
 
@@ -36,7 +36,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
 
 
     # sum(y-G)^2 ~ n_obs*noise_level^2
-    @test isapprox(norm(y_obs .- G(u_star))^2 - n_obs * noise_level^2,0 ; atol=0.05)
+    @test isapprox(norm(y_obs .- G(u_star))^2 - n_obs * noise_level^2, 0; atol = 0.05)
 
     #### Define prior information on parameters
     prior_distns = [Parameterized(Normal(0.0, 0.5)), Parameterized(Normal(3.0, 0.5))]
@@ -59,14 +59,15 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
 
     initial_ensemble = EnsembleKalmanProcessModule.construct_initial_ensemble(prior, N_ens; rng_seed = rng_seed)
     @test size(initial_ensemble) == (n_par, N_ens)
-    
-    eksobj = EnsembleKalmanProcessModule.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Sampler(prior_mean, prior_cov))
+
+    eksobj =
+        EnsembleKalmanProcessModule.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Sampler(prior_mean, prior_cov))
 
     g_ens = G(get_u_final(eksobj))
     @test size(g_ens) == (n_obs, N_ens)
     # as the columns of g are the data, this should throw an error
     g_ens_t = permutedims(g_ens, (2, 1))
-    
+
     # EKS iterations
     for i in 1:N_iter
         params_i = get_u_final(eksobj)
@@ -89,8 +90,8 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
         plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red)
         savefig(p, "EKS_test.png")
     end
-    
-    
+
+
     ###
     ###  Calibrate: Ensemble Kalman Inversion
     ###
@@ -99,7 +100,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     # We will try to compare the EKI and EKS results, therefore we need comparable timesteps and iterations
     #N_iter = 7 # number of EKI iterations
     Δ_vec = eksobj.Δt[2:end]
-    
+
     ekiobj = EnsembleKalmanProcessModule.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Inversion())
 
     # some checks 
@@ -127,9 +128,9 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
         end
         Δ = Δ_vec[i] # use the same timesteps as EKS (EKI is more stable, so this is fine to do)
         EnsembleKalmanProcessModule.update_ensemble!(ekiobj, g_ens, Δt_new = Δ)
-        
+
     end
-    @test isapprox(ekiobj.Δt - eksobj.Δt, zeros(N_iter+1))
+    @test isapprox(ekiobj.Δt - eksobj.Δt, zeros(N_iter + 1))
 
     push!(params_i_vec, get_u_final(ekiobj))
 
@@ -143,7 +144,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     # values
     eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
 
-# kind of arbitrary tolerance here,
+    # kind of arbitrary tolerance here,
     @test norm(u_star - eki_final_result) < 0.1
 
     # Plot evolution of the EKI particles

--- a/test/EnsembleKalmanProcessModule/runtests.jl
+++ b/test/EnsembleKalmanProcessModule/runtests.jl
@@ -84,10 +84,10 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
 
     if TEST_PLOT_OUTPUT
         gr()
-        p = plot(get_u_prior(eksobj)[1, :], get_u_prior(eksobj)[2, :], seriestype = :scatter)
-        plot!(get_u_final(eksobj)[1, :], get_u_final(eksobj)[2, :], seriestype = :scatter)
-        plot!([u_star[1]], xaxis = "u1", yaxis = "u2", seriestype = "vline", linestyle = :dash, linecolor = :red)
-        plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red)
+        p = plot(get_u_prior(eksobj)[1, :], get_u_prior(eksobj)[2, :], seriestype = :scatter, label="Initial ensemble")
+        plot!(get_u_final(eksobj)[1, :], get_u_final(eksobj)[2, :], seriestype = :scatter, label="Final ensemble")
+        plot!([u_star[1]], xaxis = "u1", yaxis = "u2", seriestype = "vline", linestyle = :dash, linecolor = :red, label=:none)
+        plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label=:none)
         savefig(p, "EKS_test.png")
     end
 
@@ -151,10 +151,10 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     #eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
     if TEST_PLOT_OUTPUT
         gr()
-        p = plot(get_u_prior(ekiobj)[1, :], get_u_prior(ekiobj)[2, :], seriestype = :scatter)
-        plot!(get_u_final(ekiobj)[1, :], get_u_final(ekiobj)[2, :], seriestype = :scatter)
-        plot!([u_star[1]], xaxis = "u1", yaxis = "u2", seriestype = "vline", linestyle = :dash, linecolor = :red)
-        plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red)
+        p = plot(get_u_prior(ekiobj)[1, :], get_u_prior(ekiobj)[2, :], seriestype = :scatter, label="Initial ensemble")
+        plot!(get_u_final(ekiobj)[1, :], get_u_final(ekiobj)[2, :], seriestype = :scatter, label="Final ensemble")
+        plot!([u_star[1]], xaxis = "u1", yaxis = "u2", seriestype = "vline", linestyle = :dash, linecolor = :red, label=:none)
+        plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label=:none)
         savefig(p, "EKI_test.png")
     end
 
@@ -228,9 +228,9 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
 
         ites = Array(LinRange(1, N_iter + 1, N_iter + 1))
         p = plot(ites, grid = false, θ_mean_arr[1, :], yerror = 3.0 * θθ_std_arr[1, :], label = "u1")
-        plot!(ites, fill(u_star[1], N_iter + 1), linestyle = :dash, linecolor = :grey, label = nothing)
+        plot!(ites, fill(u_star[1], N_iter + 1), linestyle = :dash, linecolor = :grey, label = :none)
         plot!(ites, grid = false, θ_mean_arr[2, :], yerror = 3.0 * θθ_std_arr[2, :], label = "u2", xaxis = "Iterations")
-        plot!(ites, fill(u_star[2], N_iter + 1), linestyle = :dash, linecolor = :grey, label = nothing)
+        plot!(ites, fill(u_star[2], N_iter + 1), linestyle = :dash, linecolor = :grey, label = :none)
         savefig(p, "UKI_test.png")
     end
 

--- a/test/EnsembleKalmanProcessModule/runtests.jl
+++ b/test/EnsembleKalmanProcessModule/runtests.jl
@@ -84,10 +84,23 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
 
     if TEST_PLOT_OUTPUT
         gr()
-        p = plot(get_u_prior(eksobj)[1, :], get_u_prior(eksobj)[2, :], seriestype = :scatter, label="Initial ensemble")
-        plot!(get_u_final(eksobj)[1, :], get_u_final(eksobj)[2, :], seriestype = :scatter, label="Final ensemble")
-        plot!([u_star[1]], xaxis = "u1", yaxis = "u2", seriestype = "vline", linestyle = :dash, linecolor = :red, label=:none)
-        plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label=:none)
+        p = plot(
+            get_u_prior(eksobj)[1, :],
+            get_u_prior(eksobj)[2, :],
+            seriestype = :scatter,
+            label = "Initial ensemble",
+        )
+        plot!(get_u_final(eksobj)[1, :], get_u_final(eksobj)[2, :], seriestype = :scatter, label = "Final ensemble")
+        plot!(
+            [u_star[1]],
+            xaxis = "u1",
+            yaxis = "u2",
+            seriestype = "vline",
+            linestyle = :dash,
+            linecolor = :red,
+            label = :none,
+        )
+        plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = :none)
         savefig(p, "EKS_test.png")
     end
 
@@ -151,10 +164,23 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     #eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
     if TEST_PLOT_OUTPUT
         gr()
-        p = plot(get_u_prior(ekiobj)[1, :], get_u_prior(ekiobj)[2, :], seriestype = :scatter, label="Initial ensemble")
-        plot!(get_u_final(ekiobj)[1, :], get_u_final(ekiobj)[2, :], seriestype = :scatter, label="Final ensemble")
-        plot!([u_star[1]], xaxis = "u1", yaxis = "u2", seriestype = "vline", linestyle = :dash, linecolor = :red, label=:none)
-        plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label=:none)
+        p = plot(
+            get_u_prior(ekiobj)[1, :],
+            get_u_prior(ekiobj)[2, :],
+            seriestype = :scatter,
+            label = "Initial ensemble",
+        )
+        plot!(get_u_final(ekiobj)[1, :], get_u_final(ekiobj)[2, :], seriestype = :scatter, label = "Final ensemble")
+        plot!(
+            [u_star[1]],
+            xaxis = "u1",
+            yaxis = "u2",
+            seriestype = "vline",
+            linestyle = :dash,
+            linecolor = :red,
+            label = :none,
+        )
+        plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = :none)
         savefig(p, "EKI_test.png")
     end
 


### PR DESCRIPTION
## Purpose

To get the EKI runtest properly working with a linear map from R^{2} -> R^{10}. (i) some reason a couple of the `@test` statements were commented out (ii) the tests comparing EKS and EKI are very dependent on N_iter

## In the PR
Changes to the EKI test in `test/EnsembleKalmanInversion/runtests.jl` So that it now converges reasonably and satisfies all the test conditions. 

NB some of the comparisons of eks/eki depended heavily on `N_iter`. To compare the two algorithms we should really look at the timesteps in absolute time. So now
1. I have increased the prior strength and bias
1. I run EKS first with it's adaptive timestep, which I store in `eksobj`
2.  then use these values in the EKI updates. 

The OLS mean is nearer the EKI at the end time, and the posterior mean is nearer the EKS at the end time, far more robustly than previously. 

## Test output plot
For EKI
![EKI_test](https://user-images.githubusercontent.com/47412152/145308290-24ca3c6e-3f48-4370-be40-a2e736cef1a0.png)



For EKS
![EKS_test](https://user-images.githubusercontent.com/47412152/145308296-a254c276-70d7-4e6e-9fdf-fa83a1fe716c.png)


