### PR TITLE
Homogenize update_ensemble! kwargs.

### DIFF
--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -103,7 +103,7 @@ end
         Δt_new::Union{Nothing, FT} = nothing,
         deterministic_forward_map::Bool = true,
         failed_ens = nothing,
-    ) where {FT, IT, FM <: FailureHandlingMethod}
+    ) where {FT, IT}
 
 Updates the ensemble according to an Inversion process. 
 
@@ -123,7 +123,7 @@ function update_ensemble!(
     Δt_new::Union{Nothing, FT} = nothing,
     deterministic_forward_map::Bool = true,
     failed_ens = nothing,
-) where {FT, IT, FM <: FailureHandlingMethod}
+) where {FT, IT}
 
     #catch works when g non-square
     if !(size(g)[2] == ekp.N_ens)

--- a/src/EnsembleKalmanSampler.jl
+++ b/src/EnsembleKalmanSampler.jl
@@ -72,9 +72,24 @@ function eks_update(
     return u, Δt
 end
 
+"""
+    update_ensemble!(
+        ekp::EnsembleKalmanProcess{FT, IT, Sampler{FT}},
+        g::AbstractMatrix{FT};
+        failed_ens = nothing,
+    ) where {FT, IT}
+
+Updates the ensemble according to a Sampler process. 
+
+Inputs:
+ - ekp :: The EnsembleKalmanProcess to update.
+ - g :: Model outputs, they need to be stored as a `N_obs × N_ens` array (i.e data are columms).
+ - failed_ens :: Indices of failed particles. If nothing, failures are computed as columns of `g`
+    with NaN entries.
+"""
 function update_ensemble!(
     ekp::EnsembleKalmanProcess{FT, IT, Sampler{FT}},
-    g::AbstractMatrix{FT},
+    g::AbstractMatrix{FT};
     failed_ens = nothing,
 ) where {FT, IT}
 

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -132,13 +132,24 @@ end
 
 """
     update_ensemble!(
-        ekp::EnsembleKalmanProcess{FT, IT, <:SparseInversion{FT,IT}},
-        g::Array{FT,2};
-        cov_threshold::FT=0.01,
-        Δt_new=nothing
+        ekp::EnsembleKalmanProcess{FT, IT, SparseInversion{FT, IT}},
+        g::AbstractMatrix{FT};
+        cov_threshold::FT = 0.01,
+        Δt_new = nothing,
+        deterministic_forward_map = true,
+        failed_ens = nothing,
     ) where {FT, IT}
 
-Updates the ensemble according to which type of Process we have. Model outputs `g` need to be a `N_obs × N_ens` array (i.e data are columms).
+Updates the ensemble according to a SparseInversion process. 
+
+Inputs:
+ - ekp :: The EnsembleKalmanProcess to update.
+ - g :: Model outputs, they need to be stored as a `N_obs × N_ens` array (i.e data are columms).
+ - cov_threshold :: Threshold below which the reduction in covariance determinant results in a warning.
+ - Δt_new :: Time step to be used in the current update.
+ - deterministic_forward_map :: Whether output `g` comes from a deterministic model.
+ - failed_ens :: Indices of failed particles. If nothing, failures are computed as columns of `g`
+    with NaN entries.
 """
 function update_ensemble!(
     ekp::EnsembleKalmanProcess{FT, IT, SparseInversion{FT, IT}},

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -481,9 +481,26 @@ function update_ensemble_analysis!(
     compute_error!(uki)
 end
 
+"""
+    update_ensemble!(
+        uki::EnsembleKalmanProcess{FT, IT, Unscented},
+        g_in::AbstractMatrix{FT};
+        Δt_new = nothing,
+        failed_ens = nothing,
+    ) where {FT <: AbstractFloat, IT <: Int}
+
+Updates the ensemble according to an Unscented process. 
+
+Inputs:
+ - uki :: The EnsembleKalmanProcess to update.
+ - g_in :: Model outputs, they need to be stored as a `N_obs × N_ens` array (i.e data are columms).
+ - Δt_new :: Time step to be used in the current update.
+ - failed_ens :: Indices of failed particles. If nothing, failures are computed as columns of `g`
+    with NaN entries.
+"""
 function update_ensemble!(
     uki::EnsembleKalmanProcess{FT, IT, Unscented},
-    g_in::AbstractMatrix{FT},
+    g_in::AbstractMatrix{FT};
     Δt_new = nothing,
     failed_ens = nothing,
 ) where {FT <: AbstractFloat, IT <: Int}


### PR DESCRIPTION
Homogenizes the use of kwargs in the `update_ensemble!` call across Processes. The only two args are the EKP object and the forward model evaluations. The rest of the inputs are taken as kwargs.