### PR TITLE
Extending functions from packges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/docs/src/API/ParameterDistributions.md
+++ b/docs/src/API/ParameterDistributions.md
@@ -23,8 +23,9 @@ batch
 get_distribution
 sample_distribution
 get_logpdf
-get_cov
-get_mean
+mean
+var
+cov
 transform_constrained_to_unconstrained
 transform_unconstrained_to_constrained
 ```

--- a/docs/src/API/ParameterDistributions.md
+++ b/docs/src/API/ParameterDistributions.md
@@ -22,7 +22,7 @@ get_n_samples
 get_all_constraints
 batch
 get_distribution
-sample_distribution
+sample
 get_logpdf
 mean
 var

--- a/docs/src/API/ParameterDistributions.md
+++ b/docs/src/API/ParameterDistributions.md
@@ -8,13 +8,14 @@ CurrentModule = EnsembleKalmanProcesses.ParameterDistributions
 Parameterized
 Samples
 Constraint
+ParameterDistribution
 no_constraint
 bounded_below
 bounded_above
 bounded
-len
+length(c::CType) where {CType <: ConstraintType}
+size(c::CType) where {CType <: ConstraintType}
 n_samples
-ParameterDistribution
 get_name
 get_dimensions
 get_n_samples

--- a/docs/src/ensemble_kalman_sampler.md
+++ b/docs/src/ensemble_kalman_sampler.md
@@ -79,8 +79,8 @@ using EnsembleKalmanProcesses.ParameterDistributions  # required to create the p
 
 # Construct prior (see `ParameterDistributions.jl` docs)
 prior = ParameterDistribution(...)
-prior_mean = get_mean(prior)
-prior_cov = get_cov(prior)
+prior_mean = mean(prior)
+prior_cov = cov(prior)
 
 # Construct initial ensemble
 N_ens = 50  # ensemble size

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -395,6 +395,6 @@ u = ParameterDistribution([d1, d2], [c1, c2], [name1, name2])
 These functions typically return a `Dict` with `ParameterDistribution.name` as a keys, or an `Array` if requested:
  - `get_name`: returns the names
  - `get_distribution`: returns the Julia Distribution object if it is `Parameterized`
- - `sample_distribution`: samples the Julia Distribution if `Parameterized`, or draws from the list of samples if `Samples`
+ - `mean, var, cov, sample`: mean,variance,covariance or samples the Julia Distribution if `Parameterized`, or draws from the list of samples if `Samples` extends the StatsBase definitions
  - `transform_unconstrained_to_constrained`: apply the constraint mappings
  - `transform_constrained_to_unconstrained`: apply the inverse constraint mappings

--- a/src/DataContainers.jl
+++ b/src/DataContainers.jl
@@ -88,12 +88,26 @@ Returns the sizes of the inputs and ouputs along dimension `idx` (if provided)
 """
 size(pdc::PairedDataContainer, idx::IT) where {IT <: Integer} = size(pdc.inputs, idx), size(pdc.outputs, idx)
 
-get_data(dc::DataContainer) = deepcopy(dc.stored_data)
+"""
+    get_data(pdc::PairedDataContainer)
 
+Returns both input and output data stored in pdc
+"""
+get_data(dc::DataContainer) = deepcopy(dc.stored_data)
 get_data(pdc::PairedDataContainer) = get_inputs(pdc), get_outputs(pdc)
 
+"""
+    get_inputs(pdc::PairedDataContainer)
+
+Returns input data stored in pdc
+"""
 get_inputs(pdc::PairedDataContainer) = get_data(pdc.inputs)
 
+"""
+    get_outputs(pdc::PairedDataContainer)
+
+Returns output data stored in pdc
+"""
 get_outputs(pdc::PairedDataContainer) = get_data(pdc.outputs)
 
 end # module

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -181,7 +181,7 @@ function construct_initial_ensemble(
     # Ensuring reproducibility of the sampled parameter values: re-seed GLOBAL_RNG if we're
     # given a seed, but if we got an explicit rng, we shouldn't re-seed it
     rng = isnothing(rng) ? Random.seed!(rng_seed) : rng
-    return sample_distribution(rng, prior, N_ens) #of size [dim(param space) N_ens]
+    return sample(rng, prior, N_ens) #of size [dim(param space) N_ens]
 end
 construct_initial_ensemble(rng::AbstractRNG, prior::ParameterDistribution, N_ens::IT) where {IT <: Int} =
     construct_initial_ensemble(prior, N_ens; rng = rng)

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -143,7 +143,7 @@ The number of dimensions of the parameter space
 """
 ndims(d::Parameterized) = length(d.distribution)
 
-ndims(d::Samples) = size(d.distribution_samples)[1]
+ndims(d::Samples) = size(d.distribution_samples, 1)
 
 """
     n_samples(d<:Samples)

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -351,10 +351,10 @@ end
 Returns a flattened variance of the distributions
 """
 var(d::Parameterized) = var(d.distribution)
-var(d::Samples) = var(d.distribution_samples)
+var(d::Samples) = var(d.distribution_samples, dims = 2)
 function var(pd::ParameterDistribution)
     d_dims = get_dimensions(pd)
-    block_var = Array{Any}(size(d_dims)[1])
+    block_var = Array{Any}(undef,size(d_dims)[1])
 
     for (i, dimension) in enumerate(d_dims)
         block_var[i] = var(pd.distributions[i])

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -20,11 +20,11 @@ export Constraint
 
 #functions
 export get_name, get_distribution, get_total_dimension, get_dimensions, get_all_constraints, get_n_samples
-export sample_distribution
+export sample
 export no_constraint, bounded_below, bounded_above, bounded
 export transform_constrained_to_unconstrained, transform_unconstrained_to_constrained
 export get_logpdf, batch
-#export get_cov, get_var, get_mean
+
 ## Objects
 # for the Distribution
 abstract type ParameterDistributionType end
@@ -153,7 +153,7 @@ The number of samples in the array.
 n_samples(d::Samples) = size(d.distribution_samples)[2]
 
 n_samples(d::Parameterized) =
-    "Distribution stored in Parameterized form, draw samples using `sample_distribution` function"
+    "Distribution stored in Parameterized form, draw samples using `sample` function"
 
 """
     ParameterDistribution
@@ -266,30 +266,30 @@ get_distribution(d::Samples) = d.distribution_samples
 get_distribution(d::Parameterized) = d.distribution
 
 """
-    sample_distribution([rng], pd::ParameterDistribution, [n_draws])
+    sample([rng], pd::ParameterDistribution, [n_draws])
 
 Draws `n_draws` samples from the parameter distributions `pd`. Returns an array, with 
 parameters as columns. `rng` is optional and defaults to `Random.GLOBAL_RNG`. `n_draws` is 
 optional and defaults to 1. 
 """
-function sample_distribution(rng::AbstractRNG, pd::ParameterDistribution, n_draws::IT) where {IT <: Integer}
-    return cat([sample_distribution(rng, d, n_draws) for d in pd.distributions]..., dims = 1)
+function sample(rng::AbstractRNG, pd::ParameterDistribution, n_draws::IT) where {IT <: Integer}
+    return cat([sample(rng, d, n_draws) for d in pd.distributions]..., dims = 1)
 end
 
 # define methods that dispatch to the above with Random.GLOBAL_RNG as a default value for rng
-sample_distribution(pd::ParameterDistribution, n_draws::IT) where {IT <: Integer} =
-    sample_distribution(Random.GLOBAL_RNG, pd, n_draws)
-sample_distribution(rng::AbstractRNG, pd::ParameterDistribution) = sample_distribution(rng, pd, 1)
-sample_distribution(pd::ParameterDistribution) = sample_distribution(Random.GLOBAL_RNG, pd, 1)
+sample(pd::ParameterDistribution, n_draws::IT) where {IT <: Integer} =
+    sample(Random.GLOBAL_RNG, pd, n_draws)
+sample(rng::AbstractRNG, pd::ParameterDistribution) = sample(rng, pd, 1)
+sample(pd::ParameterDistribution) = sample(Random.GLOBAL_RNG, pd, 1)
 
 """
-    sample_distribution([rng], d::Samples, [n_draws])
+    sample([rng], d::Samples, [n_draws])
 
 Draws `n_draws` samples from the parameter distributions `d`. Returns an array, with 
 parameters as columns. `rng` is optional and defaults to `Random.GLOBAL_RNG`. `n_draws` is 
 optional and defaults to 1. 
 """
-function sample_distribution(rng::AbstractRNG, d::Samples, n_draws::IT) where {IT <: Integer}
+function sample(rng::AbstractRNG, d::Samples, n_draws::IT) where {IT <: Integer}
     n_stored_samples = n_samples(d)
     samples_idx = sample(rng, collect(1:n_stored_samples), n_draws)
     if dimension(d) == 1
@@ -300,18 +300,18 @@ function sample_distribution(rng::AbstractRNG, d::Samples, n_draws::IT) where {I
 end
 
 # define methods that dispatch to the above with Random.GLOBAL_RNG as a default value for rng
-sample_distribution(d::Samples, n_draws::IT) where {IT <: Integer} = sample_distribution(Random.GLOBAL_RNG, d, n_draws)
-sample_distribution(rng::AbstractRNG, d::Samples) = sample_distribution(rng, d, 1)
-sample_distribution(d::Samples) = sample_distribution(Random.GLOBAL_RNG, d, 1)
+sample(d::Samples, n_draws::IT) where {IT <: Integer} = sample(Random.GLOBAL_RNG, d, n_draws)
+sample(rng::AbstractRNG, d::Samples) = sample(rng, d, 1)
+sample(d::Samples) = sample(Random.GLOBAL_RNG, d, 1)
 
 """
-    sample_distribution([rng], d::Parameterized, [n_draws])
+    sample([rng], d::Parameterized, [n_draws])
 
 Draws `n_draws` samples from the parameter distributions `d`. Returns an array, with 
 parameters as columns. `rng` is optional and defaults to `Random.GLOBAL_RNG`. `n_draws` is 
 optional and defaults to 1. 
 """
-function sample_distribution(rng::AbstractRNG, d::Parameterized, n_draws::IT) where {IT <: Integer}
+function sample(rng::AbstractRNG, d::Parameterized, n_draws::IT) where {IT <: Integer}
     if dimension(d) == 1
         return reshape(rand(rng, d.distribution, n_draws), :, n_draws) #columns are parameters
     else
@@ -320,10 +320,10 @@ function sample_distribution(rng::AbstractRNG, d::Parameterized, n_draws::IT) wh
 end
 
 # define methods that dispatch to the above with Random.GLOBAL_RNG as a default value for rng
-sample_distribution(d::Parameterized, n_draws::IT) where {IT <: Integer} =
-    sample_distribution(Random.GLOBAL_RNG, d, n_draws)
-sample_distribution(rng::AbstractRNG, d::Parameterized) = sample_distribution(rng, d, 1)
-sample_distribution(d::Parameterized) = sample_distribution(Random.GLOBAL_RNG, d, 1)
+sample(d::Parameterized, n_draws::IT) where {IT <: Integer} =
+    sample(Random.GLOBAL_RNG, d, n_draws)
+sample(rng::AbstractRNG, d::Parameterized) = sample(rng, d, 1)
+sample(d::Parameterized) = sample(Random.GLOBAL_RNG, d, 1)
 
 """
     logpdf(pd::ParameterDistribution, xarray::Array{<:Real,1})

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -5,8 +5,8 @@ using Distributions
 using Statistics
 using Random
 
-#import 
-import StatsBase
+#import (to add definitions)
+import StatsBase: mean, var, cov,sample
 
 ## Exports
 
@@ -284,7 +284,7 @@ optional and defaults to 1.
 """
 function sample_distribution(rng::AbstractRNG, d::Samples, n_draws::IT) where {IT <: Integer}
     n_stored_samples = n_samples(d)
-    samples_idx = StatsBase.sample(rng, collect(1:n_stored_samples), n_draws)
+    samples_idx = sample(rng, collect(1:n_stored_samples), n_draws)
     if dimension(d) == 1
         return reshape(d.distribution_samples[:, samples_idx], :, n_draws) #columns are parameters
     else
@@ -350,9 +350,9 @@ end
     var(pd::ParameterDistribution)
 Returns a flattened variance of the distributions
 """
-StatsBase.var(d::Parameterized) = var(d.distribution)
-StatsBase.var(d::Samples) = var(d.distribution_samples)
-function StatsBase.var(pd::ParameterDistribution)
+var(d::Parameterized) = var(d.distribution)
+var(d::Samples) = var(d.distribution_samples)
+function var(pd::ParameterDistribution)
     d_dims = get_dimensions(pd)
     block_var = Array{Any}(size(d_dims)[1])
     
@@ -368,9 +368,9 @@ end
 
 Returns a dense blocked (co)variance of the distributions.
 """
-StatsBase.cov(d::Parameterized) = cov(d.distribution)
-StatsBase.cov(d::Samples) = cov(d.distribution_samples, dims = 2) #parameters are columns
-function StatsBase.cov(pd::ParameterDistribution)
+cov(d::Parameterized) = cov(d.distribution)
+cov(d::Samples) = cov(d.distribution_samples, dims = 2) #parameters are columns
+function cov(pd::ParameterDistribution)
     d_dims = get_dimensions(pd)
     
     # create each block (co)variance
@@ -387,15 +387,15 @@ function StatsBase.cov(pd::ParameterDistribution)
 
 end
 
-#extending StatsBase.mean
+#extending mean
 """
     mean(pd::ParameterDistribution)
 
 Returns a concatenated mean of the parameter distributions. 
 """
-StatsBase.mean(d::Parameterized) = mean(d.distribution)
-StatsBase.mean(d::Samples) = mean(d.distribution_samples, dims = 2)
-function StatsBase.mean(pd::ParameterDistribution)
+mean(d::Parameterized) = mean(d.distribution)
+mean(d::Samples) = mean(d.distribution_samples, dims = 2)
+function mean(pd::ParameterDistribution)
     return cat([mean(d) for d in pd.distributions]..., dims = 1)
 end
 

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -7,7 +7,7 @@ using Random
 
 #import (to add definitions)
 import StatsBase: mean, var, cov, sample
-
+import Base: size, length
 ## Exports
 
 #types
@@ -120,14 +120,21 @@ function bounded(lower_bound::FT, upper_bound::FT) where {FT <: Real}
     return Constraint(c_to_u, u_to_c)
 end
 
+#extending Base.length
 """
-    len(c::Array{CType})
+    length(c<:ConstraintType)
 
-The number of constraints, each constraint has length 1.
+A constraint has length 1. 
 """
-len(c::CType) where {CType <: ConstraintType} = 1
+length(c::CType) where {CType <: ConstraintType} = length([c])
 
-len(carray::Array{CType}) where {CType <: ConstraintType} = size(carray)[1]
+#extending Base.size
+"""
+    size(c<:ConstraintType)
+
+A constraint has size 1.
+"""
+size(c::CType) where {CType <: ConstraintType} = size([c])
 
 """
     get_dimensions(d<:ParametrizedDistributionType)
@@ -139,7 +146,7 @@ dimension(d::Parameterized) = length(d.distribution)
 dimension(d::Samples) = size(d.distribution_samples)[1]
 
 """
-    n_samples(d::Samples)
+    n_samples(d<:Samples)
 
 The number of samples in the array.
 """
@@ -170,7 +177,7 @@ struct ParameterDistribution{PDType <: ParameterDistributionType, CType <: Const
         constraints = isa(constraints, Union{<:ConstraintType, Array{<:ConstraintType}}) ? [constraints] : constraints #to calc n_constraints_per_dist
         names = isa(names, ST) ? [names] : names
 
-        n_constraints_per_dist = [len(c) for c in constraints]
+        n_constraints_per_dist = [length(c) for c in constraints]
         n_dists = length(parameter_distributions)
         n_names = length(names)
         if !(n_parameters_per_dist == n_constraints_per_dist)

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -6,7 +6,7 @@ using Statistics
 using Random
 
 #import (to add definitions)
-import StatsBase: mean, var, cov,sample
+import StatsBase: mean, var, cov, sample
 
 ## Exports
 
@@ -355,12 +355,12 @@ var(d::Samples) = var(d.distribution_samples)
 function var(pd::ParameterDistribution)
     d_dims = get_dimensions(pd)
     block_var = Array{Any}(size(d_dims)[1])
-    
+
     for (i, dimension) in enumerate(d_dims)
-            block_var[i] = var(pd.distributions[i])
+        block_var[i] = var(pd.distributions[i])
     end
     return cat(block_var..., dims = 1) #build the flattened vector
-    
+
 end
 
 """
@@ -372,7 +372,7 @@ cov(d::Parameterized) = cov(d.distribution)
 cov(d::Samples) = cov(d.distribution_samples, dims = 2) #parameters are columns
 function cov(pd::ParameterDistribution)
     d_dims = get_dimensions(pd)
-    
+
     # create each block (co)variance
     block_cov = Array{Any}(undef, size(d_dims)[1])
     for (i, dimension) in enumerate(d_dims)

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -354,7 +354,7 @@ var(d::Parameterized) = var(d.distribution)
 var(d::Samples) = var(d.distribution_samples, dims = 2)
 function var(pd::ParameterDistribution)
     d_dims = get_dimensions(pd)
-    block_var = Array{Any}(undef,size(d_dims)[1])
+    block_var = Array{Any}(undef, size(d_dims)[1])
 
     for (i, dimension) in enumerate(d_dims)
         block_var[i] = var(pd.distributions[i])

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -19,7 +19,7 @@ export ParameterDistribution
 export Constraint
 
 #functions
-export get_name, get_distribution, get_total_dimension, get_dimensions, get_all_constraints, get_n_samples
+export get_name, get_distribution, ndims, get_dimensions, get_all_constraints, get_n_samples
 export sample
 export no_constraint, bounded_below, bounded_above, bounded
 export transform_constrained_to_unconstrained, transform_unconstrained_to_constrained
@@ -212,7 +212,7 @@ function get_dimensions(pd::ParameterDistribution)
     return [ndims(d) for d in pd.distributions]
 end
 
-function get_total_dimension(pd::ParameterDistribution)
+function ndims(pd::ParameterDistribution)
     return sum(get_dimensions(pd))
 end
 
@@ -338,7 +338,7 @@ function get_logpdf(pd::ParameterDistribution, xarray::Array{FT, 1}) where {FT <
         end
     end
     #assert xarray correct dim/length
-    if size(xarray)[1] != get_total_dimension(pd)
+    if size(xarray)[1] != ndims(pd)
         throw(DimensionMismatch("xarray must have dimension equal to the parameter space"))
     end
 

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -51,10 +51,10 @@ const EKP = EnsembleKalmanProcesses
     prior_names = ["u1", "u2"]
     prior = ParameterDistribution(prior_distns, constraints, prior_names)
 
-    prior_mean = get_mean(prior)
+    prior_mean = mean(prior)
 
     # Assuming independence of u1 and u2
-    prior_cov = get_cov(prior) #convert(Array, Diagonal([sqrt(2.), sqrt(2.)]))
+    prior_cov = cov(prior) #convert(Array, Diagonal([sqrt(2.), sqrt(2.)]))
 
 
     @testset "EnsembleKalmanSampler" begin

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -108,9 +108,9 @@ using EnsembleKalmanProcesses.ParameterDistributions
         u = ParameterDistribution([d1, d2], [c1, c2], [name1, name2])
 
         # Test for get_dimension(s)
-        @test get_total_dimension(u1) == 4
-        @test get_total_dimension(u2) == 1
-        @test get_total_dimension(u) == 5
+        @test ndims(u1) == 4
+        @test ndims(u2) == 1
+        @test ndims(u) == 5
         @test get_dimensions(u1) == [4]
         @test get_dimensions(u2) == [1]
         @test get_dimensions(u) == [4, 1]
@@ -194,7 +194,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
         @test s == cat([s1, s2]..., dims = 1)
 
         #Test for get_logpdf
-        @test_throws ErrorException get_logpdf(u, zeros(get_total_dimension(u)))
+        @test_throws ErrorException get_logpdf(u, zeros(ndims(u)))
         x_in_bd = [0.5]
         Random.seed!(seed)
         lpdf3 = logpdf.(Beta(2, 2), x_in_bd)[1] #throws deprecated warning without "."
@@ -204,13 +204,13 @@ using EnsembleKalmanProcesses.ParameterDistributions
 
         #Test for cov, var        
         block_cov = cat([cov(d1), var(d2), var(d3), cov(d4)]..., dims = (1, 2))
-        @test isapprox(cov(v) - block_cov, zeros(get_total_dimension(v), get_total_dimension(v)); atol = 1e-6)
+        @test isapprox(cov(v) - block_cov, zeros(ndims(v), ndims(v)); atol = 1e-6)
         block_var = [block_cov[i, i] for i in 1:size(block_cov)[1]]
-        @test isapprox(var(v) - block_var, zeros(get_total_dimension(v)); atol = 1e-6)
+        @test isapprox(var(v) - block_var, zeros(ndims(v)); atol = 1e-6)
 
         #Test for mean
         means = cat([mean(d1), mean(d2), mean(d3), mean(d4)]..., dims = 1)
-        @test isapprox(mean(v) - means, zeros(get_total_dimension(v)); atol = 1e-6)
+        @test isapprox(mean(v) - means, zeros(ndims(v)); atol = 1e-6)
 
     end
 

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -202,9 +202,9 @@ using EnsembleKalmanProcesses.ParameterDistributions
         #Test for cov, var        
         block_cov = cat([cov(d1), var(d2), var(d3), cov(d4)]..., dims = (1, 2))
         @test isapprox(cov(v) - block_cov, zeros(get_total_dimension(v), get_total_dimension(v)); atol = 1e-6)
-        block_var = [block_cov[i,i] for i =1:size(block_cov)[1]]
+        block_var = [block_cov[i, i] for i in 1:size(block_cov)[1]]
         @test isapprox(var(v) - block_var, zeros(get_total_dimension(v)); atol = 1e-6)
-        
+
         #Test for mean
         means = cat([mean(d1), mean(d2), mean(d3), mean(d4)]..., dims = 1)
         @test isapprox(mean(v) - means, zeros(get_total_dimension(v)); atol = 1e-6)

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -242,6 +242,10 @@ using EnsembleKalmanProcesses.ParameterDistributions
         idx = StatsBase.sample(copy(rng1), collect(1:size(d2.distribution_samples)[2]), 1)
         s2 = d2.distribution_samples[:, idx]
         @test sample(copy(rng1), u2) == s2
+        @test sample(copy(rng1), u2, 1) == s2
+        @test sample(copy(rng1), d2) == s2
+        @test sample(copy(rng1), d2, 1) == s2
+
 
         # try it again with different RNG; use StableRNG since Random doesn't provide a 
         # second seedable algorithm on julia <=1.7

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -167,30 +167,30 @@ using EnsembleKalmanProcesses.ParameterDistributions
         Random.seed!(seed)
         s1 = rand(MvNormal(4, 0.1), 1)
         Random.seed!(seed)
-        @test sample_distribution(u1) == s1
+        @test sample(u1) == s1
 
         Random.seed!(seed)
         s1 = rand(MvNormal(4, 0.1), 3)
         Random.seed!(seed)
-        @test sample_distribution(u1, 3) == s1
+        @test sample(u1, 3) == s1
 
         Random.seed!(seed)
         idx = StatsBase.sample(collect(1:size(d2.distribution_samples)[2]), 1)
         s2 = d2.distribution_samples[:, idx]
         Random.seed!(seed)
-        @test sample_distribution(u2) == s2
+        @test sample(u2) == s2
 
         Random.seed!(seed)
         idx = StatsBase.sample(collect(1:size(d2.distribution_samples)[2]), 3)
         s2 = d2.distribution_samples[:, idx]
         Random.seed!(seed)
-        @test sample_distribution(u2, 3) == s2
+        @test sample(u2, 3) == s2
 
         Random.seed!(seed)
-        s1 = sample_distribution(u1, 3)
-        s2 = sample_distribution(u2, 3)
+        s1 = sample(u1, 3)
+        s2 = sample(u2, 3)
         Random.seed!(seed)
-        s = sample_distribution(u, 3)
+        s = sample(u, 3)
         @test s == cat([s1, s2]..., dims = 1)
 
         #Test for get_logpdf
@@ -233,54 +233,54 @@ using EnsembleKalmanProcesses.ParameterDistributions
 
         # Tests for sample distribution
         rng1 = Random.MersenneTwister(rng_seed)
-        @test sample_distribution(copy(rng1), d0) == rand(copy(rng1), test_d, 1)
-        @test sample_distribution(copy(rng1), d0, 3) == rand(copy(rng1), test_d, 3)
+        @test sample(copy(rng1), d0) == rand(copy(rng1), test_d, 1)
+        @test sample(copy(rng1), d0, 3) == rand(copy(rng1), test_d, 3)
 
-        @test sample_distribution(copy(rng1), u1) == rand(copy(rng1), test_d, 1)
-        @test sample_distribution(copy(rng1), u1, 3) == rand(copy(rng1), test_d, 3)
+        @test sample(copy(rng1), u1) == rand(copy(rng1), test_d, 1)
+        @test sample(copy(rng1), u1, 3) == rand(copy(rng1), test_d, 3)
 
         idx = StatsBase.sample(copy(rng1), collect(1:size(d2.distribution_samples)[2]), 1)
         s2 = d2.distribution_samples[:, idx]
-        @test sample_distribution(copy(rng1), u2) == s2
+        @test sample(copy(rng1), u2) == s2
 
         # try it again with different RNG; use StableRNG since Random doesn't provide a 
         # second seedable algorithm on julia <=1.7
         rng2 = StableRNG(rng_seed)
-        @test sample_distribution(copy(rng2), d0) == rand(copy(rng2), test_d, 1)
-        @test sample_distribution(copy(rng2), d0, 3) == rand(copy(rng2), test_d, 3)
+        @test sample(copy(rng2), d0) == rand(copy(rng2), test_d, 1)
+        @test sample(copy(rng2), d0, 3) == rand(copy(rng2), test_d, 3)
 
-        @test sample_distribution(copy(rng2), u1) == rand(copy(rng2), test_d, 1)
-        @test sample_distribution(copy(rng2), u1, 3) == rand(copy(rng2), test_d, 3)
+        @test sample(copy(rng2), u1) == rand(copy(rng2), test_d, 1)
+        @test sample(copy(rng2), u1, 3) == rand(copy(rng2), test_d, 3)
 
         idx = StatsBase.sample(copy(rng2), collect(1:size(d2.distribution_samples)[2]), 1)
         s2 = d2.distribution_samples[:, idx]
-        @test sample_distribution(copy(rng2), u2) == s2
+        @test sample(copy(rng2), u2) == s2
 
         # test that optional parameter defaults to Random.GLOBAL_RNG, for all methods.
         # reset the global seed instead of copying the rng object's state
         rng_seed = 2468
         Random.seed!(rng_seed)
-        test_lhs = sample_distribution(d0)
+        test_lhs = sample(d0)
         Random.seed!(rng_seed)
         @test test_lhs == rand(test_d, 1)
 
         Random.seed!(rng_seed)
-        test_lhs = sample_distribution(d0, 3)
+        test_lhs = sample(d0, 3)
         Random.seed!(rng_seed)
         @test test_lhs == rand(test_d, 3)
 
         Random.seed!(rng_seed)
-        test_lhs = sample_distribution(u1)
+        test_lhs = sample(u1)
         Random.seed!(rng_seed)
         @test test_lhs == rand(test_d, 1)
 
         Random.seed!(rng_seed)
-        test_lhs = sample_distribution(u1, 3)
+        test_lhs = sample(u1, 3)
         Random.seed!(rng_seed)
         @test test_lhs == rand(test_d, 3)
 
         Random.seed!(rng_seed)
-        test_lhs = sample_distribution(d0)
+        test_lhs = sample(d0)
         Random.seed!(rng_seed)
         @test test_lhs == rand(test_d, 1)
 
@@ -288,7 +288,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
         idx = StatsBase.sample(collect(1:size(d2.distribution_samples)[2]), 1)
         test_lhs = d2.distribution_samples[:, idx]
         Random.seed!(rng_seed)
-        @test test_lhs == sample_distribution(u2)
+        @test test_lhs == sample(u2)
     end
 
     @testset "transform functions" begin

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -199,11 +199,11 @@ using EnsembleKalmanProcesses.ParameterDistributions
         @test_throws DimensionMismatch get_logpdf(u3, [0.5, 0.5])
 
         #Test for get_cov, get_var        
-        block_cov = cat([get_cov(d1), get_var(d2), get_var(d3), get_cov(d4)]..., dims = (1, 2))
-        @test isapprox(get_cov(v) - block_cov, zeros(get_total_dimension(v), get_total_dimension(v)); atol = 1e-6)
-        #Test for get_mean
-        means = cat([get_mean(d1), get_mean(d2), get_mean(d3), get_mean(d4)]..., dims = 1)
-        @test isapprox(get_mean(v) - means, zeros(get_total_dimension(v)); atol = 1e-6)
+        block_cov = cat([cov(d1), var(d2), var(d3), cov(d4)]..., dims = (1, 2))
+        @test isapprox(cov(v) - block_cov, zeros(get_total_dimension(v), get_total_dimension(v)); atol = 1e-6)
+        #Test for mean
+        means = cat([mean(d1), mean(d2), mean(d3), mean(d4)]..., dims = 1)
+        @test isapprox(mean(v) - means, zeros(get_total_dimension(v)); atol = 1e-6)
 
     end
 

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -48,6 +48,9 @@ using EnsembleKalmanProcesses.ParameterDistributions
         @test isapprox(c4.constrained_to_unconstrained(5.0) - c_to_u(5.0), 0)
         @test isapprox(c4.unconstrained_to_constrained(5.0) - u_to_c(5.0), 0)
 
+        #length, size
+        @test length(c1) == 1
+        @test size(c1) == (1,)
 
     end
 

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using Distributions
 using StableRNGs
 using StatsBase
+using LinearAlgebra
 using Random
 
 using EnsembleKalmanProcesses.ParameterDistributions
@@ -198,9 +199,12 @@ using EnsembleKalmanProcesses.ParameterDistributions
         @test isapprox(get_logpdf(u3, x_in_bd) - lpdf3, 0.0; atol = 1e-6)
         @test_throws DimensionMismatch get_logpdf(u3, [0.5, 0.5])
 
-        #Test for get_cov, get_var        
+        #Test for cov, var        
         block_cov = cat([cov(d1), var(d2), var(d3), cov(d4)]..., dims = (1, 2))
         @test isapprox(cov(v) - block_cov, zeros(get_total_dimension(v), get_total_dimension(v)); atol = 1e-6)
+        block_var = [block_cov[i,i] for i =1:size(block_cov)[1]]
+        @test isapprox(var(v) - block_var, zeros(get_total_dimension(v)); atol = 1e-6)
+        
         #Test for mean
         means = cat([mean(d1), mean(d2), mean(d3), mean(d4)]..., dims = 1)
         @test isapprox(mean(v) - means, zeros(get_total_dimension(v)); atol = 1e-6)


### PR DESCRIPTION
## Purpose
To replace some functions with corresponding extensions from existing packages. (and the relevant tests/examples)
resolves #92 
## In this PR
- ParameterDistributions: By extending from `StatsBase`. Replacing `get_mean` `get_var` `get_cov` 'sample_distribution' by extending `mean` `var` `cov` `sample` 
- ParameterDistributions: by extending `Base`: Change `len` to `length`, added `size`, change `dimension`and `get_total_dimension` to `ndims` 