### PR TITLE
Schedulers no longer break when particle failures occur

### DIFF
--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -284,6 +284,11 @@ end
 
         # Get inverse problem
         y_obs, G, Γy, A = inv_problem
+        if i_prob == 1
+            scheduler = DataMisfitController(on_terminate = "continue")
+        else
+            scheduler = DefaultScheduler()
+        end
 
         ekiobj = EKP.EnsembleKalmanProcess(
             initial_ensemble,
@@ -293,6 +298,7 @@ end
             rng = rng,
             failure_handler_method = SampleSuccGauss(),
             localization_method = loc_method,
+            scheduler = scheduler,
         )
         ekiobj_unsafe = EKP.EnsembleKalmanProcess(
             initial_ensemble,
@@ -302,6 +308,7 @@ end
             rng = rng,
             failure_handler_method = IgnoreFailures(),
             localization_method = loc_method,
+            scheduler = scheduler,
         )
 
         g_ens = G(get_ϕ_final(prior, ekiobj))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #292 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- added successful_ens filter to calculations of delta t
- added the `DataMisfitController()` into a test case which contains particle failures and it no longer breaks

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
