### PR TITLE
Improve docs snippets in prior distributions page

### DIFF
--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -264,7 +264,6 @@ using EnsembleKalmanProcesses.ParameterDistributions
         d1 = Parameterized(MvNormal(zeros(4), 0.1 * I))
         c1 = [no_constraint(), bounded_below(-1.0), bounded_above(0.4), bounded(-0.1, 0.2)]
         name1 = "constrained_mvnormal"
-
         u1 = ParameterDistribution(d1, c1, name1)
 
         d2 = Samples([1 2 3 4])
@@ -287,14 +286,16 @@ using EnsembleKalmanProcesses.ParameterDistributions
         v = combine_distributions([u1, u2, u3, u4])
 
         # Tests for sample distribution
+        # Note from julia 1.8.5, rand(X,2) != [rand(X,1) rand(X,1)]
         seed = 2020
+        testd = MvNormal(zeros(4), 0.1 * I)
         Random.seed!(seed)
-        s1 = rand(MvNormal(zeros(4), 0.1 * I), 1)
+        s1 = rand(testd, 1)
         Random.seed!(seed)
         @test sample(u1) == s1
 
         Random.seed!(seed)
-        s1 = rand(MvNormal(zeros(4), 0.1 * I), 3)
+        s1 = [rand(testd, 1) rand(testd, 1) rand(testd, 1)]
         Random.seed!(seed)
         @test sample(u1, 3) == s1
 
@@ -418,6 +419,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
 
         # test that optional parameter defaults to Random.GLOBAL_RNG, for all methods.
         # reset the global seed instead of copying the rng object's state
+        # Note, from julia 1.8.5 rand(X,2) != [rand(X,1) rand(X,1)]
         rng_seed = 2468
         Random.seed!(rng_seed)
         test_lhs = sample(d0)
@@ -427,7 +429,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
         Random.seed!(rng_seed)
         test_lhs = sample(d0, 3)
         Random.seed!(rng_seed)
-        @test test_lhs == rand(test_d, 3)
+        @test test_lhs == [rand(test_d, 1) rand(test_d, 1) rand(test_d, 1)]
 
         Random.seed!(rng_seed)
         test_lhs = sample(u1)
@@ -437,7 +439,7 @@ using EnsembleKalmanProcesses.ParameterDistributions
         Random.seed!(rng_seed)
         test_lhs = sample(u1, 3)
         Random.seed!(rng_seed)
-        @test test_lhs == rand(test_d, 3)
+        @test test_lhs == [rand(test_d, 1) rand(test_d, 1) rand(test_d, 1)]
 
         Random.seed!(rng_seed)
         test_lhs = sample(d0)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #256 
Closes #255 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Added more accessible `using` statements to begin snippets that are likely to be copy+pasted by readers
- Added what is brought in with `using` statements
- bugfix example

## Extras 
- resolved some tests fail on Julia `1` testing (here, `1.8.5`), due to updates  (bugs) in global rng / Distributions

Docs page [here](https://clima.github.io/EnsembleKalmanProcesses.jl/previews/PR258/parameter_distributions/)
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
