### PR TITLE
Add Project tomls and EKP dep for examples,

### DIFF
--- a/docs/src/installation_instructions.md
+++ b/docs/src/installation_instructions.md
@@ -6,8 +6,8 @@ command prompt and
 
 ```julia
 julia> ]
-(v1.5) pkg> add EnsembleKalmanProcesses
-(v1.5) pkg> instantiate
+(v1.7) pkg> add EnsembleKalmanProcesses
+(v1.7) pkg> instantiate
 ```
 
 This will install the latest tagged release of the package.
@@ -17,15 +17,15 @@ This will install the latest tagged release of the package.
     
     ```julia
     julia> ]
-    (v1.5) pkg> add EnsembleKalmanProcesses#main
-    (v1.5) pkg> instantiate
+    (v1.7) pkg> add EnsembleKalmanProcesses#main
+    (v1.7) pkg> instantiate
     ```
     
 You can run the tests via the package manager by:
 
 ```julia
 julia> ]
-(v1.5) pkg> test EnsembleKalmanProcesses
+(v1.7) pkg> test EnsembleKalmanProcesses
 ```
 
 ### Cloning the repository
@@ -38,16 +38,23 @@ clone the repository and then instantiate, e.g.,
 > julia --project -e 'using Pkg; Pkg.instantiate()'
 ```
 
+!!! info "Do I need to clone the repository?"
+    Most times, cloning the repository in not necessary. If you only want to use the package's
+    functionality, adding the packages as a dependency on your project is enough.
+
+### Running the test suite
+
 You can run the package's tests:
 
 ```
 > julia --project -e 'using Pkg; Pkg.test()'
 ```
-
-!!! info "Do I need to clone the repository?"
-    Most times, cloning the repository in not a necessity. If you only wanna use the package's
-    functionality then merely adding the packages as a dependency on your project will do the
-    job.
+Alternatively, you can do this from within the repository:
+```
+> julia --project
+julia> ]
+(EnsembleKalmanProcesses) pkg> test
+```
 
 ### Building the documentation locally
 
@@ -59,3 +66,28 @@ Once the project is built, you can build the project documentation under the `do
 ```
 
 The locally rendered HTML documentation can be viewed at `docs/build/index.html`
+
+### Running repository examples
+
+We have a selection of examples, found within the `examples/` directory to demonstrate different use of our toolbox.
+Each example directory contains a `Project.toml`
+
+To build with the latest `EnsembleKalmanProcesses.jl` release:
+```
+> cd examples/example-name/
+> julia --project -e 'using Pkg; Pkg.instantiate()'
+> julia --project example-file-name.jl
+```
+If you wish to run a local modified version of `EnsembleKalmanProcesses.jl` then try the following (starting from the `EnsembleKalmanProcesses.jl` package root)
+```
+> cd examples/example-name/
+> julia --project 
+> julia> ]
+> (example-name)> rm EnsembleKalmanProcesses.jl
+> (example-name)> dev ../..
+> (example-name)> instantiate
+```
+followed by
+```
+> julia --project example-file-name.jl
+```

--- a/examples/Lorenz/Project.toml
+++ b/examples/Lorenz/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/examples/LossMinimization/Project.toml
+++ b/examples/LossMinimization/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/examples/SparseLossMinimization/Project.toml
+++ b/examples/SparseLossMinimization/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"


### PR DESCRIPTION
## Purpose and Content
To add `Project.toml` files for `LossMinimization`, `SparseLossMinimization` and updates `Lorenz`, also adds some docs for running the examples
Fixes #171

## Benefits and Risks
- Examples can now run immediately after instantiation.
- Users now have docs to tell them how to instantiate examples and run them.
- Project tomls increase consistent behavior.

## PR Checklist
- [x] This PR has a corresponding issue OR is linked to an SDI.
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] Documentation has been added/updated OR N/A.
