### PR TITLE
Allow quadrature of scalar metrics in UKI, vectorize mean quadrature.

### DIFF
--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -188,21 +188,18 @@ construct_mean `x_mean` from ensemble `x`.
 """
 function construct_mean(
     uki::EnsembleKalmanProcess{FT, IT, Unscented},
-    x::Matrix{FT},
+    x::Union{Vector{FT}, Matrix{FT}},
 ) where {FT <: AbstractFloat, IT <: Int}
-    N_x, N_ens = size(x)
 
-    @assert(uki.N_ens == N_ens)
-
-    x_mean = zeros(FT, N_x)
-
-    mean_weights = uki.process.mean_weights
-
-    for i in 1:N_ens
-        x_mean += mean_weights[i] * x[:, i]
+    if isa(x, Matrix{FT})
+        _, N_ens = size(x)
+        @assert(uki.N_ens == N_ens)
+        return Array((uki.process.mean_weights' * x')')
+    else
+        N_ens = length(x)
+        @assert(uki.N_ens == N_ens)
+        return uki.process.mean_weights' * x
     end
-
-    return x_mean
 end
 
 """
@@ -210,19 +207,30 @@ construct_cov `xx_cov` from ensemble `x` and mean `x_mean`.
 """
 function construct_cov(
     uki::EnsembleKalmanProcess{FT, IT, Unscented},
-    x::Matrix{FT},
-    x_mean::Array{FT},
+    x::Union{Matrix{FT}, Vector{FT}},
+    x_mean::Union{FT, Array{FT}, Nothing} = nothing,
 ) where {FT <: AbstractFloat, IT <: Int}
-    N_ens, N_x = uki.N_ens, size(x_mean, 1)
 
     cov_weights = uki.process.cov_weights
 
-    xx_cov = zeros(FT, N_x, N_x)
+    x_mean = isnothing(x_mean) ? construct_mean(uki, x) : x_mean
 
-    for i in 1:N_ens
-        xx_cov .+= cov_weights[i] * (x[:, i] - x_mean) * (x[:, i] - x_mean)'
+    if isa(x, Matrix{FT})
+        @assert isa(x_mean, Vector{FT})
+        N_ens, N_x = uki.N_ens, size(x_mean, 1)
+        xx_cov = zeros(FT, N_x, N_x)
+
+        for i in 1:N_ens
+            xx_cov .+= cov_weights[i] * (x[:, i] - x_mean) * (x[:, i] - x_mean)'
+        end
+    else
+        @assert isa(x_mean, FT)
+        xx_cov = FT(0)
+
+        for i in 1:(uki.N_ens)
+            xx_cov += cov_weights[i] * (x[i] - x_mean) * (x[i] - x_mean)
+        end
     end
-
     return xx_cov
 end
 

--- a/test/EnsembleKalmanProcessModule/runtests.jl
+++ b/test/EnsembleKalmanProcessModule/runtests.jl
@@ -5,6 +5,7 @@ using Test
 
 using EnsembleKalmanProcesses.EnsembleKalmanProcessModule
 using EnsembleKalmanProcesses.ParameterDistributionStorage
+import EnsembleKalmanProcesses.EnsembleKalmanProcessModule: construct_mean, construct_cov
 @testset "EnsembleKalmanProcessModule" begin
 
     # Seed for pseudo-random number generator
@@ -235,6 +236,11 @@ using EnsembleKalmanProcesses.ParameterDistributionStorage
     @test get_g(ukiobj) == g_ens_vec
     @test get_g_final(ukiobj) == g_ens_vec[end]
     @test get_error(ukiobj) == ukiobj.err
+
+    @test isa(construct_mean(ukiobj, rand(2 * n_par + 1)), Float64)
+    @test isa(construct_mean(ukiobj, rand(5, 2 * n_par + 1)), Vector{Float64})
+    @test isa(construct_cov(ukiobj, rand(2 * n_par + 1)), Float64)
+    @test isa(construct_cov(ukiobj, rand(5, 2 * n_par + 1)), Matrix{Float64})
 
     # UKI results: Test if ensemble has collapsed toward the true parameter 
     # values


### PR DESCRIPTION
Adds the possibility to perform quadratures over scalars in UKI, and vectorizes some computations.

It also enables the use of `construct_cov()` directly without passing the mean. However, the default behavior is unchanged.