### PR TITLE
update cholesky in UKI

### DIFF
--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -231,7 +231,17 @@ function construct_sigma_ensemble(
 
     c_weights = process.c_weights
 
-    chol_xx_cov = cholesky(Hermitian(x_cov)).L
+    # compute cholesky factor L of x_cov
+    local chol_xx_cov
+    try
+        chol_xx_cov = cholesky(Hermitian(x_cov)).L
+    catch
+        _, S, Ut = svd(x_cov)
+        # find the first singular value that is smaller than 1e-8
+        ind_0 = searchsortedfirst(S, 1e-8, rev = true)
+        S[ind_0:end] .= S[ind_0 - 1]
+        chol_xx_cov = (qr(sqrt.(S) .* Ut).R)'
+    end
 
     x = zeros(FT, N_x, 2 * N_x + 1)
     x[:, 1] = x_mean

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -5,7 +5,7 @@ using Test
 
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions
-import EnsembleKalmanProcesses: construct_mean, construct_cov
+import EnsembleKalmanProcesses: construct_mean, construct_cov, construct_sigma_ensemble
 const EKP = EnsembleKalmanProcesses
 
 @testset "EnsembleKalmanProcess" begin
@@ -331,6 +331,7 @@ const EKP = EnsembleKalmanProcesses
         @test isa(construct_mean(ukiobj, rand(rng, 5, 2 * n_par + 1)), Vector{Float64})
         @test isa(construct_cov(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
         @test isa(construct_cov(ukiobj, rand(rng, 5, 2 * n_par + 1)), Matrix{Float64})
+        @test isposdef(construct_cov(ukiobj, construct_sigma_ensemble(ukiobj.process, [0.0; 0.0], [1.0 0; 0 0])))
 
         # UKI results: Test if ensemble has collapsed toward the true parameter 
         # values


### PR DESCRIPTION
Update the Cholesky factor computation in UKI

When the matrix is not positive definite, compute SVD of the matrix, replace 0 singular values as the smallest nonzero singular value (with a threshold 1e-8), and then compute the Cholesky factor.

