### PR TITLE
ParameterDistributions.jl improvements

### DIFF
--- a/docs/src/API/ParameterDistributions.md
+++ b/docs/src/API/ParameterDistributions.md
@@ -20,6 +20,8 @@ get_name
 get_dimensions
 get_n_samples
 get_all_constraints
+get_bounds
+get_constraint_type
 batch
 get_distribution
 sample

--- a/test/DataContainers/runtests.jl
+++ b/test/DataContainers/runtests.jl
@@ -1,18 +1,18 @@
 using Test
 using Distributions
 using Random
-
+using LinearAlgebra
 using EnsembleKalmanProcesses.DataContainers
 
 @testset "DataContainers" begin
     rng = Random.MersenneTwister(2021)
 
-    parameter_samples = rand(rng, MvNormal(2, 0.1), 10) #10 samples of 4D params
-    data_samples = rand(rng, MvNormal(12, 2), 10) #10 samples of 12D data
+    parameter_samples = rand(rng, MvNormal(zeros(2), 0.1 * I), 10) #10 samples of 2D params
+    data_samples = rand(rng, MvNormal(zeros(12), 2 * I), 10) #10 samples of 12D data
     data_samples_short = data_samples[:, 1:(end - 1)]
 
-    new_parameter_samples = rand(rng, MvNormal(2, 0.1), 10) #10 samples of 4D params
-    new_data_samples = rand(rng, MvNormal(12, 2), 10) #10 samples of 12D data
+    new_parameter_samples = rand(rng, MvNormal(zeros(2), 0.1 * I), 10) #10 samples of 4D params
+    new_data_samples = rand(rng, MvNormal(zeros(12), 2 * I), 10) #10 samples of 12D data
     new_data_samples_short = new_data_samples[:, 1:(end - 1)]
 
     #test DataContainer


### PR DESCRIPTION
## Purpose 
Fixes #184 and #192, also small update to remove warning in DataContainers/ParameterDistributions test. This works towards a better interface for ParameterDistributions. 

## Content
- Extending `constrained_gaussian` to multidimensional distirbutions by adding a `repeats=N` keyword with `N=1` default.
- Adds Types constraints into `NoConstraint` `BoundedBelow` `BoundedAbove` and `Bounded`
- Adds "parameters" to constraints, containing a Dict (or nothing). allows extraction of values of interest. for example 
`x = bounded_below(3.0)`  stores  `x.parameters = Dict("lower_bound" => 3.0)`
- extending `==` to Constraints (based on the above `parameters` and `Types`, as constraints are functions so hard to equate) 
- extending `==` to ParameterDistributions for easier testing calls
- Miscellaneous: Removed the `MvNormal(int,real)` calls that are now deprecated, replacing with `MvN(zeros(int), real*I)`

