### PR TITLE
Simplify SparseInversion struct, add more constructors.

### DIFF
--- a/examples/SparseLossMinimization/loss_minimization_sparse_eki.jl
+++ b/examples/SparseLossMinimization/loss_minimization_sparse_eki.jl
@@ -56,12 +56,11 @@ initial_ensemble = EKP.construct_initial_ensemble(prior, N_ensemble; rng_seed = 
 
 # Sparse EKI parameters
 γ = 1.0
-threshold_eki = false
 threshold_value = 1e-2
 reg = 1e-3
 uc_idx = [1, 2]
 
-process = SparseInversion(γ, threshold_eki, threshold_value, reg, uc_idx)
+process = SparseInversion(γ, threshold_value, uc_idx, reg)
 
 # We then initialize the Ensemble Kalman Process algorithm, with the initial ensemble, the
 # target, the stabilization and the process type (for sparse EKI this is `SparseInversion`). 

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -402,18 +402,17 @@ const EKP = EnsembleKalmanProcesses
 
         # Sparse EKI parameters
         γ = 1.0
-        reg = 1e-4
-        uc_idx = [1, 2]
+        regs = [1e-4, 1e-3]
+        uc_idxs = [[1, 2], :]
 
         initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
         @test size(initial_ensemble) == (n_par, N_ens)
 
-        thresholds_eki = [false, true]
-        threshold_values = [1e-2, 1e-2]
+        threshold_values = [0, 1e-2]
         test_names = ["test", "test_thresholded"]
 
-        for (threshold_eki, threshold_value, test_name, Γy) in zip(thresholds_eki, threshold_values, test_names, Γy_vec)
-            process = SparseInversion(γ, threshold_eki, threshold_value, reg, uc_idx)
+        for (threshold_value, reg, uc_idx, test_name, Γy) in zip(threshold_values, regs, uc_idxs, test_names, Γy_vec)
+            process = SparseInversion(γ, threshold_value, uc_idx, reg)
 
             ekiobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, process; rng = rng)
 
@@ -466,6 +465,10 @@ const EKP = EnsembleKalmanProcesses
                 plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red)
                 savefig(p, string("SparseEKI_", test_name, ".png"))
             end
+
+            # Test other constructors
+            @test isa(SparseInversion(γ), SparseInversion)
+
         end
     end
 


### PR DESCRIPTION
- Removes `threshold_eki` boolean, since it can be inferred from magnitude of `threshold_value`.
- Sets `reg` last, since it is a parameter only needed for numerical stability and ideally not user-facing. 
-  Verifies that `reg` is positive definite before attempting to sample from a gaussian with `reg` as its variance.
- Adds base kwarg constructor to SparseInversion.
- Adds defaults to struct properties and an outer constructor that accepts a flexible number of keyword parameters.  