### PR TITLE
new tests and constructors

### DIFF
--- a/src/EnsembleKalmanSampler.jl
+++ b/src/EnsembleKalmanSampler.jl
@@ -20,6 +20,14 @@ struct Sampler{FT <: AbstractFloat} <: Process
     prior_cov::Union{AbstractMatrix{FT}, UniformScaling{FT}}
 end
 
+function Sampler(prior::ParameterDistribution)
+    mean_prior = Vector(mean(prior))
+    cov_prior = Matrix(cov(prior))
+    FT = eltype(mean_prior)
+    return Sampler{FT}(mean_prior, cov_prior)
+end
+
+
 function FailureHandler(process::Sampler, method::IgnoreFailures)
     function failsafe_update(ekp, u, g, failed_ens)
         u_transposed = permutedims(u, (2, 1))

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -170,6 +170,17 @@ function Unscented(
     )
 end
 
+function Unscented(prior::ParameterDistribution; kwargs...)
+
+    u0_mean = Vector(mean(prior)) # mean of unconstrained distribution
+    uu0_cov = Matrix(cov(prior)) # cov of unconstrained distribution
+
+    return Unscented(u0_mean, uu0_cov; kwargs...)
+
+end
+
+
+
 # outer constructors
 function EnsembleKalmanProcess(
     obs_mean::AbstractVector{FT},

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -77,7 +77,7 @@ end
         # Get inverse problem
         y_obs, G, Γy, _ = inv_problem
 
-        eksobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Sampler(prior_mean, prior_cov); rng = rng)
+        eksobj = EKP.EnsembleKalmanProcess(initial_ensemble, y_obs, Γy, Sampler(prior); rng = rng)
 
         params_0 = get_u_final(eksobj)
         g_ens = G(params_0)
@@ -301,7 +301,7 @@ end
 
     α_reg = 1.0
     update_freq = 0
-    process = Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq, sigma_points = "symmetric")
+    process = Unscented(prior; α_reg = α_reg, update_freq = update_freq, sigma_points = "symmetric")
     iters_with_failure = [5, 8, 9, 15]
     failed_particle_index = [1, 2, 3, 1]
 
@@ -310,19 +310,12 @@ end
     ukiobj = EKP.EnsembleKalmanProcess(y_obs, Γy, process; rng = rng, failure_handler_method = SampleSuccGauss())
     ukiobj_unsafe = EKP.EnsembleKalmanProcess(y_obs, Γy, process; rng = rng, failure_handler_method = IgnoreFailures())
     # test simplex sigma points
-    process_simplex =
-        Unscented(prior_mean, prior_cov; α_reg = α_reg, update_freq = update_freq, sigma_points = "simplex")
+    process_simplex = Unscented(prior; α_reg = α_reg, update_freq = update_freq, sigma_points = "simplex")
     ukiobj_simplex =
         EKP.EnsembleKalmanProcess(y_obs, Γy, process_simplex; rng = rng, failure_handler_method = SampleSuccGauss())
 
     # Test incorrect construction throws error
-    @test_throws ArgumentError Unscented(
-        prior_mean,
-        prior_cov;
-        α_reg = α_reg,
-        update_freq = update_freq,
-        sigma_points = "unknowns",
-    )
+    @test_throws ArgumentError Unscented(prior; α_reg = α_reg, update_freq = update_freq, sigma_points = "unknowns")
 
     # UKI iterations
     params_i_vec = Array{Float64, 2}[]


### PR DESCRIPTION
## Purpose 
Unifies the constructors with the new prior interfaces. for examples users will not have to calculate means or covariances in computational space of the prior for to build `Unscented` or `Sampler` objects. instead we pass the `prior`.

## Content 
- new (additional) constructors for `Unscented` and `Sampler` objects
- unit tests

## Linked Issues
- Closes #212 

