### PR TITLE
Pass explicit RNG object to methods involving stochasticity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,8 @@ StatsBase = "^0.33"
 julia = "1.5"
 
 [extras]
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["StableRNGs", "Test"]

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -80,7 +80,7 @@ function update_ensemble!(
 
     # Scale noise using Δt
     scaled_obs_noise_cov = ekp.obs_noise_cov / ekp.Δt[end]
-    noise = rand(MvNormal(zeros(N_obs), scaled_obs_noise_cov), ekp.N_ens)
+    noise = rand(ekp.rng, MvNormal(zeros(N_obs), scaled_obs_noise_cov), ekp.N_ens)
 
     # Add obs_mean (N_obs) to each column of noise (N_obs × N_ens) if
     # G is deterministic

--- a/src/EnsembleKalmanSampler.jl
+++ b/src/EnsembleKalmanSampler.jl
@@ -51,7 +51,7 @@ function update_ensemble!(ekp::EnsembleKalmanProcess{FT, IT, Sampler{FT}}, g_in:
         (1 * Matrix(I, size(u)[2], size(u)[2]) + Δt * (ekp.process.prior_cov' \ u_cov')') \
         (u' .- Δt * (u' .- u_mean) * D .+ Δt * u_cov * (ekp.process.prior_cov \ ekp.process.prior_mean))
 
-    u = implicit' + sqrt(2 * Δt) * rand(noise, ekp.N_ens)'
+    u = implicit' + sqrt(2 * Δt) * rand(ekp.rng, noise, ekp.N_ens)'
 
     # store new parameters (and model outputs)
     push!(ekp.u, DataContainer(u, data_are_columns = false))

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -111,7 +111,7 @@ function update_ensemble!(
 
     # Scale noise using Δt
     scaled_obs_noise_cov = ekp.obs_noise_cov / ekp.Δt[end]
-    noise = rand(MvNormal(zeros(N_obs), scaled_obs_noise_cov), ekp.N_ens)
+    noise = rand(ekp.rng, MvNormal(zeros(N_obs), scaled_obs_noise_cov), ekp.N_ens)
 
     # Add obs_mean (N_obs) to each column of noise (N_obs × N_ens) if
     # G is deterministic
@@ -147,8 +147,10 @@ function update_ensemble!(
         end
 
         # Add small noise to constrained elements of u
-        u[ekp.process.uc_idx, j] +=
-            rand(MvNormal(zeros(size(ekp.process.uc_idx)[1]), ekp.process.reg * I(size(ekp.process.uc_idx)[1])))
+        u[ekp.process.uc_idx, j] += rand(
+            ekp.rng,
+            MvNormal(zeros(size(ekp.process.uc_idx)[1]), ekp.process.reg * I(size(ekp.process.uc_idx)[1])),
+        )
     end
 
     # Store error

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -38,6 +38,7 @@ function EnsembleKalmanProcess(
     obs_noise_cov::Matrix{FT},
     process::Unscented{FT, IT};
     Δt = FT(1),
+    rng::AbstractRNG = Random.GLOBAL_RNG,
 ) where {FT <: AbstractFloat, IT <: Int}
 
     #initial parameters stored as columns
@@ -53,7 +54,7 @@ function EnsembleKalmanProcess(
     # timestep store
     Δt = Array([Δt])
 
-    EnsembleKalmanProcess{FT, IT, Unscented}(init_params, obs_mean, obs_noise_cov, N_ens, g, err, Δt, process)
+    EnsembleKalmanProcess{FT, IT, Unscented}(init_params, obs_mean, obs_noise_cov, N_ens, g, err, Δt, process, rng)
 end
 
 

--- a/test/DataContainers/runtests.jl
+++ b/test/DataContainers/runtests.jl
@@ -5,15 +5,14 @@ using Random
 using EnsembleKalmanProcesses.DataContainers
 
 @testset "DataContainers" begin
-    seed = 2021
-    Random.seed!(seed)
+    rng = Random.MersenneTwister(2021)
 
-    parameter_samples = rand(MvNormal(2, 0.1), 10) #10 samples of 4D params
-    data_samples = rand(MvNormal(12, 2), 10) #10 samples of 12D data
+    parameter_samples = rand(rng, MvNormal(2, 0.1), 10) #10 samples of 4D params
+    data_samples = rand(rng, MvNormal(12, 2), 10) #10 samples of 12D data
     data_samples_short = data_samples[:, 1:(end - 1)]
 
-    new_parameter_samples = rand(MvNormal(2, 0.1), 10) #10 samples of 4D params
-    new_data_samples = rand(MvNormal(12, 2), 10) #10 samples of 12D data
+    new_parameter_samples = rand(rng, MvNormal(2, 0.1), 10) #10 samples of 4D params
+    new_data_samples = rand(rng, MvNormal(12, 2), 10) #10 samples of 12D data
     new_data_samples_short = new_data_samples[:, 1:(end - 1)]
 
     #test DataContainer

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -12,7 +12,7 @@ const EKP = EnsembleKalmanProcesses
 
     # Seed for pseudo-random number generator
     rng_seed = 42
-    Random.seed!(rng_seed)
+    rng = Random.MersenneTwister(rng_seed)
 
     ### Generate data from a linear model: a regression problem with n_par parameters
     ### and 1 observation of G(u) = A \times u, where A : R^n_par -> R^n_obs
@@ -23,7 +23,7 @@ const EKP = EnsembleKalmanProcesses
     Γy = noise_level^2 * Matrix(I, n_obs, n_obs) # Independent noise for synthetic observations
     noise = MvNormal(zeros(n_obs), Γy)
     C = [1 -.9; -.9 1]          # Correlation structure for linear operator
-    A = rand(MvNormal(zeros(2,), C), n_obs)'    # Linear operator in R^{n_par x n_obs}
+    A = rand(rng, MvNormal(zeros(2,), C), n_obs)'    # Linear operator in R^{n_par x n_obs}
 
     @test size(A) == (n_obs, n_par)
 
@@ -37,7 +37,7 @@ const EKP = EnsembleKalmanProcesses
     end
 
     y_star = G(u_star)
-    y_obs = y_star .+ rand(noise)
+    y_obs = y_star .+ rand(rng, noise)
 
     @test size(y_obs) == (n_obs,)
 
@@ -58,14 +58,18 @@ const EKP = EnsembleKalmanProcesses
 
 
     @testset "EnsembleKalmanSampler" begin
+        # Seed for pseudo-random number generator
+        rng_seed = 42
+        rng = Random.MersenneTwister(rng_seed)
 
         N_ens = 50 # number of ensemble members (NB for @test throws, make different to N_ens)
         N_iter = 20
 
-        initial_ensemble = EKP.construct_initial_ensemble(prior, N_ens; rng_seed = rng_seed)
+        initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
         @test size(initial_ensemble) == (n_par, N_ens)
 
-        global eksobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Sampler(prior_mean, prior_cov))
+        global eksobj =
+            EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Sampler(prior_mean, prior_cov); rng = rng)
 
         g_ens = G(get_u_final(eksobj))
         @test size(g_ens) == (n_obs, N_ens)
@@ -111,13 +115,16 @@ const EKP = EnsembleKalmanProcesses
 
 
     @testset "EnsembleKalmanInversion" begin
+        # Seed for pseudo-random number generator
+        rng_seed = 42
+        rng = Random.MersenneTwister(rng_seed)
 
         N_ens = 50 # number of ensemble members (NB for @test throws, make different to N_ens)
         N_iter = 20
 
-        initial_ensemble = EKP.construct_initial_ensemble(prior, N_ens; rng_seed = rng_seed)
+        initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
 
-        ekiobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Inversion())
+        ekiobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Inversion(); rng = rng)
 
         # some checks 
         g_ens = G(get_u_final(ekiobj))
@@ -155,10 +162,9 @@ const EKP = EnsembleKalmanProcesses
 
         # EKI results: Test if ensemble has collapsed toward the true parameter 
         # values
+        eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
         eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
-
-        # kind of arbitrary tolerance here,
-        @test norm(u_star - eki_final_result) < 0.1
+        @test norm(u_star - eki_final_result) < norm(u_star - eki_init_result)
 
         # Plot evolution of the EKI particles
         #eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
@@ -205,12 +211,15 @@ const EKP = EnsembleKalmanProcesses
 
 
     @testset "UnscentedKalmanInversion" begin
+        # Seed for pseudo-random number generator
+        rng_seed = 42
+        rng = Random.MersenneTwister(rng_seed)
 
         N_iter = 20 # number of UKI iterations
         α_reg = 1.0
         update_freq = 0
         process = Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq)
-        ukiobj = EKP.EnsembleKalmanProcess(y_star, Γy, process)
+        ukiobj = EKP.EnsembleKalmanProcess(y_star, Γy, process; rng = rng)
 
         # UKI iterations
         params_i_vec = []
@@ -234,15 +243,16 @@ const EKP = EnsembleKalmanProcesses
         @test get_g_final(ukiobj) == g_ens_vec[end]
         @test get_error(ukiobj) == ukiobj.err
 
-        @test isa(construct_mean(ukiobj, rand(2 * n_par + 1)), Float64)
-        @test isa(construct_mean(ukiobj, rand(5, 2 * n_par + 1)), Vector{Float64})
-        @test isa(construct_cov(ukiobj, rand(2 * n_par + 1)), Float64)
-        @test isa(construct_cov(ukiobj, rand(5, 2 * n_par + 1)), Matrix{Float64})
+        @test isa(construct_mean(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
+        @test isa(construct_mean(ukiobj, rand(rng, 5, 2 * n_par + 1)), Vector{Float64})
+        @test isa(construct_cov(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
+        @test isa(construct_cov(ukiobj, rand(rng, 5, 2 * n_par + 1)), Matrix{Float64})
 
         # UKI results: Test if ensemble has collapsed toward the true parameter 
         # values
+        uki_init_result = vec(mean(get_u_prior(ukiobj), dims = 2))
         uki_final_result = get_u_mean_final(ukiobj)
-        @test norm(u_star - uki_final_result) < 0.5
+        @test norm(u_star - uki_final_result) < norm(u_star - uki_init_result)
 
         if TEST_PLOT_OUTPUT
             gr()
@@ -279,7 +289,7 @@ const EKP = EnsembleKalmanProcesses
         noise = MvNormal(zeros(n_obs), Γy)
 
         y_star = G₁(u_star)
-        y_obs = y_star + rand(noise)
+        y_obs = y_star + rand(rng, noise)
 
         @test size(y_star) == (n_obs,)
 
@@ -294,10 +304,13 @@ const EKP = EnsembleKalmanProcesses
     ###  Calibrate (4): Sparse Ensemble Kalman Inversion
     ###
     @testset "SparseInversion" begin
+        # Seed for pseudo-random number generator
+        rng_seed = 42
+        rng = Random.MersenneTwister(rng_seed)
 
         N_ens = 20 # number of ensemble members
         N_iter = 5 # number of EKI iterations
-        initial_ensemble = EKP.construct_initial_ensemble(prior, N_ens; rng_seed = rng_seed)
+        initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
         @test size(initial_ensemble) == (n_par, N_ens)
 
         for (threshold_eki, threshold_value, test_name) in ((false, 1e-2, "test"), (true, 1e-2, "test_thresholded"))
@@ -309,7 +322,7 @@ const EKP = EnsembleKalmanProcesses
 
             process = SparseInversion(γ, threshold_eki, threshold_value, reg, uc_idx)
 
-            ekiobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, process)
+            ekiobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, process; rng = rng)
 
             # EKI iterations
             params_i_vec = []
@@ -337,8 +350,9 @@ const EKP = EnsembleKalmanProcesses
 
             # EKI results: Test if ensemble has collapsed toward the true parameter
             # values
+            eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
             eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
-            @test norm(u_star - eki_final_result) < 0.1
+            @test norm(u_star - eki_final_result) < norm(u_star - eki_init_result)
             @test sum(eki_final_result .> 0.05) < size(eki_final_result)[1]
 
             # Plot evolution of the EKI particles


### PR DESCRIPTION
This is a rebase and squash of the feature branch for PR #81 and contains no new commits. The PR message for #81 is reproduced below.
<hr>
The motivation for this PR comes from CliMA/CalibrateEmulateSample.jl#121; see discussion there. 

In order to have reproducible tests involving randomness, it's not sufficient to set the global seed for the default RNG: the default RNG algorithm used by Julia was [changed](https://julialang.org/blog/2021/11/julia-1.7-highlights/#new_rng_reproducible_rng_in_tasks) in version 1.7, and the [docs](https://docs.julialang.org/en/v1/stdlib/Random/#Reproducibility) for the Random package note that the same seed may give different random values in different versions. For this reason, [recommended practice](https://discourse.julialang.org/t/set-the-state-of-the-global-rng/12599/3) for reproducible tests is to pass an RNG object explicitly to all methods which need it. Julia convention is that the RNG is an optional first positional argument in functions which require it (see e.g. Random, StatsBase, Turning.jl...), and this is done here.

This PR implements that change; in brief
- An `rng` field is added to `EnsembleKalmanProcesses` (i.e. independent of `Process`, for all implementations).
- An optional `rng` kwarg is added to `construct_initial_ensemble()`, used in lieu of `rng_seed` if provided.
- An additional method for `construct_initial_ensemble()` takes the rng as the first argument, causing kwargs to be ignored.
- All methods for `sample_distribution()` now accept an rng as an optional first argument.

In all of the cases above, `Random.GLOBAL_RNG` is used by default if an RNG is not given: this PR is fully backwards compatible with `main`. In particular, tests are updated to use an explicit rng, but examples have been left unchanged. It may be desirable to update them as well.

