### PR TITLE
Fixes CI to Julia 1.7.3, tests not yet working for 1.8

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -15,7 +15,7 @@ jobs:
        matrix:
         version:
           - '1.6' # Long-Term Support release
-          - '1' # Latest 1.x release of julia
+          - '1.7.3' # Latest 1.x release of julia
         os:
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

The unit tests do not work yet with Julia 1.8. The CI is fixed to the 1.6+1.7.3 versions until the issues with Julia 1.8.0 are resolved.