### PR TITLE
first pass for docs improvements

### DIFF
--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -130,7 +130,7 @@ the console, we have to force push. We need to force push because we rewrote
 the local commit history.
 
 ```
-$ git push -u origin <name_of_local_branch> --force
+$ git push -uf origin <name_of_local_branch>
 ```
 
 You can find more information about squashing [here](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request#squash-your-changes).

--- a/docs/src/examples/template_example.md
+++ b/docs/src/examples/template_example.md
@@ -8,19 +8,23 @@ For small examples typically have 2 files.
 - The example script which contains the inverse problem setup and solve
 
 ## The structure of the example script
-First we create the data and the setting for the model
-1. Set up the forward model.
-2. Construct/load the truth data. Store this data conveniently in the `Observations.Observation` object
 
-Then we set up the inverse problem
-3. Define the prior distributions. Use the `ParameterDistribution` object
-4. Decide on which `process` tool you would like to use (we recommend you begin with `Inversion()`). Then initialize this with the relevant constructor
+### Create the data and the setting for the model
+1. Set up the forward model.
+2. Construct/load the truth data. 
+
+### Set up the inverse problem
+3. Define the prior distributions, and generate an initial ensemble.
+4. Initialize the `process` tool you would like to use (we recommend you begin with `Inversion()`). 
 5. initialize the `EnsembleKalmanProcess` object
 
-Then we solve the inverse problem, in a loop perform the following for as many iterations as required:
+### Solve the inverse problem, in a loop
+
 7. Obtain the current parameter ensemble
 8. Transform them from the unbounded computational space to the physical space
-9. call the forward map on the ensemble of parameters, producing an ensemble of measured data
+9. call the forward model on the ensemble of parameters, producing an ensemble of measured data
 10. call the `update_ensemble!` function to generate a new parameter ensemble based on the new data
 
-One can then obtain the solution, dependent on the `process` type.
+### Get the solution
+1. Obtain the final parameter ensemble, compute desired statistics here.
+2. Transform the final ensemble into the physical space for use in prediction studies with the forward model.

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -9,7 +9,8 @@ on GitHub.
 
 | Name        | Symbol (Theory/Docs) | Symbol (Code)    |
 | :---        |    :----:            |    :----:     |
-| Parameter vector, Parameters (unconstrained space) | ``\theta``  | `θ` |
+| Parameter vector, Parameters (unconstrained space) | ``\theta``, ``u``, ``\mathcal{T}(\phi)``  | `θ`,`u` |
+| Parameter vector, Parameters (physical / constrained space) | ``\phi``, ``\mathcal{T}^{-1}(\theta)``  | `ϕ`|
 | Parameter vector size, Number of parameters  | ``p``  | `N_par` |
 | Ensemble size  | ``J``  | `N_ens` |
 | Ensemble particles, members  | ``\theta^{(j)}``  | |

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,12 +4,12 @@
  - Ensemble Kalman Inversion (EKI) - The traditional optimization technique based on the Ensemble Kalman Filter EnKF ([Iglesias, Law, Stuart, 2013](http://dx.doi.org/10.1088/0266-5611/29/4/045001)),
  - Ensemble Kalman Sampler (EKS) - also obtains a Gaussian Approximation of the posterior distribution, through a Monte Carlo integration ([Garbuno-Inigo, Hoffmann, Li, Stuart, 2020](https://doi.org/10.1137/19M1251655)),
  - Unscented Kalman Inversion (UKI) - also obtains a Gaussian Approximation of the posterior distribution, through a quadrature based integration approach ([Huang, Schneider, Stuart, 2022](https://doi.org/10.1016/j.jcp.2022.111262)),
- - Sparsity-inducing Ensemble Kalman Inversion (SEKI) - Additionally adds approximate ``L^0`` and ``L^1`` penalization to the EKI ([Schneider, Stuart, Wu, 2020](https://doi.org/10.48550/arXiv.2007.06175)).
+- Sparsity-inducing Ensemble Kalman Inversion (SEKI) - Additionally adds approximate ``L^0`` and ``L^1`` penalization to the EKI ([Schneider, Stuart, Wu, 2020](https://doi.org/10.48550/arXiv.2007.06175)).
 
 Module                                      | Purpose
 --------------------------------------------|--------------------------------------------------------
 EnsembleKalmanProcesses.jl                  | Collection of all tools
-EnsembleKalmanProcess.jl                    | Implementations of EKI, EKS, UKI and SEKI
+EnsembleKalmanProcess.jl                    | Implementations of EKI, EKS, UKI, and SEKI 
 Observations.jl                             | Structure to hold observational data
 ParameterDistributions.jl                   | Structures to hold prior and posterior distributions
 DataContainers.jl                           | Structure to hold model parameters and outputs
@@ -19,3 +19,4 @@ Localizers.jl                               | Covariance localization kernels
 
 `EnsembleKalmanProcesses.jl` is being developed by the [Climate Modeling
 Alliance](https://clima.caltech.edu). The main developers are Oliver R. A. Dunbar and Ignacio Lopez-Gomez.
+

--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -1,4 +1,4 @@
-# [Prior distributions](@id parameter-distributions)
+# [Defining prior distributions](@id parameter-distributions)
 
 Bayesian inference begins with an explicit prior distribution. This page describes the interface EnsembleKalmanProcesses provides for specifying priors on parameters, via the ParameterDistributions module (`src/ParameterDistributions.jl`).
 
@@ -13,6 +13,13 @@ A prior is specified by a `ParameterDistribution` object, which has three compon
  3. The parameter name, given as a `String`.
 
 In multiparameter settings, one should define one `ParameterDistribution` per parameter, and then concatenate these either in the constructor or with `combine_distributions`. This is illustrated below and in the [Multidimensional example](@ref).
+
+!!! note "What's up with the notation u, ϕ, and θ?"
+    Parameters in unconstrained spaces are often denoted ``u`` or ``\theta`` in the literature. In the code, method names featuring `_u` imply the return of a computational, unconstrained parameter.
+    
+    Parameters in physical/constrained spaces are often denoted ``\mathcal{T}^{-1}(u)``, ``\mathcal{T}^{-1}(\theta)``, or ``\phi`` in the literature (for some bijection ``\mathcal{T}`` mapping to the unbounded space). In the code, method names featuring `_ϕ` imply the return of a physical, constrained parameter, and will always require a `prior` as input to perform the transformations internally.
+    
+    For more notations see our [Glossary](@ref).
 
 ### Recommended constructor
 
@@ -84,7 +91,7 @@ The `ParameterDistributionType` class comprises three subclasses for specifying 
  - The `VectorOfParameterized` type is initialized with a vector of distributions.
  - The `Samples` type is initialized using a two dimensional array. Samples are drawn randomly (with replacement) from the columns of the provided array.
 
-!!! warn
+!!! warning
     We recommend that the distributions be unbounded (see next section), as the filtering algorithms in EnsembleKalmanProcesses are not guaranteed to preserve constraints unless defined through the `ConstraintType` mechanism.
 
 
@@ -92,10 +99,10 @@ The `ParameterDistributionType` class comprises three subclasses for specifying 
 
 The inference algorithms implemented in EnsembleKalmanProcesses assume unbounded parameter domains. To be able to handle constrained parameter values consistently, the ConstraintType class defines a bijection between the physical, constrained parameter domain and an unphysical, unconstrained domain in which the filtering takes place. This bijection is specified by the functions `transform_constrained_to_unconstrained` and `transform_unconstrained_to_constrained`, which are built from either predefined constructors or user-defined constraint functions given as arguments to the `ConstraintType` constructor. 
 
-!!! warn
+!!! warning
     When a nontrivial `ConstraintType` is given, the general constructor assumes the `ParameterDistributionType` is specified in the *unconstrained* space; the actual prior pdf is then the composition of the `ParameterDistributionType`'s pdf with the `transform_unconstrained_to_constrained` transformation. We provide `constrained_gaussian` to define priors directly in the physical, constrained space.
 
-!!! warn
+!!! warning
     It is up to the user to ensure any custom mappings `transform_constrained_to_unconstrained` and `transform_unconstrained_to_constrained` are inverses of each other.
 
 We provide the following predefined constructors which implement mappings that handle the most common constraints:

--- a/docs/src/unscented_kalman_inversion.md
+++ b/docs/src/unscented_kalman_inversion.md
@@ -1,12 +1,12 @@
 # Unscented Kalman Inversion
 
-One of the ensemble Kalman processes implemented in `EnsembleKalmanProcesses.jl` is the unscented Kalman inversion ([Huang, Schneider, Stuart, 2022](https://doi.org/10.1016/j.jcp.2022.111262)). The unscented Kalman inversion (UKI) is a derivative-free approximate Bayesian inference method that seeks to find the maximum a posteriori parameters ``\theta \in \mathbb{R}^p`` in the inverse problem
+One of the ensemble Kalman processes implemented in `EnsembleKalmanProcesses.jl` is the unscented Kalman inversion ([Huang, Schneider, Stuart, 2022](https://doi.org/10.1016/j.jcp.2022.111262)). The unscented Kalman inversion (UKI) is a derivative-free method for approximate Bayesian inference. We seek to find the posterior parameter distribution ``\theta \in \mathbb{R}^p`` from the inverse problem
 ```math
  y = \mathcal{G}(\theta) + \eta
 ```
 where ``\mathcal{G}`` denotes the forward map, ``y \in \mathbb{R}^d`` is the vector of observations and ``\eta \sim \mathcal{N}(0, \Gamma_y)`` is additive Gaussian noise. Note that ``p`` is the size of the parameter vector ``\theta`` and ``d`` is taken to be the size of the observation vector ``y``. The UKI algorithm has the following properties
 
-* UKI has a fixed ensemble size and requires only ``2p + 1`` particles in general.
+* UKI has a fixed ensemble size, with members forming a quadrature stencil (rather than the random positioning of the particles from methods such as EKI). There are two quadrature options, `symmetric` (a ``2p + 1``-size stencil), and `simplex` (a ``p+2``-size stencil).
 * UKI has uncertainty quantification capabilities, it gives both mean and covariance approximation (no ensemble collapse and no empirical variance inflation) of the posterior distribution, the 3-sigma confidence interval covers the truth parameters for perfect models.
 
 ## Algorithm
@@ -30,49 +30,47 @@ The UKI updates both the mean ``m_n`` and covariance ``C_n`` estimations of the 
     \hat{C}_{n+1} = & \alpha^2 C_{n} + \Sigma_{\omega}
 \end{aligned}
 ```  
-* Generate sigma points :
+* Generate sigma points ("the ensemble") :
+For the `sigma_points = symmetric` quadrature option, the ensemble is generated as follows.
 ```math    
 \begin{aligned}
     &\hat{\theta}_{n+1}^0 = \hat{m}_{n+1} \\
-    &\hat{\theta}_{n+1}^j = \hat{m}_{n+1} + c_j [\sqrt{\hat{C}_{n+1}}]_j \quad (1\leq j\leq N_\theta)\\ 
-    &\hat{\theta}_{n+1}^{j+N_\theta} = \hat{m}_{n+1} - c_j [\sqrt{\hat{C}_{n+1}}]_j\quad (1\leq j\leq N_\theta)
+    &\hat{\theta}_{n+1}^j = \hat{m}_{n+1} + c_j [\sqrt{\hat{C}_{n+1}}]_j \quad (1\leq j\leq J)\\ 
+    &\hat{\theta}_{n+1}^{j+J} = \hat{m}_{n+1} - c_j [\sqrt{\hat{C}_{n+1}}]_j\quad (1\leq j\leq J)
 \end{aligned}
-```     
+```
+where ``[\sqrt{C}]_j`` is the ``j``-th column of the Cholesky factor of ``C``. 
 *  Analysis step :
     
 ```math
    \begin{aligned}
         &\hat{y}^j_{n+1} = \mathcal{G}(\hat{\theta}^j_{n+1}) \qquad \hat{y}_{n+1} = \hat{y}^0_{n+1}\\
-         &\hat{C}^{\theta p}_{n+1} = \sum_{j=1}^{2N_\theta}W_j^{c}
+         &\hat{C}^{\theta p}_{n+1} = \sum_{j=1}^{2J}W_j^{c}
         (\hat{\theta}^j_{n+1} - \hat{m}_{n+1} )(\hat{y}^j_{n+1} - \hat{y}_{n+1})^T \\
-        &\hat{C}^{pp}_{n+1} = \sum_{j=1}^{2N_\theta}W_j^{c}
+        &\hat{C}^{pp}_{n+1} = \sum_{j=1}^{2J}W_j^{c}
         (\hat{y}^j_{n+1} - \hat{y}_{n+1} )(\hat{y}^j_{n+1} - \hat{y}_{n+1})^T + \Sigma_{\nu}\\
         &m_{n+1} = \hat{m}_{n+1} + \hat{C}^{\theta p}_{n+1}(\hat{C}^{pp}_{n+1})^{-1}(y - \hat{y}_{n+1})\\
         &C_{n+1} = \hat{C}_{n+1} - \hat{C}^{\theta p}_{n+1}(\hat{C}^{pp}_{n+1})^{-1}{\hat{C}^{\theta p}_{n+1}}{}^{T}\\
     \end{aligned}
 ```
 
-The unscented transformation parameters are
+Where the coefficients ``c_j, W^c_j`` are given by
 ```math
     \begin{aligned}
-    &c_j = \sqrt{N_\theta +\lambda} \qquad W_j^{c} = \frac{1}{2(N_\theta+\lambda)}~(j=1,\cdots,2N_{\theta}).\\
-    &\lambda = a^2 (N_\theta + \kappa) - N_\theta \quad a=\min\{\sqrt{\frac{4}{N_\theta + \kappa}},  1\}\quad  \kappa = 0\\
+    &c_j = a\sqrt{J}, \qquad W_j^{c} = \frac{1}{2a^2J}~(j=1,\cdots,2N_{\theta}), \qquad  a=\min\{\sqrt{\frac{4}{J}},  1\} 
     \end{aligned}
-```
-And ``[\sqrt{C}]_j`` is the ``j``-th column of the Cholesky factor of ``C``. 
-    
-    
+``` 
 
 
 ## Choice of free parameters
-The free parameters in the unscented Kalman inversion are ``\alpha, r, \Sigma_{\nu}, \Sigma_{\omega}``, which are chosen based on theorems developed in [Huang et al, 2021](https://arxiv.org/abs/2102.01580)
+The free parameters in the unscented Kalman inversion are ``\alpha, r, \Sigma_{\nu}, \Sigma_{\omega}``, which are chosen based on theorems developed in [Huang et al, 2021](https://doi.org/10.1016/j.jcp.2022.111262)
 
 * the vector ``r`` is set to be the prior mean
 
 * the scalar ``\alpha \in (0,1]`` is a regularization parameter, which is used to overcome ill-posedness and overfitting. A practical guide is 
 
     * When the observation noise is negligible, and there are more observations than parameters (identifiable inverse problem) ``\alpha = 1`` (no regularization)
-    * Otherwise ``\alpha < 1``. The smaller ``\alpha`` is, the closer UKI will converge to the prior mean.
+    * Otherwise ``\alpha < 1``. The smaller ``\alpha`` is, the closer the UKI mean will converge to the prior mean.
     
 * the matrix ``\Sigma_{\nu}`` is the artificial observation error covariance. We set ``\Sigma_{\nu} = 2 \Gamma_{y}``, which makes the inverse problem consistent. 
 
@@ -82,7 +80,7 @@ The free parameters in the unscented Kalman inversion are ``\alpha, r, \Sigma_{\
     
     * otherwise ``\Lambda = C_0``, this allows that the converged covariance matrix is a weighted average between the posterior covariance matrix with an uninformative prior and ``C_0``.
 
-In a nutshell, users only need to change the ``\alpha`` (`α_reg`), and the frequency to update the ``\Lambda`` (`update_freq`). The user can first try `α_reg = 1.0` and `update_freq = 0`.
+In short, users only need to change the ``\alpha`` (`α_reg`), and the frequency to update the ``\Lambda`` (`update_freq`). The user can first try `α_reg = 1.0` and `update_freq = 0`.
 
 
 ## Implementation
@@ -114,7 +112,7 @@ ukiobj = EnsembleKalmanProcess(truth_sample, truth.obs_noise_cov, process)
 
 ```
 
-Note that no information about the forward map is necessary to initialize the Inversion process. The only forward map information required by the inversion process consists of model evaluations at the ensemble elements, necessary to update the ensemble.
+Note that no information about the forward map is necessary to initialize the Unscented process. The only forward map information required by the inversion process consists of model evaluations at the ensemble elements, necessary to update the ensemble.
 
 
 ### Constructing the Forward Map
@@ -136,18 +134,18 @@ A call to the inversion algorithm can be performed with the `update_ensemble!` f
 
 The forward map ``\mathcal{G}`` maps the space of unconstrained parameters ``\theta`` to the outputs ``y \in \mathbb{R}^d``. In practice, the user may not have access to such a map directly. And the map is a composition of several functions. The `update_ensemble!` uses only the evalutaions `g_ens` but not the forward map  
 
-For implementational reasons, the `update_ensemble` is performed by computing analysis stage first, followed by a prediction of the next sigma ensemble. And the first prediction is done in the initialization.
+For implementational reasons, the `update_ensemble` is performed by computing analysis stage first, followed by a calculation of the next sigma ensemble. The first sigma ensemble is created in the initialization.
 
 ```julia
+# Given:
+# Ψ (some black box simulator)
+# H (some observation of the simulator output)
+# prior (prior distribution and parameter constraints)
+
 N_iter = 20 # Number of steps of the algorithm
  
 for n in 1:N_iter
-
-    # define black box parameter to observation map, 
-    # with certain parameter transformation related to imposing some constraints
-    # i.e. θ -> e^θ  -> G(e^θ) = y
-    θ_n = get_u_final(ukiobj) # Get current ensemble
-    ϕ_n = transform_unconstrained_to_constrained(prior, θ_n) # Transform parameters to physical/constrained space
+    ϕ_n = get_ϕ_final(prior, ukiobj) # Get current ensemble in constrained "ϕ"-space
     G_n = [H(Ψ(ϕ_n[:, i])) for i in 1:J]  # Evaluate forward map
     g_ens = hcat(G_n...)  # Reformat into `d x N_ens` matrix
     EnsembleKalmanProcesses.update_ensemble!(ukiobj, g_ens) # Update ensemble
@@ -160,9 +158,9 @@ The solution of the unscented Kalman inversion algorithm is a Gaussian distribut
 
 ```julia
 # mean of the Gaussian distribution, also the optimal parameter for the calibration problem
-θ_optim = ukiobj.process.u_mean[end], 
+θ_optim = get_u_mean_final(ukiobj)
 # covariance of the Gaussian distribution
-sigma = ukiobj.process.uu_cov[end]
+sigma_optim = get_u_cov_final(ukiobj)
 ```
 
 There are two examples: [Lorenz96](@ref Lorenz-example) and [Cloudy](@ref Cloudy-example).
@@ -213,19 +211,16 @@ Consider the set of off-center sigma points ``\{\hat{\theta}\} = \{\hat{\theta}_
 ```math
    \tag{2} \mathrm{Cov}_q(\mathcal{G}_n, \mathcal{G}_n) \approx \sum_{j=1}^{J_s}w_{s,j} (\mathcal{G}(\hat{\theta}_{s, n}^{(j)}) - \bar{\mathcal{G}}_{s,n})(\mathcal{G}(\hat{\theta}_{s, n}^{(j)}) - \bar{\mathcal{G}}_{s,n})^T,
 ```
+
 where the weights at each successful sigma point are scaled up, to preserve the sum of weights,
 ```math
     w_{s,j} = \left(\dfrac{\sum_{i=1}^{2p} w_i}{\sum_{k=1}^{J_s} w_k}\right)w_j.
 ```
 
-In equations (1) and (2), the means ``\bar{\theta}_{s,n}`` and ``\bar{\mathcal{G}}_{s,n}`` must be modified from the original formulation if the central point ``\hat{\theta}^{(0)}=m_n`` results in model failure. If this is the case, then
+In equations (1) and (2), the means ``\bar{\theta}_{s,n}`` and ``\bar{\mathcal{G}}_{s,n}`` must be modified from the original formulation if the central point ``\hat{\theta}^{(0)}=m_n`` results in model failure. If this is the case, then an average is taken across the other (successful) ensemble members
 
 ```math
    \bar{\theta}_{s,n} =
-\dfrac{1}{J_s}\sum_{j=1}^{J_s}\hat{\theta}_{s, n}^{(j)} \qquad \text{if failure},
-```
-
-```math
-   \bar{\mathcal{G}}_{s,n} =
-\dfrac{1}{J_s}\sum_{j=1}^{J_s}\mathcal{G}(\hat{\theta}_{s, n}^{(j)}) \qquad \text{if failure}.
+\dfrac{1}{J_s}\sum_{j=1}^{J_s}\hat{\theta}_{s, n}^{(j)}, \qquad   \bar{\mathcal{G}}_{s,n} =
+\dfrac{1}{J_s}\sum_{j=1}^{J_s}\mathcal{G}(\hat{\theta}_{s, n}^{(j)}).
 ```


### PR DESCRIPTION
## Purpose and Content
To clean-up the documentation. Closes #190 

[SHORTCUT TO DOCS](https://clima.github.io/EnsembleKalmanProcesses.jl/previews/PR207/)

## Content
- Updated links with DOIs
- Unified and trimmed Docs for the methods sections. Particularly UKI.
- Added a small SEKI section in EKI
- New getter functions, and clarification note for `u`, ``\phi`` and ``\theta`` notations

## PR Checklist
- [x] I have followed CliMA's codebase [contribution](https://clima.github.io/ClimateMachine.jl/latest/Contributing/) and [style](https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/) guidelines OR N/A.
- [x] I have followed CliMA's [documentation policy](https://github.com/CliMA/policies/wiki/Documentation-Policy).
- [x] I have checked all issues and PRs and I certify that this PR does not duplicate an open PR.
- [x] Documentation has been added/updated OR N/A.
