### PR TITLE
Unscented accelerator 

### DIFF
--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -665,7 +665,7 @@ function update_ensemble!(
     terminate = calculate_timestep!(ekp, g, Δt_new)
     if isnothing(terminate)
         u = update_ensemble!(ekp, g, get_process(ekp); ekp_kwargs...)
-        update_state!(ekp, u)
+        accelerate!(ekp, u)
         if s > 0.0
             multiplicative_inflation ? multiplicative_inflation!(ekp; s = s) : nothing
             additive_inflation ? additive_inflation!(ekp; use_prior_cov = use_prior_cov, s = s) : nothing
@@ -696,11 +696,13 @@ include("SparseEnsembleKalmanInversion.jl")
 export Sampler
 include("EnsembleKalmanSampler.jl")
 
+
 # struct Unscented
 export Unscented
 export Gaussian_2d
 export construct_initial_ensemble, construct_mean, construct_cov
 include("UnscentedKalmanInversion.jl")
+
 
 # struct Accelerator
 include("Accelerators.jl")

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -54,9 +54,9 @@ Inputs:
 $(METHODLIST)
 """
 mutable struct Unscented{FT <: AbstractFloat, IT <: Int} <: Process
-    "an interable of arrays of size `N_parameters` containing the mean of the parameters (in each `uki` iteration a new array of mean is added)"
+    "an interable of arrays of size `N_parameters` containing the mean of the parameters (in each `uki` iteration a new array of mean is added), note - this is not the same as the ensemble mean of the sigma ensemble as it is taken prior to prediction"
     u_mean::Any  # ::Iterable{AbtractVector{FT}}
-    "an iterable of arrays of size (`N_parameters x N_parameters`) containing the covariance of the parameters (in each `uki` iteration a new array of `cov` is added)"
+    "an iterable of arrays of size (`N_parameters x N_parameters`) containing the covariance of the parameters (in each `uki` iteration a new array of `cov` is added), note - this is not the same as the ensemble cov of the sigma ensemble as it is taken prior to prediction"
     uu_cov::Any  # ::Iterable{AbstractMatrix{FT}}
     "an iterable of arrays of size `N_y` containing the predicted observation (in each `uki` iteration a new array of predicted observation is added)"
     obs_pred::Any # ::Iterable{AbstractVector{FT}}
@@ -226,6 +226,7 @@ function EnsembleKalmanProcess(
     process::Unscented{FT, IT};
     kwargs...,
 ) where {FT <: AbstractFloat, IT <: Int}
+
     # use the distribution stored in process to generate initial ensemble
     init_params = update_ensemble_prediction!(process, 0.0)
 
@@ -237,8 +238,8 @@ function FailureHandler(process::Unscented, method::IgnoreFailures)
         #perform analysis on the model runs
         update_ensemble_analysis!(uki, u, g)
         #perform new prediction output to model parameters u_p
-        u = update_ensemble_prediction!(uki.process, uki.Δt[end])
-        return u
+        u_p = update_ensemble_prediction!(uki.process, uki.Δt[end])
+        return u_p
     end
     return FailureHandler{Unscented, IgnoreFailures}(failsafe_update)
 end
@@ -292,17 +293,17 @@ function FailureHandler(process::Unscented, method::SampleSuccGauss)
         push!(uki.process.obs_pred, g_mean) # N_ens x N_data
         push!(uki.process.u_mean, u_mean) # N_ens x N_params
         push!(uki.process.uu_cov, uu_cov) # N_ens x N_data
-
         push!(uki.g, DataContainer(g, data_are_columns = true))
 
         compute_error!(uki)
+
     end
     function failsafe_update(uki, u, g, failed_ens)
         #perform analysis on the model runs
         succ_gauss_analysis!(uki, u, g, failed_ens)
         #perform new prediction output to model parameters u_p
-        u = update_ensemble_prediction!(uki.process, uki.Δt[end])
-        return u
+        u_p = update_ensemble_prediction!(uki.process, uki.Δt[end])
+        return u_p
     end
     return FailureHandler{Unscented, SampleSuccGauss}(failsafe_update)
 end
@@ -550,7 +551,10 @@ end
 
 UKI prediction step : generate sigma points.
 """
-function update_ensemble_prediction!(process::Unscented, Δt::FT) where {FT <: AbstractFloat}
+function update_ensemble_prediction!(
+    process::Unscented,
+    Δt::FT,
+) where {FT <: AbstractFloat, AV <: AbstractVector, AM <: AbstractMatrix}
 
     process.iter += 1
     # update evolution covariance matrix
@@ -565,7 +569,7 @@ function update_ensemble_prediction!(process::Unscented, Δt::FT) where {FT <: A
     r = process.r
     Σ_ω = process.Σ_ω
 
-    N_par = length(process.u_mean[1])
+    N_par = length(u_mean[1])
     ############# Prediction step:
 
     u_p_mean = α_reg * u_mean + (1 - α_reg) * r
@@ -623,10 +627,10 @@ function update_ensemble_analysis!(
     push!(uki.process.obs_pred, g_mean) # N_ens x N_data
     push!(uki.process.u_mean, u_mean) # N_ens x N_params
     push!(uki.process.uu_cov, uu_cov) # N_ens x N_data
-
     push!(uki.g, DataContainer(g, data_are_columns = true))
 
     compute_error!(uki)
+
 end
 
 """
@@ -677,7 +681,6 @@ function update_ensemble!(
 
     u_p = fh.failsafe_update(uki, u_p_old, g_in, failed_ens)
 
-    push!(uki.u, DataContainer(u_p, data_are_columns = true))
 
     if uki.verbose
         cov_new = get_u_cov_final(uki)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #333


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Adds the accelerator method to `Unscented`. This implementation moves the sigma points (as it is the "ensemble") and then saves the reconstructed the mean and covariance from the new sigma point locations. Note one additional subtlety, the saved "u_mean" and "uu_cov" are not just the mean and cov of the sigma points, and so are back calculated
- Adds unit tests & removed some unnecessary ensemble members / iterations in the accelerator test
- renames the ambiguous `update_state!` to `accelerate!`

## Unit test output

```
Accelerator: DefaultAccelerator Process: Inversion
┌ Info: Convergence:
│   cost_initial = 48.24023862169107
└   cost_final = 4.489933318021739
Accelerator: NesterovAccelerator Process: Inversion
┌ Info: Convergence:
│   cost_initial = 48.24023862169107
└   cost_final = 5.6012259995349245
Accelerator: DefaultAccelerator Process: TransformInversion
┌ Info: Convergence:
│   cost_initial = 48.24023862169107
└   cost_final = 4.434232345531697
Accelerator: NesterovAccelerator Process: TransformInversion
┌ Info: Convergence:
│   cost_initial = 48.24023862169107
└   cost_final = 4.955048376140534
Accelerator: DefaultAccelerator Process: Unscented
┌ Info: Convergence:
│   cost_initial = 53.28933708166123
└   cost_final = 5.84078511368908
Accelerator: NesterovAccelerator Process: Unscented
┌ Info: Convergence:
│   cost_initial = 53.28933708166123
└   cost_final = 6.29489453592627
Accelerator: DefaultAccelerator Process: Sampler
┌ Info: Convergence:
│   cost_initial = 48.24023862169107
└   cost_final = 14.943442588378828
Accelerator: NesterovAccelerator Process: Sampler
┌ Warning: Acceleration is experimental for Sampler processes and may affect convergence.
└ @ EnsembleKalmanProcesses ~/work/EnsembleKalmanProcesses.jl/EnsembleKalmanProcesses.jl/src/EnsembleKalmanProcess.jl:220
┌ Info: Convergence:
│   cost_initial = 48.24023862169107
└   cost_final = 15.733653014250967
```

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
