### PR TITLE
Update GitHub Actions workflows to use Julia 1.6.4

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1.6.4
+          version: 1.6
       - name: Cache artifacts
         uses: actions/cache@v1
         env:

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1.5.4
+          version: 1.6.4
       - name: Cache artifacts
         uses: actions/cache@v1
         env:

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -29,6 +29,17 @@ jobs:
         with:
           version: '1.6'
           show-versioninfo: 'true'
+      - name: Cache artifacts
+         uses: actions/cache@v1
+         env:
+           cache-name: cache-artifacts
+         with:
+           path: ~/.julia/artifacts
+           key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+           restore-keys: |
+             ${{ runner.os }}-test-${{ env.cache-name }}-
+             ${{ runner.os }}-test-
+             ${{ runner.os }}-
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -30,16 +30,16 @@ jobs:
           version: '1.6'
           show-versioninfo: 'true'
       - name: Cache artifacts
-         uses: actions/cache@v1
-         env:
-           cache-name: cache-artifacts
-         with:
-           path: ~/.julia/artifacts
-           key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-           restore-keys: |
-             ${{ runner.os }}-test-${{ env.cache-name }}-
-             ${{ runner.os }}-test-
-             ${{ runner.os }}-
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -26,27 +26,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1.6
-      - name: Cache artifacts
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          version: '1.6'
+          show-versioninfo: 'true'
       - name: Install dependencies
         env:
           PYTHON: ""
-        run: |
-          julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'
-          julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate()'
-          julia --color=yes --project=docs/ -e 'using Pkg; Pkg.precompile()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JULIA_PROJECT: "docs/"
+          JULIA_DEBUG: Documenter
         run: julia --color=yes --project=docs/ docs/make.jl

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -13,6 +13,7 @@ on:
       - 'src/**'
       - 'Project.toml'
       - 'Manifest.toml'
+      - '.github/workflows/**'
 
 jobs:
   docs-build:
@@ -20,7 +21,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.8.0
+        uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
@@ -29,8 +30,6 @@ jobs:
           version: '1.6'
           show-versioninfo: 'true'
       - name: Install dependencies
-        env:
-          PYTHON: ""
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: julia-actions/setup-julia@latest
       if: steps.filter.outputs.julia_file_change == 'true'
       with:
-        version: 1.6.4
+        version: 1.6
 
     - name: Apply JuliaFormatter
       if: steps.filter.outputs.julia_file_change == 'true'

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - uses: actions/checkout@v2.2.0
+    - uses: actions/checkout@v2
 
     - uses: dorny/paths-filter@v2.9.1
       id: filter

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.4.0
+      uses: styfle/cancel-workflow-action@latest
       with:
         access_token: ${{ github.token }}
 

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@latest
+      uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ github.token }}
 

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: julia-actions/setup-julia@latest
       if: steps.filter.outputs.julia_file_change == 'true'
       with:
-        version: 1.6.0
+        version: 1.6.4
 
     - name: Apply JuliaFormatter
       if: steps.filter.outputs.julia_file_change == 'true'

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,7 +24,7 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: styfle/cancel-workflow-action@0.8.0
+      - uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,29 +9,46 @@ on:
       - main
 jobs:
   test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        julia-version: ['1.5']
-        julia-arch: [x64]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+       matrix:
+        version:
+          - '1.6' # Long-Term Support release
+          - '1'   # automatically expands to the latest stable 1.x release of Julia
+          - nightly
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+        arch:
+          - x64
     steps:
-      - uses: styfle/cancel-workflow-action@0.6.0
+      - uses: styfle/cancel-workflow-action@0.8.0
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.julia-version }}
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      
       - name: Generate coverage file
         run: julia --project -e 'using Pkg; Pkg.add("Coverage");
                                  using Coverage;
                                  LCOV.writefile("coverage-lcov.info", Codecov.process_folder())'
         if: ${{ matrix.os == 'ubuntu-latest' }}
-
       - name: Submit coverage
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -32,16 +32,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - name: Generate coverage file


### PR DESCRIPTION
This PR changes the GitHub Actions workflows to use Julia v1.6.4 which is the new long-term support version.
Now the docs are being built with Julia v1.6.4 and the test run on v1.6.4 and on v1.7.

Closes #79