### PR TITLE
Fix v1.9.0 testing

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.7'
+          version: '1'
           show-versioninfo: 'true'
       - name: Cache artifacts
         uses: actions/cache@v1

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: julia-actions/setup-julia@latest
       if: steps.filter.outputs.julia_file_change == 'true'
       with:
-        version: 1.7
+        version: "1"
 
     - name: Apply JuliaFormatter
       if: steps.filter.outputs.julia_file_change == 'true'

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -575,7 +575,7 @@ function update_ensemble!(
     use_prior_cov::Bool = false,
     s::FT = 0.0,
     ekp_kwargs...,
-) where {FT, IT}
+) where {FT}
 
     update_ensemble!(ekp, g, get_process(ekp); ekp_kwargs...)
     if s > 0.0

--- a/src/FunctionParameterDistributions.jl
+++ b/src/FunctionParameterDistributions.jl
@@ -1,9 +1,11 @@
 # included at EOF within ParameterDistributions Module
 
-#usings
-using GaussianRandomFields
-const GRF = GaussianRandomFields
 
+#usings
+
+#imports - we must import GRF not using or we get annoying warnings for the include of sample into the workspace
+import GaussianRandomFields
+const GRF = GaussianRandomFields
 
 #exports
 #types

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -865,7 +865,7 @@ Here, `x` is an iterable of parameters sample ensembles for different EKP iterat
 function transform_constrained_to_unconstrained(
     pd::ParameterDistribution,
     x, # ::Iterable{AbstractMatrix{FT}},
-) where {FT <: Real}
+)
     transf_x = []
     for elem in x
         push!(transf_x, transform_constrained_to_unconstrained(pd, elem))
@@ -988,7 +988,7 @@ Here, `x` is an iterable of parameters sample ensembles for different EKP iterat
 function transform_unconstrained_to_constrained(
     pd::ParameterDistribution,
     x, # ::Iterable{AbstractMatrix{FT}},
-) where {FT <: Real}
+)
     transf_x = []
     for elem in x
         push!(transf_x, transform_unconstrained_to_constrained(pd, elem))

--- a/src/TOMLInterface.jl
+++ b/src/TOMLInterface.jl
@@ -518,7 +518,7 @@ Args:
                corresponding dictionaries of parameter information as values
 `file_path` - path of the file where parameters are saved
 """
-function write_log_file(param_dict::Dict, file_path::AbstractString) where {FT}
+function write_log_file(param_dict::Dict, file_path::AbstractString)
     open(file_path, "w") do io
         TOML.print(io, param_dict)
     end

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -312,7 +312,7 @@ function construct_sigma_ensemble(
     process::Unscented,
     x_mean::AbstractVector{FT},
     x_cov::AbstractMatrix{FT},
-) where {FT <: AbstractFloat, IT <: Int}
+) where {FT <: AbstractFloat}
 
     N_x = size(x_mean, 1)
     N_ens = process.N_ens
@@ -488,7 +488,7 @@ function construct_cov(
     obs_mean::AbstractMatrix{FT},
     y_mean::AbstractVector{FT};
     cov_weights = uki.process.cov_weights,
-) where {FT <: AbstractFloat, IT <: Int, P <: Process}
+) where {FT <: AbstractFloat, IT <: Int}
 
     N_x, N_ens = size(x)
     N_y = length(y_mean)

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -214,10 +214,17 @@ end
                     EKP.update_ensemble!(ekiobj_unsafe, g_ens_unsafe)
                 elseif i == iters_with_failure[1]
                     g_ens_unsafe[:, 1] .= NaN
-                    EKP.update_ensemble!(ekiobj_unsafe, g_ens_unsafe)
-                    u_unsafe = get_u_final(ekiobj_unsafe)
-                    # Propagation of unhandled failures
-                    @test any(isnan.(u_unsafe))
+                    #inconsistent behaviour before/after v1.9 regarding NaNs in matrices
+                    if (VERSION.major >= 1) && (VERSION.minor >= 9)
+                        # new versions the NaNs break LinearAlgebra.jl
+                        @test_throws ArgumentError EKP.update_ensemble!(ekiobj_unsafe, g_ens_unsafe)
+                    else
+                        # old versions the NaNs pass through LinearAlgebra.jl
+                        EKP.update_ensemble!(ekiobj_unsafe, g_ens_unsafe)
+                        u_unsafe = get_u_final(ekiobj_unsafe)
+                        # Propagation of unhandled failures
+                        @test any(isnan.(u_unsafe))
+                    end
                 end
             end
         end
@@ -342,9 +349,19 @@ end
                 EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
             elseif i == iters_with_failure[1]
                 g_ens_unsafe[:, 1] .= NaN
-                EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
-                u_unsafe = get_u_final(ukiobj_unsafe)
-                @test any(isnan.(u_unsafe))
+                #inconsistent behaviour before/after v1.9 regarding NaNs in matrices
+                if (VERSION.major >= 1) && (VERSION.minor >= 9)
+                    # new versions the NaNs break LinearAlgebra.jl
+                    @test_throws ArgumentError EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
+                else
+                    # old versions the NaNs pass through LinearAlgebra.jl
+                    EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
+                    u_unsafe = get_u_final(ukiobj_unsafe)
+                    # Propagation of unhandled failures
+                    @test any(isnan.(u_unsafe))
+                end
+
+
             end
         end
 

--- a/test/TOMLInterface/runtests.jl
+++ b/test/TOMLInterface/runtests.jl
@@ -22,7 +22,7 @@ const EKP = EnsembleKalmanProcesses
         "uq_param_1" => ParameterDistribution(Parameterized(Normal(-100.0, 20.0)), no_constraint(), "uq_param_1"),
         "uq_param_2" => ParameterDistribution(Parameterized(Gamma(5.0, 2.0)), bounded_below(6.0), "uq_param_2"),
         "uq_param_3" => ParameterDistribution(
-            Parameterized(MvNormal(4, 1.0)),
+            Parameterized(MvNormal(zeros(4), I(4))),
             [no_constraint(), bounded_below(-100.0), bounded_above(10.0), bounded(-42.0, 42.0)],
             "uq_param_3",
         ),
@@ -41,8 +41,11 @@ const EKP = EnsembleKalmanProcesses
             repeat([bounded_above(9.0)], 3),
             "uq_param_6",
         ),
-        "uq_param_7" =>
-            ParameterDistribution(Parameterized(MvNormal(3, 2.0)), repeat([no_constraint()], 3), "uq_param_7"),
+        "uq_param_7" => ParameterDistribution(
+            Parameterized(MvNormal(zeros(3), 4.0 * I(3))),
+            repeat([no_constraint()], 3),
+            "uq_param_7",
+        ),
         "uq_param_8" => ParameterDistribution(
             VectorOfParameterized([Gamma(2.0, 3.0), LogNormal(0.1, 0.1), Normal(0.0, 10.0)]),
             [no_constraint(), no_constraint(), bounded_below(-5.0)],


### PR DESCRIPTION
## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Adds >=v1.9 tests where behaviour changes. 
Changes weres isolated to Failure handler tests, as the most up-to-date `LinearAlgebra` no longer allows as much propagation of NaNs, rather it throws errors. (I think this is a good idea)
- Removes the various precompile warnings about "FT defined but not used" 
- Removes the precompile warning of a clash in `sample` by now importing `GaussianRandomFields` rather that using it. This is (I think) because GRF.jl does not extend the StatsBase sample function, and we cant `import StatsBase: sample` AND `using GaussianRandomFields` without warnings.
- Update github workflows for docs and formatter to include `v1.X` from pinning to `1.7` 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
