### PR TITLE
Update version of EKP.jl to post-review status.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnsembleKalmanProcesses"
 uuid = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 authors = ["CLIMA contributors <clima-software@caltech.edu>"]
-version = "0.13.1"
+version = "0.14.0"
 
 [deps]
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"


### PR DESCRIPTION
Breaking release of EKP.jl following changes in module naming conventions.