### PR TITLE
Revert to stable ICs for `constrained_gaussian` solver

### DIFF
--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -913,27 +913,6 @@ function constrained_gaussian(
     end
 end
 
-function _constrained_gaussian_guess(μ_c::Real, σ_c::Real, lower_bound::Real, upper_bound::Real)
-    # Initial guess for μ_c, σ_c in _constrained_gaussian optimization.
-    # Equations result from inverting the system 
-    # μ_c = f^{-1}(μ_u / sqrt(1 + σ_u^2/2))
-    # σ_c = f^{-1}((μ_u + σ_u/2) / sqrt(1 + σ_u^2/2)) - f^{-1}((μ_u - σ_u/2) / sqrt(1 + σ_u^2/2))
-    # where f^{-1} is the specific form of cons.unconstrained_to_constrained().
-
-    cons = bounded(lower_bound, upper_bound)
-    _Δul = upper_bound - lower_bound
-    _Δum = upper_bound - μ_c
-    _Δml = μ_c - lower_bound
-    init_σ_u =
-        0.5 * (
-            -σ_c * (_Δum^2 + _Δml^2) / (_Δum * _Δml * (σ_c - 1.0)) +
-            hypot(2 * _Δum * _Δml, _Δul * σ_c * (_Δum - _Δml)) / (_Δum * _Δml * abs(σ_c - 1.0))
-        )
-    init_σ_u = 2.0 * log(init_σ_u) / sqrt(1.0 - 2 * log(init_σ_u)^2)
-    init_μ_u = sqrt(1.0 + init_σ_u^2 / 2.0) * cons.constrained_to_unconstrained(μ_c)
-    return (init_μ_u, init_σ_u)
-end
-
 function _constrained_gaussian(
     name::AbstractString,
     μ_c::Real,
@@ -952,7 +931,7 @@ function _constrained_gaussian(
     # for analytically.
 
     cons = bounded(lower_bound, upper_bound)
-    init_μ_u, init_σ_u = _constrained_gaussian_guess(μ_c, σ_c, lower_bound, upper_bound)
+    init_μ_u, init_σ_u = (0.0, 1.0)
     # optimize in log σ to avoid constraint σ>0
     init_logσ_u = log(init_σ_u)
 

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -568,14 +568,6 @@ using EnsembleKalmanProcesses.ParameterDistributions
             @test_throws DomainError constrained_gaussian("test", 0.0, 10.0, -1.0, 1000.0)
             @test_throws DomainError constrained_gaussian("test", 0.0, 10.0, -1000.0, 1.0)
             @test_throws DomainError constrained_gaussian("test", 0.0, 10.0, -1.0, 1.0)
-            # optimization failure
-            @test_logs (:warn,) match_mode = :any ParameterDistributions._constrained_gaussian(
-                "test",
-                0.99999,
-                0.000006,
-                0.0,
-                1.0,
-            )
         end
         @testset "constrained_gaussian: closed form" begin
             μ_c = -5.0
@@ -644,11 +636,6 @@ using EnsembleKalmanProcesses.ParameterDistributions
         end
 
         @testset "constrained_gaussian: optimization" begin
-            # Analytic form for inital guess
-            μ_u, σ_u = ParameterDistributions._constrained_gaussian_guess(0.2, 0.1, 0.0, 1.0)
-            @test isapprox(μ_u, -1.54518, atol = 1e-5, rtol = 1e-5)
-            @test isapprox(σ_u, 0.69622, atol = 1e-5, rtol = 1e-5)
-
             # lognormal - analytic
             μ_u = 1.0
             σ_u = 2.0


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #223 
Note the optimization appears more robust now for no loss of accuracy (according to our unit testing)

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Set ICs in unconstrained space to (0,1) rather than trying to get a more intelligent approximation
- removed tests for IC function

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevent documentation.

-->
