### PR TITLE
Add cutoff to SEC localizer

### DIFF
--- a/examples/Localization/localization_example_lorenz96.jl
+++ b/examples/Localization/localization_example_lorenz96.jl
@@ -107,6 +107,15 @@ for i in 1:N_iter
     EKP.update_ensemble!(ekiobj_sec, g_ens, deterministic_forward_map = true)
 end
 
+# Test SEC with cutoff
+ekiobj_sec_cutoff =
+    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SEC(1.0, 0.1))
+
+for i in 1:N_iter
+    g_ens = G(get_u_final(ekiobj_sec_cutoff))
+    EKP.update_ensemble!(ekiobj_sec_cutoff, g_ens, deterministic_forward_map = true)
+end
+
 # Test SECFisher
 ekiobj_sec_fisher =
     EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SECFisher())
@@ -124,7 +133,9 @@ cov_localized = ekiobj_sec.localizer.localize(cov_est)
 fig = plot(get_error(ekiobj_vanilla), label = "No localization")
 plot!(get_error(ekiobj_bernoulli), label = "Bernoulli")
 plot!(get_error(ekiobj_sec), label = "SEC (Lee, 2021)")
-plot!(get_error(ekiobj_sec_fisher), label = "SEC (Flowerdew, 2015)")
+plot!(get_error(ekiobj_sec_fisher), label = "SECFisher (Flowerdew, 2015)")
+plot!(get_error(ekiobj_sec_cutoff), label = "SEC with cutoff")
+
 xlabel!("Iterations")
 ylabel!("Error")
 savefig(fig, "result.png")

--- a/test/Localizers/runtests.jl
+++ b/test/Localizers/runtests.jl
@@ -42,7 +42,7 @@ const EKP = EnsembleKalmanProcesses
     nonlocalized_error = get_error(ekiobj_vanilla)[end]
 
     # Test different localizers
-    loc_methods = [Delta(), RBF(1.0), RBF(0.1), BernoulliDropout(0.1), SEC(10.0), SECFisher()]
+    loc_methods = [Delta(), RBF(1.0), RBF(0.1), BernoulliDropout(0.1), SEC(10.0), SECFisher(), SEC(1.0, 0.1)]
 
     for loc_method in loc_methods
         ekiobj =


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

Adds the option to apply a cutoff below which SEC-corrected covariances are set to 0, sparsifying the covariance matrix. This follows the logic of kernels used in data assimilation which have a compact support, like the Gaspari-Cohn function.

## Benefits and Risks

Explore the usefulness of correlation sparseness, addition of a novel localization function (not used yet in the literature?). So far it is looking good! (See plot below).

## PR Checklist
- [x] I linted my code on my local machine prior to submission OR N/A.
- [x] Unit tests are included OR N/A.
- [x] Code used in an integration test OR N/A.
- [x] All tests ran successfully on my local machine OR N/A.
- [x] All classes, modules, and function contain docstrings OR N/A.
- [ ] Documentation has been added/updated OR N/A.
