### PR TITLE
minor typo fix for docstring of get_ϕ

### DIFF
--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -271,7 +271,7 @@ end
 """
     get_ϕ(prior::ParameterDistribution, ekp::EnsembleKalmanProcess)
 
-Returns the unconstrained parameters from all iterations. The outer dimension is given by the number of iterations.
+Returns the constrained parameters from all iterations. The outer dimension is given by the number of iterations.
 """
 get_ϕ(prior::ParameterDistribution, ekp::EnsembleKalmanProcess) =
     transform_unconstrained_to_constrained(prior, get_u(ekp))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Fixed a typo in the docstring

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x ] I have read and checked the items on the review checklist.
