### PR TITLE
Test on latest Julia version (~1.8)

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -15,7 +15,7 @@ jobs:
        matrix:
         version:
           - '1.6' # Long-Term Support release
-          - '1.7.3' # Latest 1.x release of julia
+          - '1' # Latest 1.x release of julia
         os:
           - ubuntu-latest
           - windows-latest

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -101,7 +101,17 @@ function eki_update(
 
     # N_obs × N_obs \ [N_obs × N_ens]
     # --> tmp is [N_obs × N_ens]
-    tmp = FT.((cov_gg + obs_noise_cov) \ (y - g))
+    tmp = try
+        FT.((cov_gg + obs_noise_cov) \ (y - g))
+    catch e
+        if e isa SingularException
+            LHS = Matrix{BigFloat}(cov_gg + obs_noise_cov)
+            RHS = Matrix{BigFloat}(y - g)
+            FT.(LHS \ RHS)
+        else
+            rethrow(e)
+        end
+    end
     return u + (cov_ug * tmp) # [N_par × N_ens]  
 end
 


### PR DESCRIPTION
# PULL REQUEST

## Purpose and Content

Update package to be compatible with Julia v1.8. Compatibility does not seem to be automatic, since our tests are not passing.