### PR TITLE
Allow users to select termination time for DataMisfitController

### DIFF
--- a/docs/src/learning_rate_scheduler.md
+++ b/docs/src/learning_rate_scheduler.md
@@ -65,8 +65,9 @@ Currently we will retain constant timestepping while we investigate further, tho
 
 Please let us know how you get on by setting the keyword argument in EKP
 ```julia
-scheduler = DataMisfitController() # terminating
-scheduler = DataMisfitController(on_terminate = "continue") #non-terminating
+scheduler = DataMisfitController() # terminating at `T=1`
+scheduler = DataMisfitController(terminate_at = 10) # terminating at `T=10`
+scheduler = DataMisfitController(on_terminate = "continue") # non-terminating
 ```
 
 !!! warning "Ensemble Kalman Sampler"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #290 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Added a keyword argument `terminate_at` for DMC
- Added tests to show it stops at the correct time
- Added a line into the docs 

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
