### PR TITLE
Add continuous UKI dynamics discretization.

### DIFF
--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -70,13 +70,7 @@ function update_ensemble!(
     cov_ug = cov(u, g, dims = 2, corrected = false) # [N_par × N_obs]
     cov_gg = cov(g, g, dims = 2, corrected = false) # [N_obs × N_obs]
 
-    if !isnothing(Δt_new)
-        push!(ekp.Δt, Δt_new)
-    elseif isnothing(Δt_new) && isempty(ekp.Δt)
-        push!(ekp.Δt, FT(1))
-    else
-        push!(ekp.Δt, ekp.Δt[end])
-    end
+    set_Δt!(ekp, Δt_new)
 
     # Scale noise using Δt
     scaled_obs_noise_cov = ekp.obs_noise_cov / ekp.Δt[end]

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -199,6 +199,16 @@ end
 
 get_error(ekp::EnsembleKalmanProcess) = ekp.err
 
+function set_Δt!(ekp::EnsembleKalmanProcess, Δt_new::T) where {T}
+    if !isnothing(Δt_new)
+        push!(ekp.Δt, Δt_new)
+    elseif isnothing(Δt_new) && isempty(ekp.Δt)
+        push!(ekp.Δt, FT(1))
+    else
+        push!(ekp.Δt, ekp.Δt[end])
+    end
+end
+
 ## include the different types of Processes and their exports:
 
 # struct Inversion

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -99,13 +99,7 @@ function update_ensemble!(
     cov_gg = cov(g, g, dims = 2, corrected = false) # [N_obs × N_obs]
     cov_uu = cov(u, u, dims = 2, corrected = false) # [N_par × N_par]
 
-    if !isnothing(Δt_new)
-        push!(ekp.Δt, Δt_new)
-    elseif isnothing(Δt_new) && isempty(ekp.Δt)
-        push!(ekp.Δt, FT(1))
-    else
-        push!(ekp.Δt, ekp.Δt[end])
-    end
+    set_Δt!(ekp, Δt_new)
 
     v = hcat(u', g')
 


### PR DESCRIPTION
Adds the continuous version of UKI dynamics as specified in Huang et al (2021), section 3.4,

Σ_ω -> Σ_ω * Δt
Σ_ν -> Σ_ν / Δt

I didn't change alpha to alpha_h, I think that's fine from the paper.

 Also moves the dt constructor to EnsembleKalmanProcess.jl.