### PR TITLE
Standardize UKI constructor to be consistent with EKS, document kwargs 

### DIFF
--- a/docs/src/unscented_kalman_inversion.md
+++ b/docs/src/unscented_kalman_inversion.md
@@ -109,7 +109,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
 #             0 : weighted average between posterior covariance matrix with an uninformative prior and prior
 update_freq = 0
 
-process = Unscented(prior_mean, prior_cov, length(truth_sample), α_reg, update_freq)
+process = Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq)
 ukiobj = EnsembleKalmanProcessModule.EnsembleKalmanProcess(truth_sample, truth.obs_noise_cov, process)
 
 ```

--- a/examples/Cloudy/Cloudy_example_uki.jl
+++ b/examples/Cloudy/Cloudy_example_uki.jl
@@ -141,7 +141,7 @@ N_iter = 20 # number of iterations
 #                 uninformative prior and prior
 update_freq = 1
 
-process = Unscented(prior_mean, prior_cov, length(truth_sample), α_reg, update_freq)
+process = Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq)
 ukiobj = EnsembleKalmanProcess(truth_sample, truth.obs_noise_cov, process)
 
 # Initialize a ParticleDistribution with dummy parameters. The parameters 

--- a/examples/Lorenz/Lorenz_example_ukp.jl
+++ b/examples/Lorenz/Lorenz_example_ukp.jl
@@ -209,7 +209,7 @@ N_iter = 20 # number of UKI iterations
 #             0 : weighted average between posterior covariance matrix with an uninformative prior and prior
 update_freq = 0
 
-process = Unscented(prior_mean, prior_cov, length(truth_sample), α_reg, update_freq)
+process = Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq)
 ukiobj = EnsembleKalmanProcessModule.EnsembleKalmanProcess(truth_sample, truth.obs_noise_cov, process)
 
 

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -62,12 +62,10 @@ end
     Unscented(
         u0_mean::Vector{FT},
         uu0_cov::Matrix{FT},
-        α_reg::FT,
-        update_freq::IT;
+        α_reg::FT = 1.0;
+        update_freq::IT = 1,
         modified_unscented_transform::Bool = true,
         prior_mean::Union{Vector{FT}, Nothing} = nothing,
-        κ::FT = 0.0,
-        β::FT = 2.0,
     ) where {FT <: AbstractFloat, IT <: Int}
 
 Construct an Unscented Inversion EnsembleKalmanProcess.

--- a/test/EnsembleKalmanProcessModule/runtests.jl
+++ b/test/EnsembleKalmanProcessModule/runtests.jl
@@ -211,7 +211,7 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     N_iter = 20 # number of UKI iterations
     α_reg = 1.0
     update_freq = 0
-    process = Unscented(prior_mean, prior_cov, α_reg, update_freq)
+    process = Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq)
     ukiobj = EnsembleKalmanProcessModule.EnsembleKalmanProcess(y_star, Γy, process)
 
     # UKI iterations


### PR DESCRIPTION
The UKI constructor modification

```
function Unscented(
    u0_mean::Vector{FT},
    uu0_cov::Matrix{FT};
    α_reg::FT = 1.0,
    update_freq::IT = 1,
    modified_unscented_transform::Bool = true,
    prior_mean::Union{Vector{FT}, Nothing} = nothing,
) where {FT <: AbstractFloat, IT <: Int}
```

require α_reg, update_freq, modified_unscented_transform, and  prior_mean as keyword arguments
clean up κ and β.