### PR TITLE
Add == for schedulers

### DIFF
--- a/src/LearningRateSchedulers.jl
+++ b/src/LearningRateSchedulers.jl
@@ -308,3 +308,12 @@ function calculate_timestep!(
     end
     nothing
 end
+
+# overload ==
+function Base.:(==)(lrs_a::LRS, lrs_b::LRS) where {LRS <: LearningRateScheduler}
+    checks = [false for i in 1:length(fieldnames(LRS))]
+    for (i, f) in enumerate(fieldnames(LRS))
+        checks[i] = getfield(lrs_a, f) == getfield(lrs_b, f)
+    end
+    return all(checks)
+end

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -80,23 +80,25 @@ end
     @test dlrs1.Δt_default == Float64(1)
     dlrs2 = EKP.DefaultScheduler(Δt)
     @test dlrs2.Δt_default == Float64(Δt)
+    @test EKP.DefaultScheduler() == EKP.DefaultScheduler()
 
     #Mutable
     mlrs1 = EKP.MutableScheduler()
     @test mlrs1.Δt_mutable == Float64[1]
     mlrs2 = EKP.MutableScheduler(Δt)
     @test mlrs2.Δt_mutable == Float64[Δt]
-
+    @test EKP.MutableScheduler() == EKP.MutableScheduler()
     # EKSStable 
     ekslrs1 = EKP.EKSStableScheduler()
     @test ekslrs1.numerator == Float64(1)
     @test ekslrs1.nugget == Float64(eps())
-
+    @test EKP.EKSStableScheduler() == EKP.EKSStableScheduler()
     num = 3
     nug = 0.0001
     ekslrs2 = EKP.EKSStableScheduler(num, nug)
     @test ekslrs2.numerator == Float64(3)
     @test ekslrs2.nugget == Float64(0.0001)
+
 
     num = Float32(3)
     nug = Float32(0.0001)
@@ -124,6 +126,7 @@ end
     @test dmclrs2.terminate_at == Float64(7)
     dmclrs3 = EKP.DataMisfitController(on_terminate = "continue_fixed")
     @test dmclrs3.on_terminate == "continue_fixed"
+    @test EKP.DataMisfitController() == EKP.DataMisfitController()
 
     # build EKP and eki objects
     # Get an inverse problem


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #297 



## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- add overload to `Base.(==)` for `LearningRateSchedulers`
- add tests

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
