### PR TITLE
Correct rng kwargs for construct_initial_ensemble()

### DIFF
--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -176,7 +176,7 @@ function construct_initial_ensemble(
     rng::AbstractRNG,
     prior::ParameterDistribution,
     N_ens::IT;
-    rng_seed::Union{IT, Nothing} = nothing
+    rng_seed::Union{IT, Nothing} = nothing,
 ) where {IT <: Int}
     # Ensuring reproducibility of the sampled parameter values: 
     # re-seed the rng *only* if we're given a seed

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -14,6 +14,16 @@ const EKP = EnsembleKalmanProcesses
     rng_seed = 42
     rng = Random.MersenneTwister(rng_seed)
 
+    ### sanity check on rng:
+    d = Parameterized(Normal(0, 1))
+    u = ParameterDistribution(d, no_constraint(), "test")
+    draw_1 = construct_initial_ensemble(u, 1)
+    draw_2 = construct_initial_ensemble(u, 1)
+    @test !isapprox(draw_1, draw_2)
+
+    # Re-seed rng
+    rng = Random.MersenneTwister(rng_seed)
+
     ### Generate data from a linear model: a regression problem with n_par parameters
     ### and 1 observation of G(u) = A \times u, where A : R^n_par -> R^n_obs
     n_obs = 10                  # dimension of synthetic observation from G(u)


### PR DESCRIPTION
Fixes CliMA/EnsembleKalmanProcesses.jl#104.

 This PR corrects the logic for construct_initial_ensemble() to the following:
1. If an rng is not passed as the first argument, GLOBAL_RNG is used (same convention as StatsBase, Random, etc.)
2. If and only if a value for `rng_seed` is given, the rng is re-seeded to that value.

Previously, passing both `rng_seed` and `rng` as optional kwargs to  meant that, if neither was supplied, GLOBAL_RNG was re-seeded to 42 on every call.

Add @ilopezgp's MWE from #104 to the unit tests as a sanity check.