### PR TITLE
Updating and checking EKP examples

### DIFF
--- a/docs/src/parameter_distributions.md
+++ b/docs/src/parameter_distributions.md
@@ -21,7 +21,7 @@ In multiparameter settings, one should define one `ParameterDistribution` per pa
     
     For more notations see our [Glossary](@ref).
 
-### Recommended constructor
+### [Recommended constructor](@id constrained-gaussian)
 
 `constrained_gaussian()` is a streamlined constructor for `ParameterDistribution`s which addresses the most common use case; more general forms of the constructor are documented below, but we **highly** recommend that users begin here when it comes to specifying priors, only using the general constructor when necessary.
 
@@ -123,7 +123,7 @@ This is simply a `String` used to identify different parameters in multi-paramet
 
 ## ParameterDistribution constructor
 
-The [Recommended constructor](@ref), `constrained_gaussian()`, is described above. For more general cases in which the prior needs to be specified in more detail, a `ParameterDistribution` may be constructed "manually" from its component objects:
+The [Recommended constructor](@ref constrained-gaussian), `constrained_gaussian()`, is described above. For more general cases in which the prior needs to be specified in more detail, a `ParameterDistribution` may be constructed "manually" from its component objects:
 
 ```julia
 prior_1 = ParameterDistribution(distribution_1, constraint_1, name_1)

--- a/examples/AerosolActivation/Project.toml
+++ b/examples/AerosolActivation/Project.toml
@@ -8,3 +8,6 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Thermodynamics = "b60c26fb-14c3-4610-9d3e-2d17fe7ff00c"
+
+[compat]
+CloudMicrophysics = "0.5"

--- a/examples/ClimateMachine/init_calibration.jl
+++ b/examples/ClimateMachine/init_calibration.jl
@@ -10,15 +10,9 @@ include(joinpath(@__DIR__, "helper_funcs.jl"))
 param_names = ["C_smag", "C_drag"]
 
 # Set parameter priors
-prior_smag =
-    Dict("distribution" => Parameterized(Normal(0.5, 0.05)), "constraint" => no_constraint(), "name" => param_names[1])
-prior_drag = Dict(
-    "distribution" => Parameterized(Normal(0.001, 0.0001)),
-    "constraint" => no_constraint(),
-    "name" => param_names[2],
-)
-
-priors = ParameterDistribution([prior_smag, prior_drag])
+prior_smag = constrained_gaussian(param_names[1], 0.5, 0.05, -Inf, Inf)
+prior_drag = constrained_gaussian(param_names[2], 1e-3, 1e-4, -Inf, Inf)
+priors = combine_distributions([prior_smag, prior_drag])
 
 # Construct initial ensemble
 N_ens = 10

--- a/examples/Localization/localization_example_lorenz96.jl
+++ b/examples/Localization/localization_example_lorenz96.jl
@@ -70,7 +70,7 @@ y = y0 + randn(D)
 
 #### Define prior information on parameters
 priors = map(1:p) do i
-    ParameterDistribution(Parameterized(Normal(0.0, 1)), no_constraint(), string("u", i))
+    constrained_gaussian(string("u", i), 0.0, 1.0, -Inf, Inf)
 end
 prior = combine_distributions(priors)
 
@@ -79,7 +79,7 @@ initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
 # Solve problem without localization
 ekiobj_vanilla = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng)
 for i in 1:N_iter
-    g_ens_vanilla = G(get_u_final(ekiobj_vanilla))
+    g_ens_vanilla = G(get_ϕ_final(prior, ekiobj_vanilla))
     EKP.update_ensemble!(ekiobj_vanilla, g_ens_vanilla, deterministic_forward_map = true)
 end
 nonlocalized_error = get_error(ekiobj_vanilla)[end]
@@ -95,7 +95,7 @@ ekiobj_bernoulli = EKP.EnsembleKalmanProcess(
 )
 
 for i in 1:N_iter
-    g_ens = G(get_u_final(ekiobj_bernoulli))
+    g_ens = G(get_ϕ_final(prior, ekiobj_bernoulli))
     EKP.update_ensemble!(ekiobj_bernoulli, g_ens, deterministic_forward_map = true)
 end
 
@@ -103,7 +103,7 @@ end
 ekiobj_sec = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SEC(1.0))
 
 for i in 1:N_iter
-    g_ens = G(get_u_final(ekiobj_sec))
+    g_ens = G(get_ϕ_final(prior, ekiobj_sec))
     EKP.update_ensemble!(ekiobj_sec, g_ens, deterministic_forward_map = true)
 end
 
@@ -112,7 +112,7 @@ ekiobj_sec_cutoff =
     EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SEC(1.0, 0.1))
 
 for i in 1:N_iter
-    g_ens = G(get_u_final(ekiobj_sec_cutoff))
+    g_ens = G(get_ϕ_final(prior, ekiobj_sec_cutoff))
     EKP.update_ensemble!(ekiobj_sec_cutoff, g_ens, deterministic_forward_map = true)
 end
 
@@ -121,7 +121,7 @@ ekiobj_sec_fisher =
     EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SECFisher())
 
 for i in 1:N_iter
-    g_ens = G(get_u_final(ekiobj_sec_fisher))
+    g_ens = G(get_ϕ_final(prior, ekiobj_sec_fisher))
     EKP.update_ensemble!(ekiobj_sec_fisher, g_ens, deterministic_forward_map = true)
 end
 

--- a/examples/Lorenz/distributed_Lorenz_example.jl
+++ b/examples/Lorenz/distributed_Lorenz_example.jl
@@ -1,6 +1,6 @@
 # Demo distributed processing uncomment for the following behaviour
-# case = "multithread" # solve with multithread (must call code with `-t <n_threads>` flag)
-case = "pmap" # solve with pmap across <n_workers> processes 
+case = "multithread" # solve with multithread (must call code with `-t <n_threads>` flag)
+#case = "pmap" # solve with pmap across <n_workers> processes 
 # case="distfor" #solve with @distributed for across <n_workers> processes 
 
 # To run code, uncomment desired `case`, open a terminal window in this folder and execute:
@@ -94,34 +94,15 @@ println(params_true)
 ###
 ###  Define the parameter priors
 ###
-# Lognormal prior or normal prior?
-log_normal = false # THIS ISN't CURRENTLY IMPLEMENTED
-
-function logmean_and_logstd(μ, σ)
-    σ_log = sqrt(log(1.0 + σ^2 / μ^2))
-    μ_log = log(μ / (sqrt(1.0 + σ^2 / μ^2)))
-    return μ_log, σ_log
-end
-#logmean_F, logstd_F = logmean_and_logstd(F_true, 5)
-#logmean_A, logstd_A = logmean_and_logstd(A_true, 0.2*A_true)
 
 if dynamics == 2
     prior_means = [F_true + 1.0, A_true + 0.5]
     prior_stds = [2.0, 0.5 * A_true]
-    prior_F = Dict(
-        "distribution" => Parameterized(Normal(prior_means[1], prior_stds[1])),
-        "constraint" => no_constraint(),
-        "name" => param_names[1],
-    )
-    prior_A = Dict(
-        "distribution" => Parameterized(Normal(prior_means[2], prior_stds[2])),
-        "constraint" => no_constraint(),
-        "name" => param_names[2],
-    )
-    priors = ParameterDistribution([prior_F, prior_A])
+    prior_F = constrained_gaussian(param_names[1], prior_means[1], prior_stds[1], 0, Inf)
+    prior_A = constrained_gaussian(param_names[2], prior_means[2], prior_stds[2], 0, Inf)
+    priors = combine_distributions([prior_F, prior_A])
 else
-    prior_F = Dict("distribution" => Parameterized(Normal(F_true, 1)), "constraint" => no_constraint(), "name" => "F")
-    priors = ParameterDistribution(prior_F)
+    priors = constrained_gaussian("F", F_true, 1.0, 0, Inf)
 end
 
 
@@ -232,9 +213,6 @@ truth_sample = truth.mean
 lorenz_settings_G = lorenz_settings; # initialize to truth settings
 
 # EKP parameters
-log_transform(a::AbstractArray) = log.(a)
-exp_transform(a::AbstractArray) = exp.(a)
-
 N_ens = 20 # number of ensemble members
 N_iter = 5 # number of EKI iterations
 # initial parameters: N_params x N_ens
@@ -246,44 +224,35 @@ ekiobj = EKP.EnsembleKalmanProcess(initial_params, truth_sample, truth.obs_noise
 println("EKP inversion error:")
 err = zeros(N_iter)
 for i in 1:N_iter
-    if log_normal == false
-        params_i = get_u_final(ekiobj)
-    else
-        params_i = exp_transform(get_u_final(ekiobj))
-    end
+    params_i = get_ϕ_final(priors, ekiobj) # the `ϕ` indicates that the `params_i` are in the constrained space    
     g_ens = GModel.run_G_ensemble(params_i, lorenz_settings_G)
     EKP.update_ensemble!(ekiobj, g_ens)
     err[i] = get_error(ekiobj)[end] #mean((params_true - mean(params_i,dims=2)).^2)
     println("Iteration: " * string(i) * ", Error: " * string(err[i]))
 end
 
-
-
 # EKI results: Has the ensemble collapsed toward the truth?
 println("True parameters: ")
 println(params_true)
 
 println("\nEKI results:")
-if log_normal == false
-    println(mean(get_u_final(ekiobj), dims = 2))
-else
-    println(mean(exp_transform(get_u_final(ekiobj)), dims = 2))
-end
+println(get_ϕ_mean_final(priors, ekiobj))
 
-u_stored = get_u(ekiobj, return_array = false)
+u_stored = get_u(ekiobj, return_array = false) # unconstrained parameters
 g_stored = get_g(ekiobj, return_array = false)
 
 @save data_save_directory * "parameter_storage.jld2" u_stored
 @save data_save_directory * "data_storage.jld2" g_stored
 
-#plots
+#plots in unconstrained space
 gr(size = (600, 600))
 u_init = get_u_prior(ekiobj)
-for i in 1:N_iter
+unconstrained_params_true = transform_constrained_to_unconstrained(priors, params_true)
+anim_ekp_unconst_lorenz = @animate for i in 1:N_iter
     u_i = get_u(ekiobj, i)
     p = plot(u_i[1, :], u_i[2, :], seriestype = :scatter, xlims = extrema(u_init[1, :]), ylims = extrema(u_init[2, :]))
     plot!(
-        [params_true[1]],
+        [unconstrained_params_true[1]],
         xaxis = "u1",
         yaxis = "u2",
         seriestype = "vline",
@@ -292,10 +261,25 @@ for i in 1:N_iter
         label = false,
         title = "EKI iteration = " * string(i),
     )
-    plot!([params_true[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = "optimum")
-    #display(p)
-    figpath = joinpath(figure_save_directory, "posterior_EKP_it_$(i).png")
-    savefig(figpath)
-    #linkfig(figpath)
-    sleep(0.5)
+    plot!([unconstrained_params_true[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = "optimum")
 end
+gif(anim_ekp_unconst_lorenz, joinpath(figure_save_directory, "ekp_unconstrained_lorenz.gif"), fps = 1) # hide
+
+# plots in constrained space
+ϕ_init = transform_unconstrained_to_constrained(priors, u_init)
+anim_ekp_lorenz = @animate for i in 1:N_iter
+    ϕ_i = get_ϕ(priors, ekiobj, i)
+    p = plot(ϕ_i[1, :], ϕ_i[2, :], seriestype = :scatter, xlims = extrema(ϕ_init[1, :]), ylims = extrema(ϕ_init[2, :]))
+    plot!(
+        [params_true[1]],
+        xaxis = "ϕ1",
+        yaxis = "ϕ2",
+        seriestype = "vline",
+        linestyle = :dash,
+        linecolor = :red,
+        label = false,
+        title = "EKI iteration = " * string(i),
+    )
+    plot!([params_true[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = "optimum")
+end
+gif(anim_ekp_lorenz, joinpath(figure_save_directory, "ekp_lorenz.gif"), fps = 1) # hide

--- a/examples/LossMinimization/loss_minimization.jl
+++ b/examples/LossMinimization/loss_minimization.jl
@@ -37,11 +37,14 @@ nothing # hide
 # ### Prior distributions
 #
 # As we work with a Bayesian method, we define a prior. This will behave like an "initial guess"
-# for the likely region of parameter space we expect the solution to live in.
-prior_u1 = Dict("distribution" => Parameterized(Normal(0, 1)), "constraint" => no_constraint(), "name" => "u1")
-prior_u2 = Dict("distribution" => Parameterized(Normal(0, 1)), "constraint" => no_constraint(), "name" => "u2")
-
-prior = ParameterDistribution([prior_u1, prior_u2])
+# for the likely region of parameter space we expect the solution to live in. Here we define
+# ``Normal(0,1)`` distributions with no constraints 
+prior_u1 = constrained_gaussian("u1", 0, 1, -Inf, Inf)
+prior_u2 = constrained_gaussian("u1", 0, 1, -Inf, Inf)
+prior = combine_distributions([prior_u1, prior_u2])
+nothing # hide
+# !!! note
+#     In this example there are no constraints, therefore no parameter transformations.
 
 # ### Calibration
 #
@@ -57,7 +60,7 @@ initial_ensemble = EKP.construct_initial_ensemble(prior, N_ensemble; rng_seed = 
 # target, the stabilization and the process type (for EKI this is `Inversion`, initialized 
 # with `Inversion()`). 
 ensemble_kalman_process = EKP.EnsembleKalmanProcess(initial_ensemble, G_target, Γ_stabilization, Inversion())
-
+nothing # hide
 # Then we calibrate by *(i)* obtaining the parameters, *(ii)* calculate the loss function on
 # the parameters (and concatenate), and last *(iii)* generate a new set of parameters using
 # the model outputs:
@@ -137,10 +140,11 @@ G_target = [0]
 # We define the prior. We can place prior information on e.g., ``u₁``, demonstrating a belief
 # that ``u₁`` is more likely to be negative. This can be implemented by setting a bias in the
 # mean of its prior distribution to e.g., ``-0.5``:
-prior_u1 = Dict("distribution" => Parameterized(Normal(-0.5, sqrt(2))), "constraint" => no_constraint(), "name" => "u1")
-prior_u2 = Dict("distribution" => Parameterized(Normal(0, sqrt(2))), "constraint" => no_constraint(), "name" => "u2")
-
-prior = ParameterDistribution([prior_u1, prior_u2])
+prior_u1 = constrained_gaussian("u1", -0.5, sqrt(2), -Inf, Inf)
+prior_u2 = constrained_gaussian("u1", 0, sqrt(2), -Inf, Inf)
+prior = combine_distributions([prior_u1, prior_u2])
+# !!! note
+#     In this example there are no constraints, therefore no parameter transformations.
 
 # ### Calibration
 #

--- a/examples/SparseLossMinimization/loss_minimization_sparse_eki.jl
+++ b/examples/SparseLossMinimization/loss_minimization_sparse_eki.jl
@@ -35,11 +35,14 @@ nothing # hide
 # ### Prior distributions
 #
 # As we work with a Bayesian method, we define a prior. This will behave like an "initial guess"
-# for the likely region of parameter space we expect the solution to live in.
-prior_u1 = Dict("distribution" => Parameterized(Normal(0, 2)), "constraint" => no_constraint(), "name" => "u1")
-prior_u2 = Dict("distribution" => Parameterized(Normal(0, 2)), "constraint" => no_constraint(), "name" => "u2")
-
-prior = ParameterDistribution([prior_u1, prior_u2])
+# for the likely region of parameter space we expect the solution to live in. Here we define
+# ``Normal(0,2^2)`` distributions with no constraints 
+prior_u1 = constrained_gaussian("u1", 0, 2, -Inf, Inf)
+prior_u2 = constrained_gaussian("u1", 0, 2, -Inf, Inf)
+prior = combine_distributions([prior_u1, prior_u2])
+nothing # hide
+# !!! note
+#     In this example there are no constraints, therefore no parameter transformations.
 
 # ### Calibration
 #
@@ -62,7 +65,7 @@ process = SparseInversion(γ, threshold_value, uc_idx, reg)
 # We then initialize the Ensemble Kalman Process algorithm, with the initial ensemble, the
 # target, the stabilization and the process type (for sparse EKI this is `SparseInversion`). 
 ensemble_kalman_process = EKP.EnsembleKalmanProcess(initial_ensemble, G_target, Γ_stabilization, process)
-
+nothing # hide
 # Then we calibrate by *(i)* obtaining the parameters, *(ii)* calculate the loss function on
 # the parameters (and concatenate), and last *(iii)* generate a new set of parameters using
 # the model outputs:


### PR DESCRIPTION
# Purpose 
To run through all current EKP examples, checking they run, checking whether manifests could be updated, and applying our new code-styles and interfaces. 

## Content
Checked and updated examples and docs for:
- [x] Loss Minimization
- [x] Loss Minimization Sparse
- [x] Lorenz (EKI/UKI/distributed) - actually uses priors with transformations, and produces gifs rather than pngs - per - iteration.
- [x] Localization
- [x] Cloudy(EKI/UKI) - also now produces gifs rather than displaying pngs
- [x] AerosolActivation - produces PDFs, and `CloudyMicrophysics` version is pinned to `v0.5`
- [x] ClimateMachine - updated priors