### PR TITLE
bugfix logpdf broadcasting

### DIFF
--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -668,13 +668,11 @@ function logpdf(d::VectorOfParameterized, xarray::VV) where {VV <: AbstractVecto
     dimensions = get_dimensions(d)
     lpdfsum = 0.0
     # perform the logpdf of each of the distributions, and returns their sum    
-    for (i, dd) in enumerate(d.distribution)
-        println(dd)
-        println(xarray[batches[i]])
-        if dimensions[i] == 1
-            lpdfsum += logpdf(dd, xarray[batches[i]][1])
+    for (i, dd, dimen, batch) in zip(1:length(d.distribution), d.distribution, dimensions, batches)
+        if dimen == 1
+            lpdfsum += logpdf(dd, xarray[batch][1]) # needs to be eval on a scalar
         else
-            lpdfsum += logpdf(dd, xarray[batches[i]])
+            lpdfsum += logpdf(dd, xarray[batch])
         end
     end
     return lpdfsum

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -652,7 +652,7 @@ Obtains the independent logpdfs of the parameter distributions at `xarray`
 logpdf(d::Parameterized, x::FT) where {FT <: Real} = logpdf(d, [x]) # make into 1D array
 
 function logpdf(d::Parameterized, xarray::VV) where {VV <: AbstractVector}
-    dimension = get_dimensions(d)
+    dimension = ndims(d)
     if dimension != length(xarray)
         throw(
             DimensionMismatch("cannot evaluate logpdf with distribution $dimension on array length $(length(xarray))"),

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -539,6 +539,8 @@ using EnsembleKalmanProcesses.ParameterDistributions
         x_in_bd = [0.5, 0.5, 0.5]
         Random.seed!(seed)
         lpdf3 = sum([logpdf(Beta(2, 2), x_in_bd[1])[1], logpdf(MvNormal(zeros(2), 0.1 * I), x_in_bd[2:3])[1]]) #throws deprecated warning without "."
+        @test_throws DimensionMismatch logpdf(u1, [1]) #u1 is 4D, 1 is 1-D
+
 
         Random.seed!(seed)
         @test isapprox(logpdf(u3, x_in_bd) - lpdf3, 0.0; atol = 1e-6)

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -538,13 +538,15 @@ using EnsembleKalmanProcesses.ParameterDistributions
         @test_throws ErrorException logpdf(u, zeros(ndims(u)))
         x_in_bd = [0.5, 0.5, 0.5]
         Random.seed!(seed)
-        lpdf3 = sum([logpdf(Beta(2, 2), x_in_bd[1])[1], logpdf(MvNormal(zeros(2), 0.1 * I), x_in_bd[2:3])[1]]) #throws deprecated warning without "."
-        @test_throws DimensionMismatch logpdf(u1, [1]) #u1 is 4D, 1 is 1-D
-
-
+        # for VectorOfParameterized
+        lpdf3 = sum([logpdf(Beta(2, 2), x_in_bd[1])[1], logpdf(MvNormal(zeros(2), 0.1 * I), x_in_bd[2:3])[1]]) #throws deprecated warning without "."     
         Random.seed!(seed)
         @test isapprox(logpdf(u3, x_in_bd) - lpdf3, 0.0; atol = 1e-6)
         @test_throws DimensionMismatch logpdf(u3, [0.5, 0.5])
+        # for Parameterized
+        x_in_bd = [0.0, 0.0, 0.0, 0.0]
+        @test isapprox(logpdf(u1, x_in_bd) - logpdf(MvNormal(zeros(4), 0.1 * I), x_in_bd)[1], 0.0, atol = 1e-6)
+        @test_throws DimensionMismatch logpdf(u1, [1])
 
         #Test for cov, var        
         block_cov = cat([cov(d1), var(d2), cov(d3), cov(d4)]..., dims = (1, 2))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #363 


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Removes accidental broadcast of logpdf (which causes errors when applying logpdf to multivariate julia-Distributions types)
- adds tests

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
