### PR TITLE
Feature/multilevel

### DIFF
--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -37,7 +37,7 @@ abstract type Accelerator end
 "Failure handling method that ignores forward model failures"
 struct IgnoreFailures <: FailureHandlingMethod end
 
-""""
+"""
     SampleSuccGauss <: FailureHandlingMethod
 
 Failure handling method that substitutes failed ensemble members by new samples from

--- a/src/EnsembleTransformKalmanInversion.jl
+++ b/src/EnsembleTransformKalmanInversion.jl
@@ -32,7 +32,7 @@ function FailureHandler(process::TransformInversion, method::SampleSuccGauss)
         n_failed = length(failed_ens)
         u[:, successful_ens] = etki_update(ekp, u[:, successful_ens], g[:, successful_ens], y, obs_noise_cov)
         if !isempty(failed_ens)
-            u[:, failed_ens] = sample_empirical_gaussian(ekp.rng, u[:, successful_ens], n_failed)
+            u[:, failed_ens] = sample_empirical_gaussian(ekp.rng, ekp, u, n_failed; ignored_indices = failed_ens)
         end
         return u
     end

--- a/src/Multilevel.jl
+++ b/src/Multilevel.jl
@@ -1,0 +1,76 @@
+export SingleLevelScheduler, MultilevelScheduler, get_N_ens, get_N_indep, levels, transform_noise
+
+struct LevelInfinity end
+
+const SingleLevelType{IT} = Union{IT, LevelInfinity}
+
+struct MultilevelScheduler{IT <: Integer} <: LevelScheduler
+    Js::Dict{IT, IT}
+    N_indep::IT
+    N_ens::IT
+
+    function MultilevelScheduler(Js::Dict{IT, IT}) where {IT <: Integer}
+        N_indep = sum(values(Js))
+        N_ens = sum(J * (level == 0 ? 1 : 2) for (level, J) in Js)
+
+        new{IT}(Js, N_indep, N_ens)
+    end
+end
+
+struct SingleLevelScheduler{IT <: Integer} <: LevelScheduler
+    N_ens::IT
+    level::SingleLevelType{IT}
+
+    function SingleLevelScheduler(N_ens::IT, level::SingleLevelType{IT} = LevelInfinity()) where {IT <: Integer}
+        new{IT}(N_ens, level)
+    end
+end
+
+
+get_N_ens(ms::MultilevelScheduler) = ms.N_ens
+
+get_N_indep(ms::MultilevelScheduler) = ms.N_indep
+
+levels(ms::MultilevelScheduler) = begin
+    vcat(
+        fill(0, ms.Js[0]),
+        (fill(l, ms.Js[l]) for l in sort(collect(keys(ms.Js))) if l != 0)...,
+        (fill(l - 1, ms.Js[l]) for l in sort(collect(keys(ms.Js))) if l != 0)...,
+    )
+end
+
+transform_noise(ms::MultilevelScheduler, noise::AbstractMatrix{FT}) where {FT <: Real} = begin
+    @assert size(noise, 2) == ms.N_indep
+
+    noise[:, vcat(1:ms.N_indep, ms.Js[0]+1:ms.N_indep)]
+end
+
+statistic_groups(ms::MultilevelScheduler) = begin
+    groups = []
+
+    offset = ms.N_indep - ms.Js[0]
+
+    index = 0;
+    for level in sort(collect(keys(ms.Js)))
+        J = ms.Js[level]
+        push!(groups, (index+1:index+J, 1))
+        if level > 0
+            push!(groups, (index+offset+1:index+offset+J, -1))
+        end
+
+        index += J
+    end
+
+    groups
+end
+
+
+get_N_ens(sls::SingleLevelScheduler) = sls.N_ens
+
+get_N_indep(sls::SingleLevelScheduler) = sls.N_ens
+
+levels(sls::SingleLevelScheduler) = fill(sls.level, sls.N_ens)
+
+transform_noise(sls::SingleLevelScheduler, noise::AbstractMatrix{FT}) where {FT <: Real} = noise
+
+statistic_groups(sls::SingleLevelScheduler) = [(1:sls.N_ens, 1)]

--- a/src/SampleStatistics.jl
+++ b/src/SampleStatistics.jl
@@ -9,14 +9,16 @@ function posdef(mat)
     V * diagm(S) * V'
 end
 
-function compute_mean(ekp::EnsembleKalmanProcess, u)
-    foldl(statistic_groups(ekp.level_scheduler); init = 0) do acc, (indices, multiplier)
-        multiplier * mean(u[:, indices]; dims = 2) .+ acc
+function compute_mean(ekp::EnsembleKalmanProcess, x; ignored_indices = [])
+    reduce(statistic_groups(ekp.level_scheduler); init = 0) do acc, (indices, multiplier)
+        indices = setdiff(indices, ignored_indices)
+        multiplier * mean(x[:, indices]; dims = 2) .+ acc
     end
 end
 
-function compute_cov(ekp::EnsembleKalmanProcess, u, g; corrected)
-    foldl(statistic_groups(ekp.level_scheduler); init = 0) do acc, (indices, multiplier)
-        multiplier * cov([u; g][:, indices]; corrected = false, dims = 2) .+ acc
+function compute_cov(ekp::EnsembleKalmanProcess, x; corrected, ignored_indices = [])
+    reduce(statistic_groups(ekp.level_scheduler); init = 0) do acc, (indices, multiplier)
+        indices = setdiff(indices, ignored_indices)
+        multiplier * cov(x[:, indices]; corrected, dims = 2) .+ acc
     end
 end

--- a/src/SampleStatistics.jl
+++ b/src/SampleStatistics.jl
@@ -1,0 +1,22 @@
+# included in EnsembleKalmanProcess.jl
+
+export compute_mean, compute_cov
+
+function posdef(mat)
+    S, V = eigen(mat)
+    V = V[:, (S .> 0)]
+    S = S[S .> 0]
+    V * diagm(S) * V'
+end
+
+function compute_mean(ekp::EnsembleKalmanProcess, u)
+    foldl(statistic_groups(ekp.level_scheduler); init = 0) do acc, (indices, multiplier)
+        multiplier * mean(u[:, indices]; dims = 2) .+ acc
+    end
+end
+
+function compute_cov(ekp::EnsembleKalmanProcess, u, g; corrected)
+    foldl(statistic_groups(ekp.level_scheduler); init = 0) do acc, (indices, multiplier)
+        multiplier * cov([u; g][:, indices]; corrected = false, dims = 2) .+ acc
+    end
+end

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -56,7 +56,7 @@ function FailureHandler(process::SparseInversion, method::SampleSuccGauss)
         u[:, successful_ens] =
             sparse_eki_update(ekp, u[:, successful_ens], g[:, successful_ens], y[:, successful_ens], obs_noise_cov)
         if !isempty(failed_ens)
-            u[:, failed_ens] = sample_empirical_gaussian(ekp.rng, u[:, successful_ens], n_failed)
+            u[:, failed_ens] = sample_empirical_gaussian(ekp.rng, ekp, u, n_failed; ignored_indices = failed_ens)
         end
         return u
     end

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -960,7 +960,9 @@ end
     rng = Random.MersenneTwister(rng_seed)
 
     u = rand(10, 4)
+    ekp = EKP.EnsembleKalmanProcess(u, [1.;], [1.;;], Inversion())
     @test_logs (:warn, r"Sample covariance matrix over ensemble is singular.") match_mode = :any sample_empirical_gaussian(
+        ekp,
         u,
         2,
     )
@@ -968,8 +970,8 @@ end
     u2 = rand(rng, 5, 20)
     @test all(
         isapprox.(
-            sample_empirical_gaussian(copy(rng), u2, 2),
-            sample_empirical_gaussian(copy(rng), u2, 2, inflation = 0.0);
+            sample_empirical_gaussian(copy(rng), ekp, u2, 2),
+            sample_empirical_gaussian(copy(rng), ekp, u2, 2, inflation = 0.0);
             atol = 1e-8,
         ),
     )

--- a/test/Multilevel/runtests.jl
+++ b/test/Multilevel/runtests.jl
@@ -87,8 +87,8 @@ end
 
     println(multilevel_cost, " ", multilevel_error)
     println(single_level_cost, " ", single_level_errors)
-    @assert multilevel_cost < 0.5 * single_level_cost
+    @test multilevel_cost < 0.5 * single_level_cost
     for single_level_error in single_level_errors
-        @assert multilevel_error < 0.5 * single_level_error
+        @test multilevel_error < single_level_error
     end
 end

--- a/test/Multilevel/runtests.jl
+++ b/test/Multilevel/runtests.jl
@@ -1,0 +1,94 @@
+using Distributions
+using LinearAlgebra
+using Random
+using Test
+
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+const EKP = EnsembleKalmanProcesses
+
+Random.seed!(123)
+artificial_noise = randn(2)
+
+forward_model(u; level) = begin
+    p(x) = u[2]*x + exp(-u[1])*(-x^2/2 + x/2)
+    exact_solution = [p(.25); p(.75)]
+    exact_solution + u.^2/norm(u.^2) .* artificial_noise / (10 * 2^(level+1))
+end
+
+@testset "Multilevel" begin
+    # Seed for pseudo-random number generator
+    rng_seed = 42
+    rng = Random.MersenneTwister(rng_seed)
+
+    priors = [
+        ParameterDistribution(Parameterized(Normal(-3, 1)), no_constraint(), "u1"),
+        ParameterDistribution(Parameterized(Normal(105, 5)), no_constraint(), "u2"),
+    ]
+    prior = combine_distributions(priors)
+
+    y = [27.5; 79.7]
+    Γ = 0.01 * I
+    N_iter = 10
+    lrs = DefaultScheduler(1)
+
+    # Approximate mean-field limit
+    println("Approximating mean field")
+    N_ens = 200_000
+    level = 30
+    initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
+    eki = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, scheduler=lrs)
+    for i in 1:N_iter
+        u = get_u_final(eki)
+        g_ens = hcat((forward_model(u[:,j]; level) for j in 1:N_ens)...)
+        EKP.update_ensemble!(eki, g_ens)
+    end
+    mean_field_limit_approx_mean = compute_mean(eki, get_u_final(eki))
+
+    # Single-level approximation
+    println("Approximating single-level")
+    num_avg = 5
+    single_level_cost = 2^20
+    single_level_errors = map(4:10) do level
+        N_ens = floor(Int, single_level_cost / 2^level)
+        mean(1:num_avg) do _
+            initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
+            eki = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, scheduler=lrs)
+            for i in 1:N_iter
+                u = get_u_final(eki)
+                g_ens = hcat((forward_model(u[:,j]; level) for j in 1:N_ens)...)
+                EKP.update_ensemble!(eki, g_ens)
+            end
+            norm(mean_field_limit_approx_mean - compute_mean(eki, get_u_final(eki)))
+        end
+    end
+
+    # Multilevel approximation
+    println("Approximating multilevel")
+    max_level = 9
+    Js = Dict(level => floor(Int, 20 * 2^((max_level - level) * 4/3)) for level in 0:max_level)
+    level_scheduler = MultilevelScheduler(Js)
+    N_ens = get_N_ens(level_scheduler)
+    num_avg = 5
+    multilevel_error = mean(1:num_avg) do _
+        initial_ensemble = EKP.construct_initial_ensemble(rng, prior, get_N_indep(level_scheduler))
+        initial_ensemble = transform_noise(level_scheduler, initial_ensemble)
+        eki = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng, level_scheduler, scheduler=lrs)
+        for i in 1:N_iter
+            u = get_u_final(eki)
+            g_ens = hcat((forward_model(u[:,j]; level) for (j, level) in zip(1:N_ens, levels(level_scheduler)))...)
+            EKP.update_ensemble!(eki, g_ens)
+        end
+        norm(mean_field_limit_approx_mean - compute_mean(eki, get_u_final(eki)))
+    end
+    multilevel_cost = reduce(Js; init = 0) do acc, (level, J)
+        acc + J * 2^level + (level == 0 ? 0 : J * 2^(level - 1))
+    end
+
+    println(multilevel_cost, " ", multilevel_error)
+    println(single_level_cost, " ", single_level_errors)
+    @assert multilevel_cost < 0.5 * single_level_cost
+    for single_level_error in single_level_errors
+        @assert multilevel_error < 0.5 * single_level_error
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ end
         "TOMLInterface",
         "SparseInversion",
         "Inflation",
+        "Multilevel",
     ]
         if all_tests || has_submodule(submodule) || "EnsembleKalmanProcesses" in ARGS
             include_test(submodule)


### PR DESCRIPTION
## Purpose 
Add [multilevel Monte Carlo simulation](https://arxiv.org/abs/2405.10146) to EKI.

This technique uses a hierarchy of accuracy levels to the forward model. Most EKI particles will use coarse, cheap models, while only a few need to simulate the full-resolution model.

## To-do
This PR is a proof of concept. I have attempted an implementation that is as non-intrusive as possible, but there are many ways to implement our MLMC algorithm, so I can adapt to feedback by the maintainers. This draft PR serves to gauge whether EKP.jl is interested in multilevel particle methods, while at the same time showing that implementing this is feasible. The implementation is not documented yet; if the maintainers decide that MLMC is desirable, I will of course add documentation.

MLMC, as proposed in the paper linked above, also applies to other particle methods such as EKS. This proof of concept is purposefully limited to EKI.

## Content
- A `LevelScheduler` object assigns *levels* to each particle in the ensemble. When evaluating the forward model in a particle, the corresponding level determines the minimum accuracy for the forward-model evaluation.
- The random noise used throughout EKI needs to be correlated for specific particles in the ensemble (see paper). This is also dictated by the `LevelScheduler`.