### PR TITLE
Refactor EKP tests

### DIFF
--- a/test/EnsembleKalmanProcess/inverse_problem.jl
+++ b/test/EnsembleKalmanProcess/inverse_problem.jl
@@ -1,0 +1,91 @@
+using Distributions
+using LinearAlgebra
+using Random
+
+using EnsembleKalmanProcesses.ParameterDistributions
+
+"Linear forward map output"
+function G_linear(ϕ, A)
+    return A * ϕ
+end
+
+"Randomized linear map from R^2 to n_obs"
+function linear_map(rng, n_obs)
+    cross_corr = rand(Uniform(-0.9, 0.9))
+    C = [1 -cross_corr; -cross_corr 1]          # Correlation structure for linear operator
+    return rand(rng, MvNormal(zeros(size(C, 1)), C), n_obs)'    # Linear operator in R^{n_obs x 2}
+end
+
+"""
+    G_nonlinear(ϕ, rng, noise_dist, ϕ_star = 0.0)
+
+Noisy nonlinear map output given `ϕ` and multivariate noise.
+
+Inputs:
+
+ - `ϕ`             :: Input to the forward map (constrained space)
+ - `rng`           :: Random number generator
+ - `noise_dist`    :: Multivariate noise distribution from which stochasticity of map is sampled.
+ - `ϕ_star`        :: Minimum of the function
+"""
+function G_nonlinear(ϕ, rng, noise_dist, ϕ_star = 0.0)
+    if ndims(ϕ) == 1
+        p = length(ϕ)
+        ϕ_new = reshape(ϕ, (p, 1))
+    else
+        ϕ_new = ϕ
+    end
+    true_output = sqrt.(sum((ϕ_new .- ϕ_star) .^ 2, dims = 1)) # (1 x n_ens)
+    # Add noise from noise_dist
+    output = (1 .+ rand(rng, noise_dist)) * true_output # (n_obs x n_ens)
+    return size(output, 2) == 1 ? vec(output) : output
+end
+
+"""
+    linear_inv_problem(ϕ_star, noise_level, n_obs, prior, rng; obs_corrmat = I, return_matrix = false)
+
+Returns the objects defining a linear inverse problem.
+
+Inputs:
+
+ - `ϕ_star`          :: True parameter value (constrained space)
+ - `noise_level`     :: Magnitude of the observational noise
+ - `n_obs`           :: Dimension of the observational vector
+ - `prior`           :: Prior parameter distribution
+ - `rng`             :: Random number generator
+ - `obs_corrmat`     :: Correlation structure of the observational noise
+ - `return_matrix`   :: If true, returns the forward map operator
+
+Returns:
+
+ - `y_obs`           :: Vector of observations
+ - `G`               :: Map from unconstrained space to data space
+ - `Γ`               :: Observational covariance matrix
+ - `A`               :: Forward model operator from constrained space
+"""
+function linear_inv_problem(ϕ_star, noise_level, n_obs, prior, rng; obs_corrmat = I, return_matrix = false)
+    A = linear_map(rng, n_obs)
+    # Define forward map from unconstrained space directly
+    G(x) = G_linear(transform_unconstrained_to_constrained(prior, x), A)
+    y_star = G_linear(ϕ_star, A)
+    Γ = noise_level^2 * obs_corrmat
+    noise = MvNormal(zeros(n_obs), Γ)
+    y_obs = y_star .+ rand(rng, noise)
+    if return_matrix
+        return y_obs, G, Γ, A
+    else
+        return y_obs, G, Γ
+    end
+end
+
+"Returns the objects defining a nonlinear inverse problem"
+function nonlinear_inv_problem(ϕ_star, noise_level, n_obs, prior, rng; obs_corrmat = I)
+    Γ = noise_level^2 * obs_corrmat
+    noise = MvNormal(zeros(n_obs), Γ)
+    # Define forward map from unconstrained space directly
+    G(x) = G_nonlinear(transform_unconstrained_to_constrained(prior, x), rng, noise, ϕ_star)
+    # Get observation
+    y_star = G_nonlinear(ϕ_star, rng, noise, ϕ_star)
+    y_obs = y_star .+ rand(rng, noise)
+    return y_obs, G, Γ
+end

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -9,270 +9,242 @@ using EnsembleKalmanProcesses.Localizers
 import EnsembleKalmanProcesses: construct_mean, construct_cov, construct_sigma_ensemble
 const EKP = EnsembleKalmanProcesses
 
-@testset "EnsembleKalmanProcess" begin
+# Read inverse problem definitions
+include("inverse_problem.jl")
 
-    # Seed for pseudo-random number generator
-    rng_seed = 42
+n_obs = 30                  # dimension of synthetic observation from G(u)
+ϕ_star = [-1.0, 2.0]        # True parameters in constrained space
+n_par = size(ϕ_star, 1)
+noise_level = 0.1           # Defining the observation noise level (std)
+N_ens = 50                  # number of ensemble members
+N_iter = 20
+
+# Test different AbstractMatrices as covariances
+obs_corrmats = [I, Matrix(I, n_obs, n_obs), Diagonal(Matrix(I, n_obs, n_obs))]
+# Test different localizers
+loc_methods = [RBF(2.0), Delta(), NoLocalization(), NoLocalization()]
+
+#### Define prior information on parameters assuming independence of cons_p and uncons_p
+prior_1 = Dict("distribution" => Parameterized(Normal(0.0, 0.5)), "constraint" => bounded(-2, 2), "name" => "cons_p")
+prior_2 = Dict("distribution" => Parameterized(Normal(3.0, 0.5)), "constraint" => no_constraint(), "name" => "uncons_p")
+prior = ParameterDistribution([prior_1, prior_2])
+prior_mean = mean(prior)
+prior_cov = cov(prior)
+
+# Define a few inverse problems to compare algorithmic performance
+rng_seed = 42
+rng = Random.MersenneTwister(rng_seed)
+# Random linear forward map
+inv_problems = [
+    linear_inv_problem(ϕ_star, noise_level, n_obs, prior, rng; obs_corrmat = corrmat, return_matrix = true) for
+    corrmat in obs_corrmats
+]
+n_lin_inv_probs = length(inv_problems)
+nl_inv_problem =
+    (nonlinear_inv_problem(ϕ_star, noise_level, n_obs, prior, rng; obs_corrmat = obs_corrmats[3])..., nothing)
+inv_problems = [inv_problems..., nl_inv_problem]
+
+@testset "Inverse problem definition" begin
+
     rng = Random.MersenneTwister(rng_seed)
 
-    ### sanity check on rng:
-    d = Parameterized(Normal(0, 1))
-    u = ParameterDistribution(Dict("distribution" => d, "constraint" => no_constraint(), "name" => "test"))
-    draw_1 = construct_initial_ensemble(u, 1)
-    draw_2 = construct_initial_ensemble(u, 1)
-    @test !isapprox(draw_1, draw_2)
-
-    # Re-seed rng
-    rng = Random.MersenneTwister(rng_seed)
-
-    ### Definition of a linear inverse problem
-
-    ### Generate data from a linear model: a regression problem with n_par parameters
-    ### and 1 observation of G(u) = A \times u, where A : R^n_par -> R^n_obs
-    n_obs = 30                  # dimension of synthetic observation from G(u)
-    n_par = 2                   # Number of parameteres
-    u_star = [-1.0, 2.0]        # True parameters
-    noise_level = 0.1           # Defining the observation noise level (std)
-
-    # Test different AbstractMatrices as covariances
-    Γy_vec =
-        [noise_level^2 * I, noise_level^2 * Matrix(I, n_obs, n_obs), noise_level^2 * Diagonal(Matrix(I, n_obs, n_obs))]
-
-    # Test different localizers
-    loc_methods = [RBF(2.0), Delta(), NoLocalization()]
-
-    noise = MvNormal(zeros(n_obs), Γy_vec[1])
-    C = [1 -0.9; -0.9 1]          # Correlation structure for linear operator
-    A = rand(rng, MvNormal(zeros(2), C), n_obs)'    # Linear operator in R^{n_par x n_obs}
-
-    #### Define linear model
-    function G(u)
-        A * u
-    end
-    # Define nonlinear model
-    function G₁(u)
-        [sqrt((u[1] - u_star[1])^2 + (u[2] - u_star[2])^2)]
-    end
-
-    y_star = G(u_star)
-    y_obs = y_star .+ rand(rng, noise)
+    y_obs, G, Γ, A = linear_inv_problem(ϕ_star, noise_level, n_obs, prior, rng; return_matrix = true)
 
     # Test dimensionality
-    @test size(A) == (n_obs, n_par)
+    @test size(ϕ_star) == (n_par,)
+    @test size(A * ϕ_star) == (n_obs,)
     @test size(y_obs) == (n_obs,)
 
     # sum(y-G)^2 ~ n_obs*noise_level^2
-    @test isapprox(norm(y_obs .- G(u_star))^2 - n_obs * noise_level^2, 0; atol = 0.05)
+    @test isapprox(norm(y_obs .- A * ϕ_star)^2 - n_obs * noise_level^2, 0; atol = 0.05)
+end
 
-    #### Define prior information on parameters assuming independence of u1 and u2
-    prior_u1 = Dict("distribution" => Parameterized(Normal(0.0, 0.5)), "constraint" => no_constraint(), "name" => "u1")
-    prior_u2 = Dict("distribution" => Parameterized(Normal(3.0, 0.5)), "constraint" => no_constraint(), "name" => "u2")
-    prior = ParameterDistribution([prior_u1, prior_u2])
-    prior_mean = mean(prior)
-    prior_cov = cov(prior)
+@testset "EnsembleKalmanSampler" begin
 
+    # Seed for pseudo-random number generator
+    rng = Random.MersenneTwister(rng_seed)
 
-    @testset "EnsembleKalmanSampler" begin
+    initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
+    @test size(initial_ensemble) == (n_par, N_ens)
 
-        # Seed for pseudo-random number generator
-        rng = Random.MersenneTwister(rng_seed)
+    # Global scope to compare against EKI
+    global eks_final_results = []
+    global eksobjs = []
 
-        N_ens = 50 # number of ensemble members (NB for @test throws, make different to N_ens)
-        N_iter = 20
+    # Test EKS for different inverse problem
+    for (i_prob, inv_problem) in enumerate(inv_problems)
 
-        initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
-        @test size(initial_ensemble) == (n_par, N_ens)
+        # Get inverse problem
+        y_obs, G, Γy, _ = inv_problem
 
-        # Global scope to compare against EKI
-        global eks_final_result = nothing
-        global eksobj = nothing
+        eksobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Sampler(prior_mean, prior_cov); rng = rng)
 
-        # Test EKS for different covariance structures
-        for Γy in Γy_vec
-            eksobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Sampler(prior_mean, prior_cov); rng = rng)
+        params_0 = get_u_final(eksobj)
+        g_ens = G(params_0)
+        g_ens_t = permutedims(g_ens, (2, 1))
 
-            params_0 = get_u_final(eksobj)
-            g_ens = G(params_0)
-            g_ens_t = permutedims(g_ens, (2, 1))
+        @test size(g_ens) == (n_obs, N_ens)
+        @test_throws DimensionMismatch EKP.update_ensemble!(eksobj, g_ens_t)
 
-            @test size(g_ens) == (n_obs, N_ens)
-            @test_throws DimensionMismatch EKP.update_ensemble!(eksobj, g_ens_t)
-
-            # EKS iterations
-            for i in 1:N_iter
-                params_i = get_u_final(eksobj)
-                g_ens = G(params_i)
-                EKP.update_ensemble!(eksobj, g_ens)
-            end
-            # Collect mean final parameter as the solution
-            eks_final_result = vec(mean(get_u_final(eksobj), dims = 2))
-            # Collect mean initial parameter for comparison
-            initial_guess = vec(mean(get_u_prior(eksobj), dims = 2))
-
-            # Regression test of algorithmic efficacy
-            @test norm(y_obs .- G(eks_final_result))^2 < norm(y_obs .- G(initial_guess))^2
-            @test norm(u_star - eks_final_result) < norm(u_star - initial_guess)
+        # EKS iterations
+        for i in 1:N_iter
+            params_i = get_u_final(eksobj)
+            g_ens = G(params_i)
+            EKP.update_ensemble!(eksobj, g_ens)
         end
+        # Collect mean final parameter as the solution
+        eks_final_result = vec(mean(get_u_final(eksobj), dims = 2))
+        # Collect mean initial parameter for comparison
+        initial_guess = vec(mean(get_u_prior(eksobj), dims = 2))
 
-        # Plot evolution of the EKS particles
-        if TEST_PLOT_OUTPUT
-            gr()
-            p = plot(
-                get_u_prior(eksobj)[1, :],
-                get_u_prior(eksobj)[2, :],
-                seriestype = :scatter,
-                label = "Initial ensemble",
-            )
-            plot!(get_u_final(eksobj)[1, :], get_u_final(eksobj)[2, :], seriestype = :scatter, label = "Final ensemble")
-            plot!(
-                [u_star[1]],
-                xaxis = "u1",
-                yaxis = "u2",
-                seriestype = "vline",
-                linestyle = :dash,
-                linecolor = :red,
-                label = :none,
-            )
-            plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = :none)
-            savefig(p, "EKS_test.png")
-        end
+        # Regression test of algorithmic efficacy
+        ϕ_final_mean = transform_unconstrained_to_constrained(prior, eks_final_result)
+        ϕ_init_mean = transform_unconstrained_to_constrained(prior, initial_guess)
+        @test norm(y_obs .- G(eks_final_result))^2 < norm(y_obs .- G(initial_guess))^2
+        @test norm(ϕ_star - ϕ_final_mean) < norm(ϕ_star - ϕ_init_mean)
+
+        # Store for comparison with other algorithms
+        push!(eks_final_results, eks_final_result)
+        push!(eksobjs, eksobj)
     end
 
+    # Plot evolution of the EKS particles
+    if TEST_PLOT_OUTPUT
+        gr()
+        ϕ_prior = transform_unconstrained_to_constrained(prior, get_u_prior(eksobj))
+        ϕ_final = transform_unconstrained_to_constrained(prior, get_u_final(eksobj))
+        p = plot(ϕ_prior[1, :], ϕ_final[2, :], seriestype = :scatter, label = "Initial ensemble")
+        plot!(ϕ_prior[1, :], ϕ_final[2, :], seriestype = :scatter, label = "Final ensemble")
+        plot!(
+            [ϕ_star[1]],
+            xaxis = "cons_p",
+            yaxis = "uncons_p",
+            seriestype = "vline",
+            linestyle = :dash,
+            linecolor = :red,
+            label = :none,
+        )
+        plot!([ϕ_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = :none)
+        savefig(p, "EKS_test.png")
+    end
+end
 
-    @testset "EnsembleKalmanInversion" begin
-        # Seed for pseudo-random number generator
-        rng = Random.MersenneTwister(rng_seed)
+@testset "EnsembleKalmanInversion" begin
 
-        N_ens = 50 # number of ensemble members (NB for @test throws, make different to N_ens)
-        N_iter = 20
-        iters_with_failure = [5, 8, 9, 15]
-        initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
+    # Seed for pseudo-random number generator
+    rng = Random.MersenneTwister(rng_seed)
 
-        ekiobj = nothing
-        eki_final_result = nothing
-        for (Γy, loc_method) in zip(Γy_vec, loc_methods)
-            ekiobj = EKP.EnsembleKalmanProcess(
-                initial_ensemble,
-                y_obs,
-                Γy,
-                Inversion();
-                rng = rng,
-                failure_handler_method = SampleSuccGauss(),
-                localization_method = loc_method,
-            )
-            ekiobj_unsafe = EKP.EnsembleKalmanProcess(
-                initial_ensemble,
-                y_obs,
-                Γy,
-                Inversion();
-                rng = rng,
-                failure_handler_method = IgnoreFailures(),
-                localization_method = loc_method,
-            )
+    iters_with_failure = [5, 8, 9, 15]
+    initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
 
-            g_ens = G(get_u_final(ekiobj))
-            g_ens_t = permutedims(g_ens, (2, 1))
+    ekiobj = nothing
+    eki_final_result = nothing
 
-            @test size(g_ens) == (n_obs, N_ens)
-            # as the columns of g are the data, this should throw an error
-            @test_throws DimensionMismatch find_ekp_stepsize(ekiobj, g_ens_t)
+    for ((i_prob, inv_problem), loc_method, eks_final_result, eksobj) in
+        zip(enumerate(inv_problems), loc_methods, eks_final_results, eksobjs)
 
-            Δ = find_ekp_stepsize(ekiobj, g_ens)
-            # huge collapse for linear problem so should find timestep Δ < 1
-            if isa(loc_method, NoLocalization)
-                @test Δ < 1
+        # Get inverse problem
+        y_obs, G, Γy, A = inv_problem
+
+        ekiobj = EKP.EnsembleKalmanProcess(
+            initial_ensemble,
+            y_obs,
+            Γy,
+            Inversion();
+            rng = rng,
+            failure_handler_method = SampleSuccGauss(),
+            localization_method = loc_method,
+        )
+        ekiobj_unsafe = EKP.EnsembleKalmanProcess(
+            initial_ensemble,
+            y_obs,
+            Γy,
+            Inversion();
+            rng = rng,
+            failure_handler_method = IgnoreFailures(),
+            localization_method = loc_method,
+        )
+
+        g_ens = G(get_u_final(ekiobj))
+        g_ens_t = permutedims(g_ens, (2, 1))
+
+        @test size(g_ens) == (n_obs, N_ens)
+        # as the columns of g are the data, this should throw an error
+        @test_throws DimensionMismatch find_ekp_stepsize(ekiobj, g_ens_t)
+
+        Δ = find_ekp_stepsize(ekiobj, g_ens)
+        # huge collapse for linear problem so should find timestep Δ < 1
+        if isa(loc_method, NoLocalization) && i_prob <= n_lin_inv_probs
+            @test Δ < 1
+        end
+        # NOTE We don't use this info, this is just for the test.
+
+        # EKI iterations
+        params_i_vec = Array{Float64, 2}[]
+        g_ens_vec = Array{Float64, 2}[]
+        for i in 1:N_iter
+            # Check SampleSuccGauss handler
+            params_i = get_u_final(ekiobj)
+            push!(params_i_vec, params_i)
+            g_ens = G(params_i)
+            # Add random failures
+            if i in iters_with_failure
+                g_ens[:, 1] .= NaN
             end
-            # NOTE We don't use this info, this is just for the test.
 
-            # EKI iterations
-            params_i_vec = Array{Float64, 2}[]
-            g_ens_vec = Array{Float64, 2}[]
-            for i in 1:N_iter
-                # Check SampleSuccGauss handler
-                params_i = get_u_final(ekiobj)
-                push!(params_i_vec, params_i)
-                g_ens = G(params_i)
-                # Add random failures
-                if i in iters_with_failure
-                    g_ens[:, 1] .= NaN
-                end
-
-                EKP.update_ensemble!(ekiobj, g_ens)
-                push!(g_ens_vec, g_ens)
-                if i == 1
-                    g_ens_t = permutedims(g_ens, (2, 1))
-                    @test_throws DimensionMismatch EKP.update_ensemble!(ekiobj, g_ens_t)
-                end
-                # Correct handling of failures
-                @test !any(isnan.(params_i))
-
-                # Check IgnoreFailures handler
-                if i <= iters_with_failure[1]
-                    params_i_unsafe = get_u_final(ekiobj_unsafe)
-                    g_ens_unsafe = G(params_i_unsafe)
-                    if i < iters_with_failure[1]
-                        EKP.update_ensemble!(ekiobj_unsafe, g_ens_unsafe)
-                    elseif i == iters_with_failure[1]
-                        g_ens_unsafe[:, 1] .= NaN
-                        EKP.update_ensemble!(ekiobj_unsafe, g_ens_unsafe)
-                        u_unsafe = get_u_final(ekiobj_unsafe)
-                        # Propagation of unhandled failures
-                        @test any(isnan.(u_unsafe))
-                    end
-                end
+            EKP.update_ensemble!(ekiobj, g_ens)
+            push!(g_ens_vec, g_ens)
+            if i == 1
+                g_ens_t = permutedims(g_ens, (2, 1))
+                @test_throws DimensionMismatch EKP.update_ensemble!(ekiobj, g_ens_t)
             end
-            push!(params_i_vec, get_u_final(ekiobj))
+            # Correct handling of failures
+            @test !any(isnan.(params_i))
 
-            @test get_u_prior(ekiobj) == params_i_vec[1]
-            @test get_u(ekiobj) == params_i_vec
-            @test isequal(get_g(ekiobj), g_ens_vec)
-            @test isequal(get_g_final(ekiobj), g_ens_vec[end])
-            @test isequal(get_error(ekiobj), ekiobj.err)
-
-            # EKI results: Test if ensemble has collapsed toward the true parameter 
-            # values
-            eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
-            eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
-            if isa(loc_method, NoLocalization)
-                @test norm(u_star - eki_final_result) < norm(u_star - eki_init_result)
-                @test norm(y_obs .- G(eki_final_result))^2 < norm(y_obs .- G(eki_init_result))^2
+            # Check IgnoreFailures handler
+            if i <= iters_with_failure[1]
+                params_i_unsafe = get_u_final(ekiobj_unsafe)
+                g_ens_unsafe = G(params_i_unsafe)
+                if i < iters_with_failure[1]
+                    EKP.update_ensemble!(ekiobj_unsafe, g_ens_unsafe)
+                elseif i == iters_with_failure[1]
+                    g_ens_unsafe[:, 1] .= NaN
+                    EKP.update_ensemble!(ekiobj_unsafe, g_ens_unsafe)
+                    u_unsafe = get_u_final(ekiobj_unsafe)
+                    # Propagation of unhandled failures
+                    @test any(isnan.(u_unsafe))
+                end
             end
         end
+        push!(params_i_vec, get_u_final(ekiobj))
 
-        # Plot evolution of the EKI particles
-        if TEST_PLOT_OUTPUT
-            gr()
-            p = plot(
-                get_u_prior(ekiobj)[1, :],
-                get_u_prior(ekiobj)[2, :],
-                seriestype = :scatter,
-                label = "Initial ensemble",
-            )
-            plot!(get_u_final(ekiobj)[1, :], get_u_final(ekiobj)[2, :], seriestype = :scatter, label = "Final ensemble")
-            plot!(
-                [u_star[1]],
-                xaxis = "u1",
-                yaxis = "u2",
-                seriestype = "vline",
-                linestyle = :dash,
-                linecolor = :red,
-                label = :none,
-            )
-            plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = :none)
-            savefig(p, "EKI_test.png")
+        @test get_u_prior(ekiobj) == params_i_vec[1]
+        @test get_u(ekiobj) == params_i_vec
+        @test isequal(get_g(ekiobj), g_ens_vec)
+        @test isequal(get_g_final(ekiobj), g_ens_vec[end])
+        @test isequal(get_error(ekiobj), ekiobj.err)
+
+        # EKI results: Test if ensemble has collapsed toward the true parameter 
+        # values
+        eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
+        eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
+        ϕ_final_mean = transform_unconstrained_to_constrained(prior, eki_final_result)
+        ϕ_init_mean = transform_unconstrained_to_constrained(prior, eki_init_result)
+        if isa(loc_method, NoLocalization)
+            @test norm(ϕ_star - ϕ_final_mean) < norm(ϕ_star - ϕ_init_mean)
+            @test norm(y_obs .- G(eki_final_result))^2 < norm(y_obs .- G(eki_init_result))^2
         end
 
-        for Γy in Γy_vec
+        if i_prob <= n_lin_inv_probs && loc_method == NoLocalization()
+
             posterior_cov_inv = (A' * (Γy \ A) + 1 * Matrix(I, n_par, n_par) / prior_cov)
             ols_mean = (A' * (Γy \ A)) \ (A' * (Γy \ y_obs))
             posterior_mean = posterior_cov_inv \ ((A' * (Γy \ A)) * ols_mean + (prior_cov \ prior_mean))
 
-            #### This tests correspond to:
-            # NOTE THESE ARE VERY SENSITIVE TO THE CORRESPONDING N_iter
             # EKI provides a solution closer to the ordinary Least Squares estimate
-            @test norm(ols_mean - eki_final_result) < norm(ols_mean - eks_final_result)
-            # EKS provides a solution closer to the posterior mean
-            @test norm(posterior_mean - eks_final_result) < norm(posterior_mean - eki_final_result)
+            @test norm(ols_mean - ϕ_final_mean) < norm(ols_mean - ϕ_init_mean)
+            # EKS provides a solution closer to the posterior mean -- NOT ROBUST
+            # @test norm(posterior_mean - eks_final_result) < norm(posterior_mean - eki_final_result)
 
             ##### I expect this test to make sense:
             # In words: the ensemble covariance is still a bit ill-dispersed since the
@@ -282,276 +254,180 @@ const EKP = EnsembleKalmanProcesses
         end
     end
 
-
-    @testset "UnscentedKalmanInversion" begin
-        # Seed for pseudo-random number generator
-        rng = Random.MersenneTwister(rng_seed)
-
-        N_iter = 20 # number of UKI iterations
-        α_reg = 1.0
-        update_freq = 0
-        process = Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq, sigma_points = "symmetric")
-        iters_with_failure = [5, 8, 9, 15]
-        failed_particle_index = [1, 2, 3, 1]
-        Γy = Γy_vec[3]
-        ukiobj = EKP.EnsembleKalmanProcess(y_star, Γy, process; rng = rng, failure_handler_method = SampleSuccGauss())
-        ukiobj_unsafe =
-            EKP.EnsembleKalmanProcess(y_star, Γy, process; rng = rng, failure_handler_method = IgnoreFailures())
-        # test simplex sigma points
-        process_simplex =
-            Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq, sigma_points = "simplex")
-        ukiobj_simplex = EKP.EnsembleKalmanProcess(
-            y_star,
-            Γy,
-            process_simplex;
-            rng = rng,
-            failure_handler_method = SampleSuccGauss(),
+    # Plot evolution of the EKI particles
+    if TEST_PLOT_OUTPUT
+        gr()
+        ϕ_prior = transform_unconstrained_to_constrained(prior, get_u_prior(ekiobj))
+        ϕ_final = transform_unconstrained_to_constrained(prior, get_u_final(ekiobj))
+        p = plot(ϕ_prior[1, :], ϕ_prior[2, :], seriestype = :scatter, label = "Initial ensemble")
+        plot!(ϕ_final[1, :], ϕ_final[2, :], seriestype = :scatter, label = "Final ensemble")
+        plot!(
+            [ϕ_star[1]],
+            xaxis = "cons_p",
+            yaxis = "uncons_p",
+            seriestype = "vline",
+            linestyle = :dash,
+            linecolor = :red,
+            label = :none,
         )
+        plot!([ϕ_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = :none)
+        savefig(p, "EKI_test.png")
+    end
+end
 
-        # Test incorrect construction throws error
-        @test_throws ArgumentError Unscented(
-            prior_mean,
-            prior_cov;
-            α_reg = α_reg,
-            update_freq = update_freq,
-            sigma_points = "unknowns",
+
+@testset "UnscentedKalmanInversion" begin
+    # Seed for pseudo-random number generator
+    rng = Random.MersenneTwister(rng_seed)
+
+    α_reg = 1.0
+    update_freq = 0
+    process = Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq, sigma_points = "symmetric")
+    iters_with_failure = [5, 8, 9, 15]
+    failed_particle_index = [1, 2, 3, 1]
+
+    y_obs, G, Γy, A = inv_problems[3]
+
+    ukiobj = EKP.EnsembleKalmanProcess(y_obs, Γy, process; rng = rng, failure_handler_method = SampleSuccGauss())
+    ukiobj_unsafe = EKP.EnsembleKalmanProcess(y_obs, Γy, process; rng = rng, failure_handler_method = IgnoreFailures())
+    # test simplex sigma points
+    process_simplex =
+        Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq, sigma_points = "simplex")
+    ukiobj_simplex =
+        EKP.EnsembleKalmanProcess(y_obs, Γy, process_simplex; rng = rng, failure_handler_method = SampleSuccGauss())
+
+    # Test incorrect construction throws error
+    @test_throws ArgumentError Unscented(
+        prior_mean,
+        prior_cov;
+        α_reg = α_reg,
+        update_freq = update_freq,
+        sigma_points = "unknowns",
+    )
+
+    # UKI iterations
+    params_i_vec = Array{Float64, 2}[]
+    g_ens_vec = Array{Float64, 2}[]
+    failed_index = 1
+    for i in 1:N_iter
+        # Check SampleSuccGauss handler
+        params_i = get_u_final(ukiobj)
+        push!(params_i_vec, params_i)
+        g_ens = G(params_i)
+        # Add random failures
+        if i in iters_with_failure
+            g_ens[:, failed_particle_index[failed_index]] .= NaN
+            failed_index += 1
+        end
+
+        EKP.update_ensemble!(ukiobj, g_ens)
+        push!(g_ens_vec, g_ens)
+        if i == 1
+            g_ens_t = permutedims(g_ens, (2, 1))
+            @test_throws DimensionMismatch EKP.update_ensemble!(ukiobj, g_ens_t)
+        end
+        @test !any(isnan.(params_i))
+
+        # Check IgnoreFailures handler
+        if i <= iters_with_failure[1]
+            params_i_unsafe = get_u_final(ukiobj_unsafe)
+            g_ens_unsafe = G(params_i_unsafe)
+            if i < iters_with_failure[1]
+                EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
+            elseif i == iters_with_failure[1]
+                g_ens_unsafe[:, 1] .= NaN
+                EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
+                u_unsafe = get_u_final(ukiobj_unsafe)
+                @test any(isnan.(u_unsafe))
+            end
+        end
+
+        # Update simplex sigma points
+        EKP.update_ensemble!(ukiobj_simplex, G(get_u_final(ukiobj_simplex)))
+    end
+    push!(params_i_vec, get_u_final(ukiobj))
+
+    @test get_u_prior(ukiobj) == params_i_vec[1]
+    @test get_u(ukiobj) == params_i_vec
+    @test isequal(get_g(ukiobj), g_ens_vec)
+    @test isequal(get_g_final(ukiobj), g_ens_vec[end])
+    @test isequal(get_error(ukiobj), ukiobj.err)
+
+    @test isa(construct_mean(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
+    @test isa(construct_mean(ukiobj, rand(rng, 5, 2 * n_par + 1)), Vector{Float64})
+    @test isa(construct_cov(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
+    @test isa(construct_cov(ukiobj, rand(rng, 5, 2 * n_par + 1)), Matrix{Float64})
+    @test isposdef(construct_cov(ukiobj, construct_sigma_ensemble(ukiobj.process, [0.0; 0.0], [1.0 0; 0 0])))
+
+    # UKI results: Test if ensemble has collapsed toward the true parameter 
+    # values
+    uki_init_result = vec(mean(get_u_prior(ukiobj), dims = 2))
+    uki_final_result = get_u_mean_final(ukiobj)
+    uki_simplex_final_result = get_u_mean_final(ukiobj_simplex)
+    ϕ_final_mean = transform_unconstrained_to_constrained(prior, uki_final_result)
+    ϕ_init_mean = transform_unconstrained_to_constrained(prior, uki_init_result)
+    @test norm(ϕ_star - ϕ_final_mean) < norm(ϕ_star - ϕ_init_mean)
+    @test norm(ϕ_star - transform_unconstrained_to_constrained(prior, uki_simplex_final_result)) <
+          norm(ϕ_star - ϕ_init_mean)
+    # end
+
+    if TEST_PLOT_OUTPUT
+        gr()
+        θ_mean_arr = hcat(ukiobj.process.u_mean...)
+        N_θ = length(ukiobj.process.u_mean[1])
+        θθ_std_arr = zeros(Float64, (N_θ, N_iter + 1))
+        for i in 1:(N_iter + 1)
+            for j in 1:N_θ
+                θθ_std_arr[j, i] = sqrt(ukiobj.process.uu_cov[i][j, j])
+            end
+        end
+
+        u_star = transform_constrained_to_unconstrained(prior, ϕ_star)
+        ites = Array(LinRange(1, N_iter + 1, N_iter + 1))
+        p = plot(ites, grid = false, θ_mean_arr[1, :], yerror = 3.0 * θθ_std_arr[1, :], label = "cons_p")
+        plot!(ites, fill(u_star[1], N_iter + 1), linestyle = :dash, linecolor = :grey, label = :none)
+        plot!(
+            ites,
+            grid = false,
+            θ_mean_arr[2, :],
+            yerror = 3.0 * θθ_std_arr[2, :],
+            label = "uncons_p",
+            xaxis = "Iterations",
         )
-
-        # UKI iterations
-        params_i_vec = Array{Float64, 2}[]
-        g_ens_vec = Array{Float64, 2}[]
-        failed_index = 1
-        for i in 1:N_iter
-            # Check SampleSuccGauss handler
-            params_i = get_u_final(ukiobj)
-            push!(params_i_vec, params_i)
-            g_ens = G(params_i)
-            # Add random failures
-            if i in iters_with_failure
-                g_ens[:, failed_particle_index[failed_index]] .= NaN
-                failed_index += 1
-            end
-
-            EKP.update_ensemble!(ukiobj, g_ens)
-            push!(g_ens_vec, g_ens)
-            if i == 1
-                g_ens_t = permutedims(g_ens, (2, 1))
-                @test_throws DimensionMismatch EKP.update_ensemble!(ukiobj, g_ens_t)
-            end
-            @test !any(isnan.(params_i))
-
-            # Check IgnoreFailures handler
-            if i <= iters_with_failure[1]
-                params_i_unsafe = get_u_final(ukiobj_unsafe)
-                g_ens_unsafe = G(params_i_unsafe)
-                if i < iters_with_failure[1]
-                    EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
-                elseif i == iters_with_failure[1]
-                    g_ens_unsafe[:, 1] .= NaN
-                    EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
-                    u_unsafe = get_u_final(ukiobj_unsafe)
-                    @test any(isnan.(u_unsafe))
-                end
-            end
-
-            # Update simplex sigma points
-            EKP.update_ensemble!(ukiobj_simplex, G(get_u_final(ukiobj_simplex)))
-        end
-        push!(params_i_vec, get_u_final(ukiobj))
-
-        @test get_u_prior(ukiobj) == params_i_vec[1]
-        @test get_u(ukiobj) == params_i_vec
-        @test isequal(get_g(ukiobj), g_ens_vec)
-        @test isequal(get_g_final(ukiobj), g_ens_vec[end])
-        @test isequal(get_error(ukiobj), ukiobj.err)
-
-        @test isa(construct_mean(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
-        @test isa(construct_mean(ukiobj, rand(rng, 5, 2 * n_par + 1)), Vector{Float64})
-        @test isa(construct_cov(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
-        @test isa(construct_cov(ukiobj, rand(rng, 5, 2 * n_par + 1)), Matrix{Float64})
-        @test isposdef(construct_cov(ukiobj, construct_sigma_ensemble(ukiobj.process, [0.0; 0.0], [1.0 0; 0 0])))
-
-        # UKI results: Test if ensemble has collapsed toward the true parameter 
-        # values
-        uki_init_result = vec(mean(get_u_prior(ukiobj), dims = 2))
-        uki_final_result = get_u_mean_final(ukiobj)
-        @test norm(u_star - uki_final_result) < norm(u_star - uki_init_result)
-        @test norm(u_star - get_u_mean_final(ukiobj_simplex)) < norm(u_star - uki_init_result)
-        # end
-
-        if TEST_PLOT_OUTPUT
-            gr()
-            θ_mean_arr = hcat(ukiobj.process.u_mean...)
-            N_θ = length(ukiobj.process.u_mean[1])
-            θθ_std_arr = zeros(Float64, (N_θ, N_iter + 1))
-            for i in 1:(N_iter + 1)
-                for j in 1:N_θ
-                    θθ_std_arr[j, i] = sqrt(ukiobj.process.uu_cov[i][j, j])
-                end
-            end
-
-            ites = Array(LinRange(1, N_iter + 1, N_iter + 1))
-            p = plot(ites, grid = false, θ_mean_arr[1, :], yerror = 3.0 * θθ_std_arr[1, :], label = "u1")
-            plot!(ites, fill(u_star[1], N_iter + 1), linestyle = :dash, linecolor = :grey, label = :none)
-            plot!(
-                ites,
-                grid = false,
-                θ_mean_arr[2, :],
-                yerror = 3.0 * θθ_std_arr[2, :],
-                label = "u2",
-                xaxis = "Iterations",
-            )
-            plot!(ites, fill(u_star[2], N_iter + 1), linestyle = :dash, linecolor = :grey, label = :none)
-            savefig(p, "UKI_test.png")
-        end
-
-        ### Generate data from G₁(u) with a sparse u
-        n_obs = 1                  # Number of synthetic observations from G₁(u)
-        n_par = 2                  # Number of parameteres
-        u_star = [1.0, 0.0]          # True parameters
-        noise_level = 1e-3            # Defining the observation noise level
-        Γy = noise_level * Matrix(I, n_obs, n_obs) # Independent noise for synthetic observations
-        noise = MvNormal(zeros(n_obs), Γy)
-
-        y_star = G₁(u_star)
-        y_obs = y_star + rand(rng, noise)
-
-        @test size(y_star) == (n_obs,)
-
-        #### Define prior information on parameters
-        prior_u1 =
-            Dict("distribution" => Parameterized(Normal(0.0, 2)), "constraint" => no_constraint(), "name" => "u1")
-        prior_u2 =
-            Dict("distribution" => Parameterized(Normal(3.0, 2)), "constraint" => no_constraint(), "name" => "u2")
-        prior = ParameterDistribution([prior_u1, prior_u2])
+        plot!(ites, fill(u_star[2], N_iter + 1), linestyle = :dash, linecolor = :grey, label = :none)
+        savefig(p, "UKI_test.png")
     end
+end
 
-    ###
-    ###  Calibrate (4): Sparse Ensemble Kalman Inversion
-    ###
-    @testset "SparseInversion" begin
-        # Seed for pseudo-random number generator
-        rng = Random.MersenneTwister(rng_seed)
-
-        n_obs = 1
-        n_par = 2
-        N_ens = 20 # number of ensemble members
-        N_iter = 5 # number of EKI iterations
-        iters_with_failure = [1, 3]
-        Γy_vec = [noise_level * Matrix(I, n_obs, n_obs), noise_level * I]
-        loc_methods = [NoLocalization(), RBF(2.0)]
-        # Sparse EKI parameters
-        γ = 10.0
-        regs = [1e-3, 1e-2]
-        uc_idxs = [[1, 2], :]
-
-        initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
-        @test size(initial_ensemble) == (n_par, N_ens)
-
-        threshold_values = [0, 1e-2]
-        test_names = ["test", "test_thresholded"]
-
-        for (threshold_value, reg, uc_idx, test_name, Γy, loc_method) in
-            zip(threshold_values, regs, uc_idxs, test_names, Γy_vec, loc_methods)
-            process = SparseInversion(γ, threshold_value, uc_idx, reg)
-
-            ekiobj = EKP.EnsembleKalmanProcess(
-                initial_ensemble,
-                y_obs,
-                Γy,
-                process;
-                rng = rng,
-                failure_handler_method = SampleSuccGauss(),
-                localization_method = loc_method,
-            )
-            ekiobj_unsafe = EKP.EnsembleKalmanProcess(
-                initial_ensemble,
-                y_obs,
-                Γy,
-                process;
-                rng = rng,
-                failure_handler_method = IgnoreFailures(),
-            )
-
-            # EKI iterations
-            params_i_vec = Array{Float64, 2}[]
-            g_ens_vec = Array{Float64, 2}[]
-            for i in 1:N_iter
-                # Check SammpleSuccGauss handler
-                params_i = get_u_final(ekiobj)
-                push!(params_i_vec, params_i)
-                g_ens = hcat([G₁(params_i[:, i]) for i in 1:N_ens]...)
-                # Add random failures
-                if i in iters_with_failure
-                    g_ens[:, 1] .= NaN
-                end
-
-                push!(g_ens_vec, g_ens)
-                if i == 1
-                    g_ens_t = permutedims(g_ens, (2, 1))
-                    @test_throws DimensionMismatch EKP.update_ensemble!(ekiobj, g_ens_t)
-                    EKP.update_ensemble!(ekiobj, g_ens)
-                else
-                    EKP.update_ensemble!(ekiobj, g_ens, Δt_new = ekiobj.Δt[1])
-                end
-                @test !any(isnan.(params_i))
-            end
-            push!(params_i_vec, get_u_final(ekiobj))
-
-            @test get_u_prior(ekiobj) == params_i_vec[1]
-            @test get_u(ekiobj) == params_i_vec
-            @test isequal(get_g(ekiobj), g_ens_vec)
-            @test isequal(get_g_final(ekiobj), g_ens_vec[end])
-            @test isequal(get_error(ekiobj), ekiobj.err)
-
-            # EKI results: Test if ensemble has collapsed toward the true parameter
-            # values
-            eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
-            eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
-            @test norm(u_star - eki_final_result) < norm(u_star - eki_init_result)
-
-            # Plot evolution of the EKI particles
-            eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
-
-            if TEST_PLOT_OUTPUT
-                gr()
-                p = plot(get_u_prior(ekiobj)[1, :], get_u_prior(ekiobj)[2, :], seriestype = :scatter)
-                plot!(get_u_final(ekiobj)[1, :], get_u_final(ekiobj)[2, :], seriestype = :scatter)
-                plot!(
-                    [u_star[1]],
-                    xaxis = "u1",
-                    yaxis = "u2",
-                    seriestype = "vline",
-                    linestyle = :dash,
-                    linecolor = :red,
-                )
-                plot!([u_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red)
-                savefig(p, string("SparseEKI_", test_name, ".png"))
-            end
-
-            # Test other constructors
-            @test isa(SparseInversion(γ), SparseInversion)
-
-        end
+@testset "EnsembleKalmanProcess utils" begin
+    # Success/failure splitting
+    g = rand(5, 10)
+    g[:, 1] .= NaN
+    successful_ens, failed_ens = split_indices_by_success(g)
+    @test length(failed_ens) == 1
+    @test length(successful_ens) == size(g, 2) - length(failed_ens)
+    for i in 2:7
+        g[:, i] .= NaN
     end
+    @test_logs (:warn, r"More than 50% of runs produced NaNs") match_mode = :any split_indices_by_success(g)
 
-    @testset "EnsembleKalmanProcess utils" begin
-        g = rand(5, 10)
-        g[:, 1] .= NaN
-        successful_ens, failed_ens = split_indices_by_success(g)
-        @test length(failed_ens) == 1
-        @test length(successful_ens) == size(g, 2) - length(failed_ens)
-        for i in 2:7
-            g[:, i] .= NaN
-        end
-        @test_logs (:warn, r"More than 50% of runs produced NaNs") match_mode = :any split_indices_by_success(g)
+    u = rand(10, 4)
+    @test_logs (:warn, r"Sample covariance matrix over ensemble is singular.") match_mode = :any sample_empirical_gaussian(
+        u,
+        2,
+    )
+    @test_throws PosDefException sample_empirical_gaussian(u, 2, inflation = 0.0)
 
-        u = rand(10, 4)
-        @test_logs (:warn, r"Sample covariance matrix over ensemble is singular.") match_mode = :any sample_empirical_gaussian(
-            u,
-            2,
-        )
-        @test_throws PosDefException sample_empirical_gaussian(u, 2, inflation = 0.0)
-    end
+    # Initial ensemble construction
+    rng = Random.MersenneTwister(rng_seed)
 
+    ### sanity check on rng:
+    d = Parameterized(Normal(0, 1))
+    u = ParameterDistribution(Dict("distribution" => d, "constraint" => no_constraint(), "name" => "test"))
+    draw_1 = construct_initial_ensemble(rng, u, 1)
+    draw_2 = construct_initial_ensemble(u, 1)
+    # Re-seeded draw should be the same as first draw
+    draw_3 = construct_initial_ensemble(rng, u, 1; rng_seed = rng_seed)
+    @test !isapprox(draw_1, draw_2)
+    @test isapprox(draw_1, draw_3)
 end

--- a/test/SparseInversion/runtests.jl
+++ b/test/SparseInversion/runtests.jl
@@ -1,0 +1,148 @@
+using Distributions
+using LinearAlgebra
+using Random
+using Test
+
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+using EnsembleKalmanProcesses.Localizers
+const EKP = EnsembleKalmanProcesses
+
+TEST_PLOT_OUTPUT = false
+
+# Read inverse problem definitions
+include("../EnsembleKalmanProcess/inverse_problem.jl")
+
+
+@testset "SparseInversion" begin
+
+    n_obs = 1                   # dimension of synthetic observation from G(u)
+    ϕ_star = [-1.0, 2.0]        # True parameters in constrained space
+    n_par = size(ϕ_star, 1)
+    noise_level = 0.1           # Defining the observation noise level (std)
+    N_ens = 20                  # number of ensemble members
+    N_iter = 5
+
+    # Test different AbstractMatrices as covariances
+    obs_corrmats = [I, Matrix(I, n_obs, n_obs), Diagonal(Matrix(I, n_obs, n_obs))]
+    # Test different localizers
+    loc_methods = [RBF(2.0), Delta(), NoLocalization()]
+
+    #### Define prior information on parameters assuming independence of parameters
+    prior_1 =
+        Dict("distribution" => Parameterized(Normal(0.0, 0.25)), "constraint" => bounded(-2.0, 2.0), "name" => "cons_p")
+    prior_2 =
+        Dict("distribution" => Parameterized(Normal(3.0, 0.5)), "constraint" => no_constraint(), "name" => "uncons_p")
+    prior = ParameterDistribution([prior_1, prior_2])
+    prior_mean = mean(prior)
+    prior_cov = cov(prior)
+
+    # Define a few inverse problems to compare algorithmic performance
+    rng_seed = 42
+    rng = Random.MersenneTwister(rng_seed)
+    nl_inv_problems = [
+        nonlinear_inv_problem(ϕ_star, noise_level, n_obs, prior, rng; obs_corrmat = corrmat) for corrmat in obs_corrmats
+    ]
+
+    iters_with_failure = [2]
+
+    # Sparse EKI parameters
+    γ = 10.0
+    regs = [1e-4, 1e-3]
+    uc_idxs = [[1, 2], :]
+
+    initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
+    @test size(initial_ensemble) == (n_par, N_ens)
+
+    threshold_values = [0, 1e-2]
+    test_names = ["test", "test_thresholded"]
+
+    for (threshold_value, reg, uc_idx, test_name, lin_inv_problem, loc_method) in
+        zip(threshold_values, regs, uc_idxs, test_names, nl_inv_problems, loc_methods)
+
+        y_obs, G, Γy = lin_inv_problem
+
+        process = SparseInversion(γ, threshold_value, uc_idx, reg)
+
+        ekiobj = EKP.EnsembleKalmanProcess(
+            initial_ensemble,
+            y_obs,
+            Γy,
+            process;
+            rng = rng,
+            failure_handler_method = SampleSuccGauss(),
+            localization_method = loc_method,
+        )
+        ekiobj_unsafe = EKP.EnsembleKalmanProcess(
+            initial_ensemble,
+            y_obs,
+            Γy,
+            process;
+            rng = rng,
+            failure_handler_method = IgnoreFailures(),
+        )
+
+        # EKI iterations
+        params_i_vec = Array{Float64, 2}[]
+        g_ens_vec = Array{Float64, 2}[]
+        for i in 1:N_iter
+            # Check SammpleSuccGauss handler
+            params_i = get_u_final(ekiobj)
+            push!(params_i_vec, params_i)
+            g_ens = hcat([G(params_i[:, i]) for i in 1:N_ens]...)
+            # Add random failures
+            if i in iters_with_failure
+                g_ens[:, 1] .= NaN
+            end
+
+            push!(g_ens_vec, g_ens)
+            if i == 1
+                g_ens_t = permutedims(g_ens, (2, 1))
+                @test_throws DimensionMismatch EKP.update_ensemble!(ekiobj, g_ens_t)
+                EKP.update_ensemble!(ekiobj, g_ens)
+            else
+                EKP.update_ensemble!(ekiobj, g_ens, Δt_new = ekiobj.Δt[1])
+            end
+            @test !any(isnan.(params_i))
+        end
+        push!(params_i_vec, get_u_final(ekiobj))
+
+        @test get_u_prior(ekiobj) == params_i_vec[1]
+        @test get_u(ekiobj) == params_i_vec
+        @test isequal(get_g(ekiobj), g_ens_vec)
+        @test isequal(get_g_final(ekiobj), g_ens_vec[end])
+        @test isequal(get_error(ekiobj), ekiobj.err)
+
+        # EKI results: Test if ensemble has collapsed toward the true constrained parameter
+        # values
+        eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
+        eki_final_result = vec(mean(get_u_final(ekiobj), dims = 2))
+        ϕ_final_mean = transform_unconstrained_to_constrained(prior, eki_final_result)
+        ϕ_init_mean = transform_unconstrained_to_constrained(prior, eki_init_result)
+        @test norm(ϕ_star - ϕ_final_mean) < norm(ϕ_star - ϕ_init_mean)
+        @test norm(y_obs .- G(eki_final_result))^2 < norm(y_obs .- G(eki_init_result))^2
+
+        # Plot evolution of the EKI particles in constrained space
+        if TEST_PLOT_OUTPUT
+            gr()
+            ϕ_prior = transform_unconstrained_to_constrained(prior, get_u_prior(ekiobj))
+            ϕ_final = transform_unconstrained_to_constrained(prior, get_u_final(ekiobj))
+            p = plot(ϕ_prior[1, :], ϕ_prior[2, :], seriestype = :scatter)
+            plot!(ϕ_final[1, :], ϕ_final[2, :], seriestype = :scatter)
+            plot!(
+                [ϕ_star[1]],
+                xaxis = "cons_p",
+                yaxis = "uncons_p",
+                seriestype = "vline",
+                linestyle = :dash,
+                linecolor = :red,
+            )
+            plot!([ϕ_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red)
+            savefig(p, string("SparseEKI_", test_name, ".png"))
+        end
+
+        # Test other constructors
+        @test isa(SparseInversion(γ), SparseInversion)
+
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ end
         "EnsembleKalmanProcess",
         "Localizers",
         "UQParameters",
+        "SparseInversion",
     ]
         if all_tests || has_submodule(submodule) || "EnsembleKalmanProcesses" in ARGS
             include_test(submodule)


### PR DESCRIPTION
# PULL REQUEST

Major refactoring of EKP unit tests.

## Purpose and Content

- Separate inverse problem definition from tests. Inverse problem definition moved to different file for readability and portability.
- Include nonlinear inverse problem test for EKI, EKS, UKI.
- Fix UKI test, which before used perfect denoised samples.
- Separate SparseEKI into a different file, and modify the test to make it much easier to pass.