### PR TITLE
Include expected warning text in @test_logs

### DIFF
--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -516,10 +516,13 @@ const EKP = EnsembleKalmanProcesses
         for i in 2:7
             g[:, i] .= NaN
         end
-        @test_logs (:warn,) split_indices_by_success(g)
+        @test_logs (:warn, r"More than 50% of runs produced NaNs") match_mode = :any split_indices_by_success(g)
 
         u = rand(10, 4)
-        @test_logs (:warn,) sample_empirical_gaussian(u, 2)
+        @test_logs (:warn, r"Sample covariance matrix over ensemble is singular.") match_mode = :any sample_empirical_gaussian(
+            u,
+            2,
+        )
         @test_throws PosDefException sample_empirical_gaussian(u, 2, inflation = 0.0)
     end
 


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

### Purpose
Change use of `@test_logs` to allow unit tests to pass when dependencies raise deprecation warnings. The writeup in issue #175 makes the case that the solution implemented here is the best way to deal with the case where the deprecation warning is raised in code we don't control. 

### Content
For all uses of `@test_logs` in unit tests,
1) add a filter to match the text of the expected warning message,
2) add `match_mode=:any`, to allow the test to pass when deprecation errors are raised.



## Benefits and Risks

### Benefits
Unit test suite now passes without needing to wait for the deprecations in Distributions.jl to be fixed in a new release;

### Risks
If other, "serious" warnings are raised in addition to the warning being tested for, this implementation will give a false negative. As discussed in issue #175, as far as I know there's no way to optionally filter out deprecation warnings only.

## Linked Issues
- Closes #175

## PR Checklist
- [X] This PR has a corresponding issue OR is linked to an SDI.
- [X] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [X] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [X] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [X] I linted my code on my local machine prior to submission OR N/A.
- [X] Unit tests are included OR N/A.
- [X] Code used in an integration test OR N/A.
- [X] All tests ran successfully on my local machine OR N/A.
- [X] All classes, modules, and function contain docstrings OR N/A.
- [X] Documentation has been added/updated OR N/A.
