### PR TITLE
Cast empirical covariance to symmetric.

### DIFF
--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -296,7 +296,7 @@ function sample_empirical_gaussian(
     n::IT;
     inflation::Union{FT, Nothing} = nothing,
 ) where {FT <: Real, IT <: Int}
-    cov_u_new = cov(u, u, dims = 2)
+    cov_u_new = Symmetric(cov(u, u, dims = 2))
     if !isposdef(cov_u_new)
         @warn string("Sample covariance matrix over ensemble is singular.", "\n Appplying variance inflation.")
         if isnothing(inflation)


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

- Fixes #170 by casting the covariance to Symmetric, which should avoid complex eigenvalues due to discrete precision arithmetic.
