### PR TITLE
Organize localizers into module, add randomized localizer

### DIFF
--- a/docs/src/API/Localizers.md
+++ b/docs/src/API/Localizers.md
@@ -1,0 +1,11 @@
+# Localizers
+
+```@meta
+CurrentModule = EnsembleKalmanProcesses.Localizers
+```
+
+```@docs
+Localizer
+RBF
+BernoulliDropout
+```

--- a/src/EnsembleKalmanProcesses.jl
+++ b/src/EnsembleKalmanProcesses.jl
@@ -6,6 +6,7 @@ using Distributions, Statistics, LinearAlgebra, DocStringExtensions
 include("ParameterDistributions.jl")
 include("DataContainers.jl")
 include("Observations.jl")
+include("Localizers.jl")
 
 # algorithmic updates
 include("EnsembleKalmanProcess.jl")

--- a/src/Localizers.jl
+++ b/src/Localizers.jl
@@ -1,0 +1,94 @@
+module Localizers
+
+using Distributions
+using LinearAlgebra
+using DocStringExtensions
+
+export NoLocalization, Delta, RBF, BernoulliDropout
+export LocalizationMethod, Localizer
+
+abstract type LocalizationMethod end
+
+struct NoLocalization <: LocalizationMethod end
+struct Delta <: LocalizationMethod end
+
+"""
+    RBF{FT <: Real} <: LocalizationMethod
+
+Radial basis function localization method. Covariance
+terms are damped as d(i,j)= |i-j|/l increases, following
+a Gaussian.
+
+# Fields
+
+$(TYPEDFIELDS)
+"""
+struct RBF{FT <: Real} <: LocalizationMethod
+    "Length scale defining the RBF kernel"
+    lengthscale::FT
+end
+
+"""
+    BernoulliDropout{FT <: Real} <: LocalizationMethod
+
+Localization method that drops cross-covariance terms with
+probability 1-p, retaining a Hermitian structure.
+
+# Fields
+
+$(TYPEDFIELDS)
+"""
+struct BernoulliDropout{FT <: Real} <: LocalizationMethod
+    "Probability of keeping a given cross-covariance term"
+    prob::FT
+end
+
+struct Localizer{LM <: LocalizationMethod, T}
+    kernel::Union{AbstractMatrix{T}, UniformScaling{T}}
+end
+
+"Uniform kernel constructor"
+function Localizer(localization::NoLocalization, p::IT, d::IT, T = Float64) where {IT <: Int}
+    kernel = ones(T, p, d)
+    return Localizer{NoLocalization, T}(kernel)
+end
+
+"Delta kernel localizer constructor"
+function Localizer(localization::Delta, p::IT, d::IT, T = Float64) where {IT <: Int}
+    kernel = T(1) * Matrix(I, p, d)
+    return Localizer{Delta, T}(kernel)
+end
+
+"RBF kernel localizer constructor"
+function Localizer(localization::RBF, p::IT, d::IT, T = Float64) where {IT <: Int}
+    l = localization.lengthscale
+    kernel = zeros(T, p, d)
+    for i in 1:p
+        for j in 1:d
+            @inbounds kernel[i, j] = exp(-(i - j) * (i - j) / (2 * l * l))
+        end
+    end
+    return Localizer{RBF, T}(kernel)
+end
+
+"Randomized Bernoulli dropout kernel localizer constructor"
+function Localizer(localization::BernoulliDropout, p::IT, d::IT, T = Float64) where {IT <: Int}
+    kernel = T(1) * Matrix(I, p, d)
+
+    # Transpose
+    kernel = p < d ? kernel' : kernel
+    for i in 2:size(kernel, 1)
+        for j in 1:min(i - 1, size(kernel, 2))
+            @inbounds kernel[i, j] = T(rand(Bernoulli(localization.prob)))
+            if i <= size(kernel, 2)
+                kernel[j, i] = kernel[i, j]
+            end
+        end
+    end
+    # Transpose back
+    kernel = p < d ? kernel' : kernel
+
+    return Localizer{BernoulliDropout, T}(kernel)
+end
+
+end # module

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -5,6 +5,7 @@ using Test
 
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions
+using EnsembleKalmanProcesses.Localizers
 import EnsembleKalmanProcesses: construct_mean, construct_cov, construct_sigma_ensemble
 const EKP = EnsembleKalmanProcesses
 
@@ -522,62 +523,4 @@ const EKP = EnsembleKalmanProcesses
         @test_throws PosDefException sample_empirical_gaussian(u, 2, inflation = 0.0)
     end
 
-    @testset "Localization" begin
-        # Linear problem with d == p >> N_ens - Section 6.1 of Tong and Morzfeld (2022)
-        G(u) = u
-        N_ens = 10
-        p = 50
-        N_iter = 20
-        # Generate random truth
-        y = 10.0 * rand(p)
-        Γ = 1.0 * I
-
-        #### Define prior information on parameters
-        prior_distns = repeat([Parameterized(Normal(0.0, 0.5))], p)
-        constraints = repeat([[no_constraint()]], p)
-        prior_names = [string("u_", i) for i in 1:p]
-        prior = ParameterDistribution(prior_distns, constraints, prior_names)
-
-        initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
-
-        # Solve problem without localization
-        ekiobj_vanilla = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng)
-        for i in 1:N_iter
-            g_ens_vanilla = G(get_u_final(ekiobj_vanilla))
-            EKP.update_ensemble!(ekiobj_vanilla, g_ens_vanilla)
-        end
-        nonlocalized_error = get_error(ekiobj_vanilla)[end]
-
-        # Test different localizers
-        loc_methods = [Delta(), RBF(1.0), RBF(0.1)]
-
-        for loc_method in loc_methods
-            ekiobj = EKP.EnsembleKalmanProcess(
-                initial_ensemble,
-                y,
-                Γ,
-                Inversion();
-                rng = rng,
-                localization_method = loc_method,
-            )
-            @test isa(ekiobj.localizer, Localizer)
-
-            for i in 1:N_iter
-                g_ens = G(get_u_final(ekiobj))
-                EKP.update_ensemble!(ekiobj, g_ens, deterministic_forward_map = true)
-            end
-
-            # Test that localized version does better in the setting p >> N_ens
-            @test get_error(ekiobj)[end] < nonlocalized_error
-
-            # Test Schur product theorem
-            u_final = get_u_final(ekiobj)
-            g_final = get_g_final(ekiobj)
-            cov_ug = cov(u_final, g_final, dims = 2, corrected = false)
-            kernel = ekiobj.localizer.kernel
-            @test rank(cov_ug) < rank(kernel .* cov_ug)
-
-        end
-
-    end
 end

--- a/test/Localizers/runtests.jl
+++ b/test/Localizers/runtests.jl
@@ -1,0 +1,67 @@
+using Distributions
+using LinearAlgebra
+using Random
+using Test
+
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+using EnsembleKalmanProcesses.Localizers
+import EnsembleKalmanProcesses: construct_mean, construct_cov, construct_sigma_ensemble
+const EKP = EnsembleKalmanProcesses
+
+@testset "Localization" begin
+
+    # Seed for pseudo-random number generator
+    rng_seed = 42
+    rng = Random.MersenneTwister(rng_seed)
+
+    # Linear problem with d == p >> N_ens - Section 6.1 of Tong and Morzfeld (2022)
+    G(u) = u
+    N_ens = 10
+    p = 50
+    N_iter = 20
+    # Generate random truth
+    y = 10.0 * rand(p)
+    Γ = 1.0 * I
+
+    #### Define prior information on parameters
+    prior_distns = repeat([Parameterized(Normal(0.0, 0.5))], p)
+    constraints = repeat([[no_constraint()]], p)
+    prior_names = [string("u_", i) for i in 1:p]
+    prior = ParameterDistribution(prior_distns, constraints, prior_names)
+
+    initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
+
+    # Solve problem without localization
+    ekiobj_vanilla = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng)
+    for i in 1:N_iter
+        g_ens_vanilla = G(get_u_final(ekiobj_vanilla))
+        EKP.update_ensemble!(ekiobj_vanilla, g_ens_vanilla)
+    end
+    nonlocalized_error = get_error(ekiobj_vanilla)[end]
+
+    # Test different localizers
+    loc_methods = [Delta(), RBF(1.0), RBF(0.1), BernoulliDropout(0.1)]
+
+    for loc_method in loc_methods
+        ekiobj =
+            EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = loc_method)
+        @test isa(ekiobj.localizer, Localizer)
+
+        for i in 1:N_iter
+            g_ens = G(get_u_final(ekiobj))
+            EKP.update_ensemble!(ekiobj, g_ens, deterministic_forward_map = true)
+        end
+
+        # Test that localized version does better in the setting p >> N_ens
+        @test get_error(ekiobj)[end] < nonlocalized_error
+
+        # Test Schur product theorem
+        u_final = get_u_final(ekiobj)
+        g_final = get_g_final(ekiobj)
+        cov_ug = cov(u_final, g_final, dims = 2, corrected = false)
+        kernel = ekiobj.localizer.kernel
+        @test rank(cov_ug) < rank(kernel .* cov_ug)
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ end
         end
     end
 
-    for submodule in ["DataContainers", "ParameterDistributions", "Observations", "EnsembleKalmanProcess"]
+    for submodule in ["DataContainers", "ParameterDistributions", "Observations", "EnsembleKalmanProcess", "Localizers"]
         if all_tests || has_submodule(submodule) || "EnsembleKalmanProcesses" in ARGS
             include_test(submodule)
         end


### PR DESCRIPTION
This PR:

- Organizes the Localizers as a new module of the package, to declutter `EnsembleKalmanProcess.jl`,
- Literates docstrings describing non-evident localizer kernels,
- Adds a new Localizer that drops correlations as Bernoulli trials, based on the notion of Dropout in deep learning.