### PR TITLE
Add localization kernels.

### DIFF
--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -109,6 +109,8 @@ end
 Returns the sparse updated parameter vectors given their current values and
 the corresponding forward model evaluations, using the inversion algorithm
 from eqns. (3.7) and (3.14) of Schneider et al. (2021).
+
+Localization is applied following Tong and Morzfeld (2022).
 """
 function sparse_eki_update(
     ekp::EnsembleKalmanProcess{FT, IT, SparseInversion{FT}},
@@ -121,6 +123,9 @@ function sparse_eki_update(
     cov_ug = cov(u, g, dims = 2, corrected = false) # [N_par × N_obs]
     cov_gg = cov(g, g, dims = 2, corrected = false) # [N_par × N_obs]
     cov_uu = cov(u, u, dims = 2, corrected = false) # [N_par × N_par]
+
+    # Localization following Tong and Morzfeld (2022)
+    cov_ug = cov_ug .* ekp.localizer.kernel
 
     v = hcat(u', g')
 


### PR DESCRIPTION
Adds localization kernels to EKI, UKI and SparseEKI following the localization of the empirical cross-covariance as suggested by Tong and Morzfeld (2022).

Three localization kernels are implemented: The NoLocalization kernel, the Delta kernel and the RBF kernel. Kernels are built at EKP construction time and stored in the struct.