### PR TITLE
[WIP] Resolving some test problem consistency and apparent UKI instability

### DIFF
--- a/docs/src/unscented_kalman_inversion.md
+++ b/docs/src/unscented_kalman_inversion.md
@@ -80,8 +80,10 @@ The free parameters in the unscented Kalman inversion are ``\alpha, r, \Sigma_{\
     
     * otherwise ``\Lambda = C_0``, this allows that the converged covariance matrix is a weighted average between the posterior covariance matrix with an uninformative prior and ``C_0``.
 
-In short, users only need to change the ``\alpha`` (`α_reg`), and the frequency to update the ``\Lambda`` (`update_freq`). The user can first try `α_reg = 1.0` and `update_freq = 0`.
+In short, users only need to change the ``\alpha`` (`α_reg`), and the frequency to update the ``\Lambda`` to the current covariance (`update_freq`). The user can first try `α_reg = 1.0` and `update_freq = 0` (corresponding to ``\Lambda = C_0``).
 
+!!! note "Preventing ensemble divergence"
+    If UKI suffers divergence (for example when inverse problems are not well-posed), one can prevent it by using Tikhonov regularization (see [Huang, Schneider, Stuart, 2022](https://doi.org/10.1016/j.jcp.2022.111262)). It is used by setting the `impose_prior = true` flag. In this mode, the free parameters are fixed to `α_reg = 1.0`, `update_freq = 1`. 
 
 ## Implementation
 

--- a/test/EnsembleKalmanProcess/inverse_problem.jl
+++ b/test/EnsembleKalmanProcess/inverse_problem.jl
@@ -25,7 +25,64 @@ function linear_map(rng, n_obs)
 end
 
 """
-    G_nonlinear(ϕ, rng, noise_dist, ϕ_star = 0.0)
+    G_nonlinear_old(ϕ, rng, noise_dist, ϕ_star = 0.0)
+
+Noisy nonlinear map output given `ϕ` and multivariate noise.
+The map: `(||ϕ-ϕ_star^*||_1, ||ϕ-ϕ_star||_2, ||ϕ-ϕ_star||_∞)`
+
+Inputs:
+
+ - `ϕ`                           :: Input to the forward map (constrained space)
+ - `rng`                         :: Random number generator
+ - `noise_dist`                  :: Multivariate noise distribution from which stochasticity of map is sampled.
+ - `ϕ_star`                      :: Minimum of the function
+ - `add_or_mult_noise = nothing` :: additive ["add"] or multiplicative ["mult"] variability optional
+"""
+function G_nonlinear(ϕ, rng, noise_dist; ϕ_star = 0.0, add_or_mult_noise = nothing)
+    if ndims(ϕ) == 1
+        p = length(ϕ)
+        ϕ_new = reshape(ϕ, (p, 1))
+    else
+        ϕ_new = ϕ
+    end
+
+    true_output = zeros(3, size(ϕ_new, 2)) #l^1, l^2, l^inf norm
+    true_output[1, :] = reshape([norm(c, 1) for c in eachcol(ϕ_new .- ϕ_star)], 1, :)
+    true_output[2, :] = reshape([norm(c, 2) for c in eachcol(ϕ_new .- ϕ_star)], 1, :)
+    true_output[3, :] = reshape([maximum(abs.(c)) for c in eachcol(ϕ_new .- ϕ_star)], 1, :)
+
+
+    # Add noise from noise_dist
+    if isnothing(add_or_mult_noise)
+        #just copy the observation n_obs//3 times
+        output = repeat(true_output, length(noise_dist), 1) # (n_obs x n_ens)
+    else
+        output = zeros(length(noise_dist) * size(true_output, 1), size(true_output, 2))
+        internal_noise = rand(rng, noise_dist, size(true_output, 2))
+
+        if add_or_mult_noise == "add"
+            for i in 1:length(noise_dist)
+                output[(3 * (i - 1) + 1):(3 * i), :] = reshape(internal_noise[i, :], 1, :) .+ true_output
+            end
+        elseif add_or_mult_noise == "mult"
+            for i in 1:length(noise_dist)
+                output[(3 * (i - 1) + 1):(3 * i), :] = (1 .+ reshape(internal_noise[i, :], 1, :)) .* true_output
+            end
+        else
+            throw(
+                ArgumentError(
+                    "`add_or_mult_noise` keyword expects either nothing, \"add\" or \"mult\". Got $(add_or_mult_noise).",
+                ),
+            )
+        end
+    end
+
+    return size(output, 2) == 1 ? vec(output) : output
+end
+
+
+"""
+    G_nonlinear_old(ϕ, rng, noise_dist, ϕ_star = 0.0)
 
 Noisy nonlinear map output given `ϕ` and multivariate noise.
 The map: √(sum(ϕ - ϕ_star)²)
@@ -39,7 +96,7 @@ Inputs:
  - `add_or_mult_noise = nothing` :: additive ["add"] or multiplicative ["mult"] variability optional
 
 """
-function G_nonlinear(ϕ, rng, noise_dist; ϕ_star = 0.0, add_or_mult_noise = nothing)
+function G_nonlinear_old(ϕ, rng, noise_dist; ϕ_star = 0.0, add_or_mult_noise = nothing)
     if ndims(ϕ) == 1
         p = length(ϕ)
         ϕ_new = reshape(ϕ, (p, 1))
@@ -47,11 +104,12 @@ function G_nonlinear(ϕ, rng, noise_dist; ϕ_star = 0.0, add_or_mult_noise = not
         ϕ_new = ϕ
     end
     true_output = sqrt.(sum((ϕ_new .- ϕ_star) .^ 2, dims = 1)) # (1 x n_ens)
+
     # Add noise from noise_dist
 
     if isnothing(add_or_mult_noise)
         #just copy the observation n_obs times
-        output = ones(length(noise_dist), 1) * true_output # (n_obs x n_ens)
+        output = repeat(true_output, length(noise_dist), 1) # (n_obs x n_ens)
     elseif add_or_mult_noise == "add"
         output = rand(rng, noise_dist, size(true_output, 2)) .+ true_output # (n_obs x n_ens)   
     elseif add_or_mult_noise == "mult"
@@ -67,14 +125,14 @@ function G_nonlinear(ϕ, rng, noise_dist; ϕ_star = 0.0, add_or_mult_noise = not
 end
 
 """
-    linear_inv_problem(ϕ_star, noise_level, n_obs, rng; obs_corrmat = I, return_matrix = false)
+    linear_inv_problem(ϕ_star, noise_sd, n_obs, rng; obs_corrmat = I, return_matrix = false)
 
 Returns the objects defining a linear inverse problem.
 
 Inputs:
 
  - `ϕ_star`          :: True parameter value (constrained space)
- - `noise_level`     :: Magnitude of the observational noise
+ - `noise_sd`        :: Magnitude of the observational noise
  - `n_obs`           :: Dimension of the observational vector
  - `rng`             :: Random number generator
  - `obs_corrmat`     :: Correlation structure of the observational noise
@@ -87,12 +145,12 @@ Returns:
  - `Γ`               :: Observational covariance matrix
  - `A`               :: Forward model operator from constrained space
 """
-function linear_inv_problem(ϕ_star, noise_level, n_obs, rng; obs_corrmat = I, return_matrix = false)
+function linear_inv_problem(ϕ_star, noise_sd, n_obs, rng; obs_corrmat = I, return_matrix = false)
     A = linear_map(rng, n_obs)
     # Define forward map from unconstrained space directly
     G(x) = G_linear(x, A)
     y_star = G(ϕ_star)
-    Γ = noise_level^2 * obs_corrmat
+    Γ = noise_sd^2 * obs_corrmat
     noise = MvNormal(zeros(n_obs), Γ)
     y_obs = y_star .+ rand(rng, noise)
     if return_matrix
@@ -103,33 +161,67 @@ function linear_inv_problem(ϕ_star, noise_level, n_obs, rng; obs_corrmat = I, r
 end
 
 """
-    nonlinear_inv_problem(ϕ_star, noise_level, n_obs, rng; obs_corrmat = I; add_or_mult_noise = "add")
+    nonlinear_inv_problem(ϕ_star, noise_sd, n_obs, rng; obs_corrmat = I; add_or_mult_noise = "add")
 
-Returns the objects defining a random nonlinear inverse problem
+Returns the objects defining a random nonlinear inverse problem 
 
 Inputs:
 
  - `ϕ_star`                      :: True parameter value (constrained space)
- - `noise_level`                 :: Magnitude of the observational noise
+ - `noise_sd`                    :: Magnitude of the observational noise
  - `n_obs`                       :: Dimension of the observational vector
  - `rng`                         :: Random number generator
  - `obs_corrmat = I  `           :: Correlation structure of the observational noise 
  - `add_or_mult_noise = nothing` :: additive ["add"] or multiplicative ["mult"] variability optional
-
 Returns:
 
  - `y_obs`           :: Vector of observations
  - `G`               :: Map from constrained space to data space
  - `Γ`               :: Observational covariance matrix
 """
+function nonlinear_inv_problem(ϕ_star, noise_sd, n_obs, rng; obs_corrmat = I, add_or_mult_noise = nothing)
+    Γ = noise_sd^2 * obs_corrmat
+    # G produces a 3D output so must div by 3
+    @assert n_obs % 3 == 0
 
-function nonlinear_inv_problem(ϕ_star, noise_level, n_obs, rng; obs_corrmat = I, add_or_mult_noise = nothing)
-    Γ = noise_level^2 * obs_corrmat
     noise = MvNormal(zeros(n_obs), Γ)
+    internal_noise = MvNormal(zeros(Int(n_obs // 3)), noise_sd^2 * I)
     # Define forward map from unconstrained space directly
-    G(x) = G_nonlinear(x, rng, noise, ϕ_star = ϕ_star, add_or_mult_noise = add_or_mult_noise)
+    G(x) = G_nonlinear(x, rng, internal_noise, ϕ_star = ϕ_star, add_or_mult_noise = add_or_mult_noise)
     # Get observation
     y_star = G(ϕ_star)
     y_obs = y_star .+ rand(rng, noise)
     return y_obs, G, Γ
+end
+
+function nonlinear_inv_problem_old(ϕ_star, noise_sd, n_obs, rng; obs_corrmat = I, add_or_mult_noise = nothing)
+    Γ = noise_sd^2 * obs_corrmat
+    noise = MvNormal(zeros(n_obs), Γ)
+    # Define forward map from unconstrained space directly
+    G(x) = G_nonlinear_old(x, rng, noise, ϕ_star = ϕ_star, add_or_mult_noise = add_or_mult_noise)
+    # Get observation
+    y_star = G(ϕ_star)
+    y_obs = y_star .+ rand(rng, noise)
+    return y_obs, G, Γ
+end
+
+
+function plot_inv_problem_ensemble(prior, ekp, filepath)
+    gr()
+    ϕ_prior = transform_unconstrained_to_constrained(prior, get_u_prior(ekp))
+    ϕ_final = get_ϕ_final(prior, ekp)
+    p = plot(ϕ_prior[1, :], ϕ_prior[2, :], seriestype = :scatter, label = "Initial ensemble")
+    plot!(ϕ_final[1, :], ϕ_final[2, :], seriestype = :scatter, label = "Final ensemble")
+
+    plot!(
+        [ϕ_star[1]],
+        xaxis = "cons_p",
+        yaxis = "uncons_p",
+        seriestype = "vline",
+        linestyle = :dash,
+        linecolor = :red,
+        label = :none,
+    )
+    plot!([ϕ_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = :none)
+    savefig(p, filepath)
 end

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -2,29 +2,24 @@ using Distributions
 using LinearAlgebra
 using Random
 using Test
-
+using Plots
 using EnsembleKalmanProcesses
 using EnsembleKalmanProcesses.ParameterDistributions
-using EnsembleKalmanProcesses.Localizers
 import EnsembleKalmanProcesses: construct_mean, construct_cov, construct_sigma_ensemble
 const EKP = EnsembleKalmanProcesses
-
-
 
 # Read inverse problem definitions
 include("inverse_problem.jl")
 
-n_obs = 30                  # dimension of synthetic observation from G(u)
+n_obs = 12                  # dimension of synthetic observation from G(u)
 ϕ_star = [-1.0, 2.0]        # True parameters in constrained space
 n_par = size(ϕ_star, 1)
 noise_level = 0.1           # Defining the observation noise level (std)
-N_ens = 50                  # number of ensemble members
-N_iter = 20
+N_ens = 30                  # number of ensemble members
+N_iter = 100
 
-# Test different AbstractMatrices as covariances
-obs_corrmats = [I, Matrix(I, n_obs, n_obs), Diagonal(Matrix(I, n_obs, n_obs))]
-# Test different localizers
-loc_methods = [RBF(2.0), Delta(), NoLocalization(), NoLocalization()]
+# Test different AbstractMatrix types as covariances
+obs_corrmats = [1.0 * I, Matrix(1.0 * I, n_obs, n_obs), Diagonal(Matrix(1.0 * I, n_obs, n_obs))]
 
 #### Define prior information on parameters assuming independence of cons_p and uncons_p
 prior_1 = Dict("distribution" => Parameterized(Normal(0.0, 0.5)), "constraint" => bounded(-2, 2), "name" => "cons_p")
@@ -32,7 +27,6 @@ prior_2 = Dict("distribution" => Parameterized(Normal(3.0, 0.5)), "constraint" =
 prior = ParameterDistribution([prior_1, prior_2])
 prior_mean = mean(prior)
 prior_cov = cov(prior)
-
 # Define a few inverse problems to compare algorithmic performance
 rng_seed = 42
 rng = Random.MersenneTwister(rng_seed)
@@ -55,8 +49,20 @@ nl_inv_problems = [
         )...,
         nothing,
     ),
+    (
+        nonlinear_inv_problem(
+            ϕ_star,
+            noise_level,
+            n_obs,
+            rng,
+            obs_corrmat = obs_corrmats[3],
+            add_or_mult_noise = "mult",
+        )...,
+        nothing,
+    ),
 ]
 inv_problems = [inv_problems..., nl_inv_problems...]
+
 @testset "Inverse problem definition" begin
 
     rng = Random.MersenneTwister(rng_seed)
@@ -69,7 +75,7 @@ inv_problems = [inv_problems..., nl_inv_problems...]
     @test size(y_obs) == (n_obs,)
 
     # sum(y-G)^2 ~ n_obs*noise_level^2
-    @test isapprox(norm(y_obs .- A * ϕ_star)^2 - n_obs * noise_level^2, 0; atol = 0.05)
+    @test isapprox(norm(y_obs .- A * ϕ_star)^2 - n_obs * noise_level^2, 0; atol = 0.06)
 end
 
 
@@ -143,10 +149,10 @@ end
     #test
     processes = [
         Inversion(),
-        #        Unscented(prior), TO BE UNCOMMENTED WHEN UKI BUG-FIXED
+        Unscented(prior; impose_prior = true),
         #Sparse inversion tests in test/SparseInversion/runtests.jl
     ]
-    T_end = 3 # (this could fail a test if N_iters is not enough to reach T_end)
+    T_end = 1 # (this could fail a test if N_iters is not enough to reach T_end)
     for process in processes
         schedulers = [
             DefaultScheduler(0.05),
@@ -196,14 +202,28 @@ end
                 end
             end
         end
-        for i in 1:length(final_means)
+        if nameof(typeof(process)) == Inversion
+            for i in 1:length(final_means)
+                u_star = transform_constrained_to_unconstrained(prior, ϕ_star)
+                inv_sqrt_Γy = sqrt(inv(Γy))
+                # @test norm(u_star - final_means[i]) < norm(u_star - init_means[i])
+                @test norm(inv_sqrt_Γy * (y_obs .- G(transform_unconstrained_to_constrained(prior, final_means[i])))) <
+                      norm(inv_sqrt_Γy * (y_obs .- G(transform_unconstrained_to_constrained(prior, init_means[i]))))
+
+            end
+        elseif nameof(typeof(process)) == Unscented
+            # we are regularizing by the prior, therefore we must account for this in the metric of success
             u_star = transform_constrained_to_unconstrained(prior, ϕ_star)
             inv_sqrt_Γy = sqrt(inv(Γy))
-            #            @test norm(u_star - final_means[i]) < norm(u_star - init_means[i])
-            @test norm(inv_sqrt_Γy * (y_obs .- G(transform_unconstrained_to_constrained(prior, final_means[i])))) <
-                  norm(inv_sqrt_Γy * (y_obs .- G(transform_unconstrained_to_constrained(prior, init_means[i]))))
-
+            # compare stats in unconstrained space
+            prior_mean = mean(prior)
+            inv_sqrt_prior_cov = sqrt(inv(cov(prior)))
+            @test norm(inv_sqrt_Γy * (y_obs .- G(transform_unconstrained_to_constrained(prior, final_means[i]))))^2 +
+                  norm(inv_sqrt_prior_cov * (final_means[i] .- prior_mean))^2 <
+                  norm(inv_sqrt_Γy * (y_obs .- G(transform_unconstrained_to_constrained(prior, init_means[i]))))^2 +
+                  norm(inv_sqrt_prior_cov * (init_means[i] .- prior_mean))^2
         end
+
     end
 end
 
@@ -215,7 +235,7 @@ end
     initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
     @test size(initial_ensemble) == (n_par, N_ens)
 
-    # Global scope to compare against EKI
+    # Global scope to compare against EKS
     global eks_final_results = []
     global eksobjs = []
 
@@ -229,10 +249,13 @@ end
 
         params_0 = get_u_final(eksobj)
         g_ens = G(params_0)
-        g_ens_t = permutedims(g_ens, (2, 1))
 
         @test size(g_ens) == (n_obs, N_ens)
-        @test_throws DimensionMismatch EKP.update_ensemble!(eksobj, g_ens_t)
+
+        if !(size(g_ens, 1) == size(g_ens, 2))
+            g_ens_t = permutedims(g_ens, (2, 1))
+            @test_throws DimensionMismatch EKP.update_ensemble!(eksobj, g_ens_t)
+        end
 
         # EKS iterations
         for i in 1:N_iter
@@ -247,6 +270,9 @@ end
 
         @test initial_guess == get_u_mean(eksobj, 1)
         @test eks_final_result == vec(mean(get_u_final(eksobj), dims = 2))
+        eks_init_spread = tr(get_u_cov(eksobj, 1))
+        eks_final_spread = tr(get_u_cov_final(eksobj))
+        @test eks_final_spread < 2 * eks_init_spread # we wouldn't expect the spread to increase much in any one dimension
 
         ϕ_final_mean = get_ϕ_mean_final(prior, eksobj)
         ϕ_init_mean = get_ϕ_mean(prior, eksobj, 1)
@@ -265,6 +291,9 @@ end
         # Store for comparison with other algorithms
         push!(eks_final_results, eks_final_result)
         push!(eksobjs, eksobj)
+        if TEST_PLOT_OUTPUT
+            plot_inv_problem_ensemble(prior, eksobj, joinpath(@__DIR__, "EKS_test_$(i_prob).png"))
+        end
 
     end
 
@@ -282,8 +311,7 @@ end
     ekiobj = nothing
     eki_final_result = nothing
 
-    for ((i_prob, inv_problem), loc_method, eks_final_result, eksobj) in
-        zip(enumerate(inv_problems), loc_methods, eks_final_results, eksobjs)
+    for ((i_prob, inv_problem), eks_final_result, eksobj) in zip(enumerate(inv_problems), eks_final_results, eksobjs)
 
         # Get inverse problem
         y_obs, G, Γy, A = inv_problem
@@ -300,7 +328,6 @@ end
             Inversion();
             rng = rng,
             failure_handler_method = SampleSuccGauss(),
-            localization_method = loc_method,
             scheduler = scheduler,
         )
         ekiobj_unsafe = EKP.EnsembleKalmanProcess(
@@ -310,7 +337,6 @@ end
             Inversion();
             rng = rng,
             failure_handler_method = IgnoreFailures(),
-            localization_method = loc_method,
             scheduler = scheduler,
         )
 
@@ -335,8 +361,10 @@ end
             EKP.update_ensemble!(ekiobj, g_ens)
             push!(g_ens_vec, g_ens)
             if i == 1
-                g_ens_t = permutedims(g_ens, (2, 1))
-                @test_throws DimensionMismatch EKP.update_ensemble!(ekiobj, g_ens_t)
+                if !(size(g_ens, 1) == size(g_ens, 2))
+                    g_ens_t = permutedims(g_ens, (2, 1))
+                    @test_throws DimensionMismatch EKP.update_ensemble!(ekiobj, g_ens_t)
+                end
             end
             # Correct handling of failures
             @test !any(isnan.(params_i))
@@ -375,6 +403,8 @@ end
         # values
         eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
         eki_final_result = get_u_mean_final(ekiobj)
+        eki_init_spread = tr(get_u_cov(ekiobj, 1))
+        eki_final_spread = tr(get_u_cov_final(ekiobj))
 
         g_mean_init = get_g_mean(ekiobj, 1)
         g_mean_final = get_g_mean_final(ekiobj)
@@ -382,15 +412,18 @@ end
         @test eki_init_result == get_u_mean(ekiobj, 1)
         @test eki_final_result == vec(mean(get_u_final(ekiobj), dims = 2))
 
+        @test eki_final_spread < 2 * eki_init_spread # we wouldn't expect the spread to increase much in any one dimension
+
         ϕ_final_mean = get_ϕ_mean_final(prior, ekiobj)
         ϕ_init_mean = get_ϕ_mean(prior, ekiobj, 1)
-        if isa(loc_method, NoLocalization)
+
+        if nameof(typeof(ekiobj.localizer)) == EKP.Localizers.NoLocalization
             @test norm(ϕ_star - ϕ_final_mean) < norm(ϕ_star - ϕ_init_mean)
             @test norm(y_obs .- G(eki_final_result))^2 < norm(y_obs .- G(eki_init_result))^2
             @test norm(y_obs .- g_mean_final)^2 < norm(y_obs .- g_mean_init)^2
         end
 
-        if i_prob <= n_lin_inv_probs && loc_method == NoLocalization()
+        if i_prob <= n_lin_inv_probs && nameof(typeof(ekiobj.localizer)) == EKP.Localizers.NoLocalization
 
             posterior_cov_inv = (A' * (Γy \ A) + 1 * Matrix(I, n_par, n_par) / prior_cov)
             ols_mean = (A' * (Γy \ A)) \ (A' * (Γy \ y_obs))
@@ -410,22 +443,7 @@ end
 
         # Plot evolution of the EKI particles
         if TEST_PLOT_OUTPUT
-            gr()
-            ϕ_prior = transform_unconstrained_to_constrained(prior, get_u_prior(ekiobj))
-            ϕ_final = get_ϕ_final(prior, ekiobj)
-            p = plot(ϕ_prior[1, :], ϕ_prior[2, :], seriestype = :scatter, label = "Initial ensemble")
-            plot!(ϕ_final[1, :], ϕ_final[2, :], seriestype = :scatter, label = "Final ensemble")
-            plot!(
-                [ϕ_star[1]],
-                xaxis = "cons_p",
-                yaxis = "uncons_p",
-                seriestype = "vline",
-                linestyle = :dash,
-                linecolor = :red,
-                label = :none,
-            )
-            plot!([ϕ_star[2]], seriestype = "hline", linestyle = :dash, linecolor = :red, label = :none)
-            savefig(p, joinpath(@__DIR__, "EKI_test_$(i_prob).png"))
+            plot_inv_problem_ensemble(prior, ekiobj, joinpath(@__DIR__, "EKI_test_$(i_prob).png"))
         end
     end
 end
@@ -435,132 +453,157 @@ end
     # Seed for pseudo-random number generator
     rng = Random.MersenneTwister(rng_seed)
 
-    α_reg = 1.0
-    update_freq = 0
-    process = Unscented(prior; α_reg = α_reg, update_freq = update_freq, sigma_points = "symmetric")
+    #  using augmented system (Tikhonov regularization with Kalman inversion in Chada 
+    #  et al 2020 and Huang et al (2022)) to regularize the inverse problem, which also imposes prior 
+    #  for posterior estimation.
+    #  This should be used when the number of observations is smaller than the number
+    #  of parameters (ill-posed inverse problems). 
+    impose_priors = [false, false, false, true, true, true]
+    update_freqs = [1, 1, 1, 0, 0, 0]
     iters_with_failure = [5, 8, 9, 15]
     failed_particle_index = [1, 2, 3, 1]
 
-    y_obs, G, Γy, A = inv_problems[n_lin_inv_probs] # lin problem with diag noise
+    ukiobj = nothing
+    uki_final_result = nothing
 
-    ukiobj = EKP.EnsembleKalmanProcess(y_obs, Γy, process; rng = rng, failure_handler_method = SampleSuccGauss())
-    ukiobj_unsafe = EKP.EnsembleKalmanProcess(y_obs, Γy, process; rng = rng, failure_handler_method = IgnoreFailures())
-    # test simplex sigma points
-    process_simplex = Unscented(prior; α_reg = α_reg, update_freq = update_freq, sigma_points = "simplex")
-    ukiobj_simplex =
-        EKP.EnsembleKalmanProcess(y_obs, Γy, process_simplex; rng = rng, failure_handler_method = SampleSuccGauss())
+    # checks for the initial vs prior stats 
+    proc_tmp = Unscented([1, 1], [1 0; 0 1]; impose_prior = true)
+    @test proc_tmp.uu_cov[1] == [1.0 0.0; 0.0 1.0]
+    @test proc_tmp.u_mean[1] == [1.0, 1.0]
 
-    # Test incorrect construction throws error
-    @test_throws ArgumentError Unscented(prior; α_reg = α_reg, update_freq = update_freq, sigma_points = "unknowns")
-
-    # UKI iterations
-    u_i_vec = Array{Float64, 2}[]
-    g_ens_vec = Array{Float64, 2}[]
-    failed_index = 1
-    for i in 1:N_iter
-        # Check SampleSuccGauss handler
-        params_i = get_ϕ_final(prior, ukiobj)
-        push!(u_i_vec, get_u_final(ukiobj))
-        g_ens = G(params_i)
-        # Add random failures
-        if i in iters_with_failure
-            g_ens[:, failed_particle_index[failed_index]] .= NaN
-            failed_index += 1
-        end
-
-        EKP.update_ensemble!(ukiobj, g_ens)
-        push!(g_ens_vec, g_ens)
-        if i == 1
-            g_ens_t = permutedims(g_ens, (2, 1))
-            @test_throws DimensionMismatch EKP.update_ensemble!(ukiobj, g_ens_t)
-        end
-        @test !any(isnan.(params_i))
-
-        # Check IgnoreFailures handler
-        if i <= iters_with_failure[1]
-            params_i_unsafe = get_ϕ_final(prior, ukiobj_unsafe)
-            g_ens_unsafe = G(params_i_unsafe)
-            if i < iters_with_failure[1]
-                EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
-            elseif i == iters_with_failure[1]
-                g_ens_unsafe[:, 1] .= NaN
-                #inconsistent behaviour before/after v1.9 regarding NaNs in matrices
-                if (VERSION.major >= 1) && (VERSION.minor >= 9)
-                    # new versions the NaNs break LinearAlgebra.jl
-                    @test_throws ArgumentError EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
-                else
-                    # old versions the NaNs pass through LinearAlgebra.jl
-                    EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
-                    u_unsafe = get_u_final(ukiobj_unsafe)
-                    # Propagation of unhandled failures
-                    @test any(isnan.(u_unsafe))
-                end
+    # if different initial and prior mean/cov
+    proc_tmp = Unscented(prior; impose_prior = true)
+    @test proc_tmp.prior_cov == proc_tmp.uu_cov[1]
+    @test proc_tmp.prior_mean == proc_tmp.u_mean[1]
 
 
-            end
-        end
+    for (i_prob, inv_problem, impose_prior, update_freq) in
+        zip(1:length(inv_problems), inv_problems, impose_priors, update_freqs)
 
-        # Update simplex sigma points
-        EKP.update_ensemble!(ukiobj_simplex, G(get_ϕ_final(prior, ukiobj_simplex)))
-    end
-    push!(u_i_vec, get_u_final(ukiobj))
+        y_obs, G, Γy, A = inv_problem
+        scheduler = DataMisfitController(on_terminate = "continue")
 
-    @test get_u_prior(ukiobj) == u_i_vec[1]
-    @test get_u(ukiobj) == u_i_vec
-    @test isequal(get_g(ukiobj), g_ens_vec)
-    @test isequal(get_g_final(ukiobj), g_ens_vec[end])
-    @test isequal(get_error(ukiobj), ukiobj.err)
-
-    @test isa(construct_mean(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
-    @test isa(construct_mean(ukiobj, rand(rng, 5, 2 * n_par + 1)), Vector{Float64})
-    @test isa(construct_cov(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
-    @test isa(construct_cov(ukiobj, rand(rng, 5, 2 * n_par + 1)), Matrix{Float64})
-    @test isposdef(construct_cov(ukiobj, construct_sigma_ensemble(ukiobj.process, [0.0; 0.0], [1.0 0; 0 0])))
-
-    # UKI results: Test if ensemble has collapsed toward the true parameter 
-    # values
-    uki_init_result = vec(mean(get_u_prior(ukiobj), dims = 2))
-    uki_final_result = get_u_mean_final(ukiobj)
-    uki_simplex_final_result = get_u_mean_final(ukiobj_simplex)
-    ϕ_final_mean = get_ϕ_mean_final(prior, ukiobj)
-    ϕ_init_mean = get_ϕ_mean(prior, ukiobj, 1)
-    u_cov_final = get_u_cov_final(ukiobj)
-    u_cov_init = get_u_cov(ukiobj, 1)
-
-    @test ϕ_init_mean == transform_unconstrained_to_constrained(prior, uki_init_result)
-    @test ϕ_final_mean == transform_unconstrained_to_constrained(prior, uki_final_result)
-
-    @test tr(u_cov_final) < tr(u_cov_init)
-    @test norm(ϕ_star - ϕ_final_mean) < norm(ϕ_star - ϕ_init_mean)
-    @test norm(ϕ_star - transform_unconstrained_to_constrained(prior, uki_simplex_final_result)) <
-          norm(ϕ_star - ϕ_init_mean)
-    # end
-
-    if TEST_PLOT_OUTPUT
-        gr()
-        θ_mean_arr = hcat(ukiobj.process.u_mean...)
-        N_θ, N_ens = size(θ_mean_arr)
-        θθ_std_arr = zeros(Float64, (N_θ, N_ens))
-        for i in 1:(N_ens)
-            for j in 1:N_θ
-                θθ_std_arr[j, i] = sqrt(ukiobj.process.uu_cov[i][j, j])
-            end
-        end
-
-        u_star = transform_constrained_to_unconstrained(prior, ϕ_star)
-        ites = Array(LinRange(1, N_ens, N_ens))
-        p = plot(ites, grid = false, θ_mean_arr[1, :], yerror = 3.0 * θθ_std_arr[1, :], label = "cons_p")
-        plot!(ites, fill(u_star[1], N_ens), linestyle = :dash, linecolor = :grey, label = :none)
-        plot!(
-            ites,
-            grid = false,
-            θ_mean_arr[2, :],
-            yerror = 3.0 * θθ_std_arr[2, :],
-            label = "uncons_p",
-            xaxis = "Iterations",
+        process = Unscented(prior; sigma_points = "symmetric", impose_prior = impose_prior, update_freq = update_freq)
+        ukiobj = EKP.EnsembleKalmanProcess(
+            y_obs,
+            Γy,
+            process;
+            rng = rng,
+            scheduler = scheduler,
+            failure_handler_method = SampleSuccGauss(),
         )
-        plot!(ites, fill(u_star[2], N_ens), linestyle = :dash, linecolor = :grey, label = :none)
-        savefig(p, joinpath(@__DIR__, "UKI_test.png"))
+        ukiobj_unsafe = EKP.EnsembleKalmanProcess(
+            y_obs,
+            Γy,
+            process;
+            rng = rng,
+            scheduler = scheduler,
+            failure_handler_method = IgnoreFailures(),
+        )
+        # test simplex sigma points
+        process_simplex = Unscented(prior; sigma_points = "simplex", impose_prior = impose_prior)
+        ukiobj_simplex = EKP.EnsembleKalmanProcess(
+            y_obs,
+            Γy,
+            process_simplex;
+            rng = rng,
+            scheduler = scheduler,
+            failure_handler_method = SampleSuccGauss(),
+        )
+
+        # Test incorrect construction throws error
+        @test_throws ArgumentError Unscented(prior; sigma_points = "unknowns", impose_prior = impose_prior)
+
+        # UKI iterations
+        u_i_vec = Array{Float64, 2}[]
+        g_ens_vec = Array{Float64, 2}[]
+        failed_index = 1
+        for i in 1:N_iter
+            # Check SampleSuccGauss handler
+            params_i = get_ϕ_final(prior, ukiobj)
+            push!(u_i_vec, get_u_final(ukiobj))
+            g_ens = G(params_i)
+            # Add random failures
+            if i in iters_with_failure
+                g_ens[:, failed_particle_index[failed_index]] .= NaN
+                failed_index += 1
+            end
+
+            EKP.update_ensemble!(ukiobj, g_ens)
+            push!(g_ens_vec, g_ens)
+            if i == 1
+                if !(size(g_ens, 1) == size(g_ens, 2))
+                    g_ens_t = permutedims(g_ens, (2, 1))
+                    @test_throws DimensionMismatch EKP.update_ensemble!(ukiobj, g_ens_t)
+                end
+            end
+            @test !any(isnan.(params_i))
+
+            # Check IgnoreFailures handler
+            if i <= iters_with_failure[1]
+                params_i_unsafe = get_ϕ_final(prior, ukiobj_unsafe)
+                g_ens_unsafe = G(params_i_unsafe)
+                if i < iters_with_failure[1]
+                    EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
+                elseif i == iters_with_failure[1]
+                    g_ens_unsafe[:, 1] .= NaN
+                    #inconsistent behaviour before/after v1.9 regarding NaNs in matrices
+                    if (VERSION.major >= 1) && (VERSION.minor >= 9)
+                        # new versions the NaNs break LinearAlgebra.jl
+                        @test_throws ArgumentError EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
+                    else
+                        # old versions the NaNs pass through LinearAlgebra.jl
+                        EKP.update_ensemble!(ukiobj_unsafe, g_ens_unsafe)
+                        u_unsafe = get_u_final(ukiobj_unsafe)
+                        # Propagation of unhandled failures
+                        @test any(isnan.(u_unsafe))
+                    end
+
+
+                end
+            end
+
+            # Update simplex sigma points
+            EKP.update_ensemble!(ukiobj_simplex, G(get_ϕ_final(prior, ukiobj_simplex)))
+        end
+        push!(u_i_vec, get_u_final(ukiobj))
+
+        @test get_u_prior(ukiobj) == u_i_vec[1]
+        @test get_u(ukiobj) == u_i_vec
+        @test isequal(get_g(ukiobj), g_ens_vec)
+        @test isequal(get_g_final(ukiobj), g_ens_vec[end])
+        @test isequal(get_error(ukiobj), ukiobj.err)
+
+        @test isa(construct_mean(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
+        @test isa(construct_mean(ukiobj, rand(rng, 5, 2 * n_par + 1)), Vector{Float64})
+        @test isa(construct_cov(ukiobj, rand(rng, 2 * n_par + 1)), Float64)
+        @test isa(construct_cov(ukiobj, rand(rng, 5, 2 * n_par + 1)), Matrix{Float64})
+        @test isposdef(construct_cov(ukiobj, construct_sigma_ensemble(ukiobj.process, [0.0; 0.0], [1.0 0; 0 0])))
+
+        # UKI results: Test if ensemble has collapsed toward the true parameter 
+        # values
+        uki_init_result = vec(mean(get_u_prior(ukiobj), dims = 2))
+        uki_final_result = get_u_mean_final(ukiobj)
+        uki_simplex_final_result = get_u_mean_final(ukiobj_simplex)
+        ϕ_final_mean = get_ϕ_mean_final(prior, ukiobj)
+        ϕ_init_mean = get_ϕ_mean(prior, ukiobj, 1)
+        u_cov_final = get_u_cov_final(ukiobj)
+        u_cov_init = get_u_cov(ukiobj, 1)
+
+        @test ϕ_init_mean == transform_unconstrained_to_constrained(prior, uki_init_result)
+        @test ϕ_final_mean == transform_unconstrained_to_constrained(prior, uki_final_result)
+
+        @test tr(u_cov_final) < 2 * tr(u_cov_init)
+        @test norm(ϕ_star - ϕ_final_mean) < norm(ϕ_star - ϕ_init_mean)
+        @test norm(ϕ_star - transform_unconstrained_to_constrained(prior, uki_simplex_final_result)) <
+              norm(ϕ_star - ϕ_init_mean)
+        # end
+        if TEST_PLOT_OUTPUT
+            plot_inv_problem_ensemble(prior, ukiobj, joinpath(@__DIR__, "UKI_test_$(i_prob).png"))
+            plot_inv_problem_ensemble(prior, ukiobj_simplex, joinpath(@__DIR__, "UKI_test_simplex_$(i_prob).png"))
+
+        end
+
     end
 end
 

--- a/test/Localizers/runtests.jl
+++ b/test/Localizers/runtests.jl
@@ -54,6 +54,12 @@ const EKP = EnsembleKalmanProcesses
             EKP.update_ensemble!(ekiobj, g_ens, deterministic_forward_map = true)
         end
 
+        # Check for expansion in some dimension
+        eki_init_spread = tr(get_u_cov(ekiobj, 1))
+        eki_final_spread = tr(get_u_cov_final(ekiobj))
+        @test eki_final_spread < 2 * eki_init_spread
+
+
         # Test that localized version does better in the setting p >> N_ens
         @test get_error(ekiobj)[end] < nonlocalized_error
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #287 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- more consistent plotting between tests
- adjustments to the test problems
- removed inappropriate Localization tests in `EnsembleKalmanProcess/runtests.jl` examples, (they are already properly tested in `Localizers/runtests.jl` ) - These caused blow up without disturbing the ensemble mean, therefore added some spread-checking too to ensure the tr(ensemble cov) does not increase too much


- test UKI with nonlinear problems, not just linear ones
- Added prior Tikhonov regularization for UKI, modified test checks to account for the regularization.
- Changed the default `update_freq` in UKI from 1 to 0. I.e. uses prior cov not current cov by default.
- Minor type change in UKI constructor to allow arrays to be converted to float type internally
- added note to docs RE this update
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.

## UPDATED Example:
To reproduce run `julia --project; ENV["CES_TEST_PLOT_OUTPUT"] = true; ]; test` and look for the figures  `XYZ_test_4.png` in the runtest directory.

Problem: `x in R^2`, and  `y = (||x-x*||_1,||x-x*||_2, ||x-x*||_infty ) + N(0,0.01)`, 100 iterations of methods:
Prior bounded by `[-2,2]` in x axis

### EKI & EKS 

<img src="https://github.com/CliMA/EnsembleKalmanProcesses.jl/assets/47412152/ac03092e-b0b6-4fb6-8dd0-8ab000f5c2a8" width=300> <img src="https://github.com/CliMA/EnsembleKalmanProcesses.jl/assets/47412152/7a275262-a1ee-4bc8-a7cb-b71743387c96" width=300>

### Tikhonov UKI quad & simplex

<img src="https://github.com/CliMA/EnsembleKalmanProcesses.jl/assets/47412152/38017e26-45ac-4b5e-9dc3-15dbd548d040" width=300> <img src="https://github.com/CliMA/EnsembleKalmanProcesses.jl/assets/47412152/21748770-4aa4-47ba-b62f-c70aa57c03bc" width=300>
