### PR TITLE
Substitute types by abstractions.

### DIFF
--- a/src/DataContainers.jl
+++ b/src/DataContainers.jl
@@ -16,9 +16,9 @@ Container to store data samples as columns in an array.
 """
 struct DataContainer{FT <: Real}
     #stored data, each piece of data is a column [data dimension × number samples]
-    stored_data::Array{FT, 2}
+    stored_data::AbstractMatrix{FT}
     #constructor with 2D arrays
-    function DataContainer(stored_data::Array{FT, 2}; data_are_columns = true) where {FT <: Real}
+    function DataContainer(stored_data::AbstractMatrix{FT}; data_are_columns = true) where {FT <: Real}
 
         if data_are_columns
             new{FT}(stored_data)
@@ -41,8 +41,8 @@ struct PairedDataContainer{FT <: Real}
 
     #constructor with 2D Arrays
     function PairedDataContainer(
-        inputs::Array{FT, 2},
-        outputs::Array{FT, 2};
+        inputs::AbstractMatrix{FT},
+        outputs::AbstractMatrix{FT};
         data_are_columns = true,
     ) where {FT <: Real}
 

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -8,14 +8,14 @@ An ensemble Kalman Inversion process
 struct Inversion <: Process end
 
 """
-    find_ekp_stepsize(ekp::EnsembleKalmanProcess{FT, IT, Inversion}, g::Array{FT, 2}; cov_threshold::FT=0.01) where {FT}
+    find_ekp_stepsize(ekp::EnsembleKalmanProcess{FT, IT, Inversion}, g::AbstractMatrix{FT}; cov_threshold::FT=0.01) where {FT}
 
 Find largest stepsize for the EK solver that leads to a reduction of the determinant of the sample
 covariance matrix no greater than cov_threshold. 
 """
 function find_ekp_stepsize(
     ekp::EnsembleKalmanProcess{FT, IT, Inversion},
-    g::Array{FT, 2};
+    g::AbstractMatrix{FT};
     cov_threshold::FT = 0.01,
 ) where {FT, IT}
     accept_stepsize = false
@@ -48,7 +48,7 @@ Updates the ensemble according to which type of Process we have. Model outputs `
 """
 function update_ensemble!(
     ekp::EnsembleKalmanProcess{FT, IT, Inversion},
-    g::Array{FT, 2};
+    g::AbstractMatrix{FT};
     cov_threshold::FT = 0.01,
     Δt_new = nothing,
     deterministic_forward_map = true,

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -35,7 +35,7 @@ struct EnsembleKalmanProcess{FT <: AbstractFloat, IT <: Int, P <: Process}
     "vector of the observed vector size [`N_obs`]"
     obs_mean::Vector{FT}
     "covariance matrix of the observational noise, of size [`N_obs × N_obs`]"
-    obs_noise_cov::Array{FT, 2}
+    obs_noise_cov::Union{AbstractMatrix{FT}, UniformScaling{FT}}
     "ensemble size"
     N_ens::IT
     "Array of stores for forward model outputs, each of size  [`N_obs × N_ens`]"
@@ -53,9 +53,9 @@ end
 # outer constructors
 """
     EnsembleKalmanProcess(
-        params::Array{FT, 2},
+        params::AbstractMatrix{FT},
         obs_mean,
-        obs_noise_cov::Array{FT, 2},
+        obs_noise_cov::Union{AbstractMatrix{FT}, UniformScaling{FT}},
         process::P;
         Δt = FT(1),
         rng::AbstractRNG = Random.GLOBAL_RNG
@@ -64,9 +64,9 @@ end
 Ensemble Kalman process constructor.
 """
 function EnsembleKalmanProcess(
-    params::Array{FT, 2},
+    params::AbstractMatrix{FT},
     obs_mean,
-    obs_noise_cov::Array{FT, 2},
+    obs_noise_cov::Union{AbstractMatrix{FT}, UniformScaling{FT}},
     process::P;
     Δt = FT(1),
     rng::AbstractRNG = Random.GLOBAL_RNG,

--- a/src/EnsembleKalmanSampler.jl
+++ b/src/EnsembleKalmanSampler.jl
@@ -9,12 +9,12 @@ struct Sampler{FT <: AbstractFloat} <: Process
     ""
     prior_mean::Vector{FT}
     ""
-    prior_cov::Array{FT, 2}
+    prior_cov::AbstractMatrix{FT}
 end
 
 
 
-function update_ensemble!(ekp::EnsembleKalmanProcess{FT, IT, Sampler{FT}}, g_in::Array{FT, 2}) where {FT, IT}
+function update_ensemble!(ekp::EnsembleKalmanProcess{FT, IT, Sampler{FT}}, g_in::AbstractMatrix{FT}) where {FT, IT}
 
     #catch works when g_in non-square 
     if !(size(g_in)[2] == ekp.N_ens)

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -25,11 +25,11 @@ struct Observation{FT <: AbstractFloat}
     are the variances of the samples, or to a scalar variance in the case of 
     1d samples. `obs_noise_cov` is set to nothing if only a single sample is 
     provided."
-    obs_noise_cov::Union{Array{FT, 2}, FT, Nothing}
+    obs_noise_cov::Union{AbstractMatrix{FT}, UniformScaling{FT}, FT, Nothing}
     "sample mean"
-    mean::Union{Vector{FT}, FT}
+    mean::Union{AbstractVector{FT}, FT}
     "names of the data"
-    data_names::Union{Vector{String}, String}
+    data_names::Union{AbstractVector{String}, String}
 end
 
 # Constructors
@@ -59,7 +59,10 @@ function Observation(samples::Vector{Vector{FT}}, data_names::Union{Vector{Strin
     Observation(samples, obs_noise_cov, samplemean, data_names)
 end
 
-function Observation(samples::Array{FT, 2}, data_names::Union{Vector{String}, String}) where {FT <: AbstractFloat}
+function Observation(
+    samples::AbstractMatrix{FT},
+    data_names::Union{AbstractVector{String}, String},
+) where {FT <: AbstractFloat}
 
     # samples is of size sample_dim x N_samples
     sample_dim, N_samples = size(samples)
@@ -89,8 +92,8 @@ end
 
 function Observation(
     samples::Vector{Vector{FT}},
-    obs_noise_cov::Array{FT, 2},
-    data_names::Union{Vector{String}, String},
+    obs_noise_cov::AbstractMatrix{FT},
+    data_names::Union{AbstractVector{String}, String},
 ) where {FT <: AbstractFloat}
 
     N_samples = length(samples)
@@ -126,9 +129,9 @@ function Observation(
 end
 
 function Observation(
-    samples::Array{FT, 2},
-    obs_noise_cov::Union{Array{FT, 2}, Nothing},
-    data_names::Union{Vector{String}, String},
+    samples::AbstractMatrix{FT},
+    obs_noise_cov::Union{AbstractMatrix{FT}, Nothing},
+    data_names::Union{AbstractVector{String}, String},
 ) where {FT <: AbstractFloat}
 
     # samples is of size sample_dim x N_samples

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -44,11 +44,11 @@ end
 A distribution comprised of only samples, stored as columns of parameters.
 """
 struct Samples{FT <: Real} <: ParameterDistributionType
-    distribution_samples::Array{FT, 2} #parameters are columns
-    Samples(distribution_samples::Array{FT, 2}; params_are_columns = true) where {FT <: Real} =
+    distribution_samples::AbstractMatrix{FT} #parameters are columns
+    Samples(distribution_samples::AbstractMatrix{FT}; params_are_columns = true) where {FT <: Real} =
         params_are_columns ? new{FT}(distribution_samples) : new{FT}(permutedims(distribution_samples, (2, 1)))
     #Distinguish 1 sample of an ND parameter or N samples of 1D parameter, and store as 2D array  
-    Samples(distribution_samples::Array{FT, 1}; params_are_columns = true) where {FT <: Real} =
+    Samples(distribution_samples::AbstractVector{FT}; params_are_columns = true) where {FT <: Real} =
         params_are_columns ? new{FT}(reshape(distribution_samples, 1, :)) : new{FT}(reshape(distribution_samples, :, 1))
 end
 
@@ -328,9 +328,9 @@ sample(d::Parameterized) = sample(Random.GLOBAL_RNG, d, 1)
 Obtains the independent logpdfs of the parameter distributions at `xarray`
 (non-Samples Distributions only), and returns their sum.
 """
-get_logpdf(d::Parameterized, xarray::Array{FT, 1}) where {FT <: Real} = logpdf.(d.distribution, xarray)
+get_logpdf(d::Parameterized, xarray::AbstractVector{FT}) where {FT <: Real} = logpdf.(d.distribution, xarray)
 
-function get_logpdf(pd::ParameterDistribution, xarray::Array{FT, 1}) where {FT <: Real}
+function get_logpdf(pd::ParameterDistribution, xarray::AbstractVector{FT}) where {FT <: Real}
     #first check we don't have sampled distribution
     for d in pd.distributions
         if typeof(d) <: Samples
@@ -410,7 +410,10 @@ end
 
 Apply the transformation to map (possibly constrained) parameters `xarray` into the unconstrained space.
 """
-function transform_constrained_to_unconstrained(pd::ParameterDistribution, xarray::Array{FT, 1}) where {FT <: Real}
+function transform_constrained_to_unconstrained(
+    pd::ParameterDistribution,
+    xarray::AbstractVector{FT},
+) where {FT <: Real}
     return cat([c.constrained_to_unconstrained(xarray[i]) for (i, c) in enumerate(pd.constraints)]..., dims = 1)
 end
 
@@ -420,7 +423,10 @@ end
 Apply the transformation to map (possibly constrained) parameter samples `xarray` into the unconstrained space.
 Here, `xarray` contains parameters as columns and samples as rows.
 """
-function transform_constrained_to_unconstrained(pd::ParameterDistribution, xarray::Array{FT, 2}) where {FT <: Real}
+function transform_constrained_to_unconstrained(
+    pd::ParameterDistribution,
+    xarray::AbstractMatrix{FT},
+) where {FT <: Real}
     return Array(hcat([c.constrained_to_unconstrained.(xarray[i, :]) for (i, c) in enumerate(pd.constraints)]...)')
 end
 
@@ -429,7 +435,10 @@ end
 
 Apply the transformation to map parameters `xarray` from the unconstrained space into (possibly constrained) space.
 """
-function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{FT, 1}) where {FT <: Real}
+function transform_unconstrained_to_constrained(
+    pd::ParameterDistribution,
+    xarray::AbstractVector{FT},
+) where {FT <: Real}
     return cat([c.unconstrained_to_constrained(xarray[i]) for (i, c) in enumerate(pd.constraints)]..., dims = 1)
 end
 
@@ -439,7 +448,10 @@ end
 Apply the transformation to map parameter samples `xarray` from the unconstrained space into (possibly constrained) space.
 Here, `xarray` contains parameters as columns and samples as rows.
 """
-function transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{FT, 2}) where {FT <: Real}
+function transform_unconstrained_to_constrained(
+    pd::ParameterDistribution,
+    xarray::AbstractMatrix{FT},
+) where {FT <: Real}
     return Array(hcat([c.unconstrained_to_constrained.(xarray[i, :]) for (i, c) in enumerate(pd.constraints)]...)')
 end
 
@@ -447,11 +459,11 @@ end
     transform_unconstrained_to_constrained(pd::ParameterDistribution, xarray::Array{Array{<:Real,2},1})
 
 Apply the transformation to map parameter sample ensembles `xarray` from the unconstrained space into (possibly constrained) space.
-Here, `xarray` contains parameters sample ensembles for different EKP iterations.
+Here, `xarray` is an iterable of parameters sample ensembles for different EKP iterations.
 """
 function transform_unconstrained_to_constrained(
     pd::ParameterDistribution,
-    xarray::Array{Array{FT, 2}, 1},
+    xarray, # ::Iterable{AbstractMatrix{FT}},
 ) where {FT <: Real}
     transf_xarray = []
     for elem in xarray

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -17,14 +17,14 @@ struct SparseInversion{FT <: AbstractFloat, IT <: Int} <: Process
     "a small value for regularization to enhance robustness of convex optimization"
     reg::FT
     "a list of index to indicate the parameters included in the evaluation of l1-norm"
-    uc_idx::Vector{IT}
+    uc_idx::AbstractVector{IT}
 end
 
 """
     sparse_qp(
         ekp::EnsembleKalmanProcess{FT, IT, SparseInversion{FT,IT}},
         v_j::Vector{FT},
-        cov_vv_inv::Array{FT, 2},
+        cov_vv_inv::AbstractMatrix{FT},
         H_u::SparseArrays.SparseMatrixCSC{FT},
         H_g::SparseArrays.SparseMatrixCSC{FT},
         y_j::Vector{FT};
@@ -36,11 +36,11 @@ Solving quadratic programming problem with sparsity constraint.
 function sparse_qp(
     ekp::EnsembleKalmanProcess{FT, IT, SparseInversion{FT, IT}},
     v_j::Vector{FT},
-    cov_vv_inv::Array{FT, 2},
-    H_u::SparseArrays.SparseMatrixCSC{FT},
-    H_g::SparseArrays.SparseMatrixCSC{FT},
+    cov_vv_inv::AbstractMatrix{FT},
+    H_u::AbstractMatrix{FT},
+    H_g::AbstractMatrix{FT},
     y_j::Vector{FT};
-    H_uc::SparseArrays.SparseMatrixCSC{FT} = H_u,
+    H_uc::AbstractMatrix{FT} = H_u,
 ) where {FT, IT}
 
     P = H_g' * (ekp.obs_noise_cov \ H_g) + cov_vv_inv
@@ -76,7 +76,7 @@ Updates the ensemble according to which type of Process we have. Model outputs `
 """
 function update_ensemble!(
     ekp::EnsembleKalmanProcess{FT, IT, SparseInversion{FT, IT}},
-    g::Array{FT, 2};
+    g::AbstractMatrix{FT};
     cov_threshold::FT = 0.01,
     Δt_new = nothing,
     deterministic_forward_map = true,


### PR DESCRIPTION
Relaxes the allowed types of some objects and input args for improved generalization:

- Vector - > AbstractVector
- Matrix -> AbstractMatrix
- Sparse.SparseMatrix -> AbstractMatrix
- Union{Vector, Matrix} -> AbstractVecOrMat

For covariance matrices in output space,

- Matrix -> Union{AbstractMatrix, UniformScaling}

Tests involving different matrix types are now included for all Ensemble Kalman Processes.