### PR TITLE
Update groups, i.e. domain and observation localization

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,7 +9,8 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
-       matrix:
+      fail-fast: false #don't cancel all jobs if one fails
+      matrix:
         version:
           - 'lts' # Long-Term Support release
           - '1' # Latest 1.x release of julia

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,7 +9,6 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
        matrix:
         version:
           - 'lts' # Long-Term Support release

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,6 +9,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
+        fail-fast: false
        matrix:
         version:
           - 'lts' # Long-Term Support release
@@ -17,7 +18,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        fail-fast: false
     steps:
       - uses: styfle/cancel-workflow-action@0.9.1
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -17,6 +17,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
+        fail-fast: false
     steps:
       - uses: styfle/cancel-workflow-action@0.9.1
         with:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -82,6 +82,7 @@ pages = [
     "Learning rate schedulers" => "learning_rate_scheduler.md",
     "Prior distributions" => "parameter_distributions.md",
     "Observations and Minibatching" => "observations.md",
+    "Update Groups" => "update_groups.md",
     "Localization and SEC" => "localization.md",
     "Inflation" => "inflation.md",
     "Parallelism and HPC" => "parallel_hpc.md",

--- a/docs/src/update_groups.md
+++ b/docs/src/update_groups.md
@@ -44,7 +44,11 @@ observation_vec = []
 for i in 1:length(data_block_names)
     push!(
         observation_vec,
-        Observation(Dict("samples" => y[i], "covariances" => Γ[i], "names" => data_block_names[i])),
+        Observation(Dict(
+            "samples" => y[i],
+            "covariances" => Γ[i],
+            "names" => data_block_names[i]
+        )),
     )
 end
 observation = combine_observations(observation_vec)
@@ -64,8 +68,13 @@ update_groups = create_update_groups(prior, observation, group_identifiers)
 ```
 and this can then be entered into the `EnsembleKalmanProcess` object as a keyword argument
 ```julia
-# ... initial_params = construct_initial_ensemble(rng, priors, N_ens)
-ekiobj = EnsembleKalmanProcess(initial_params, observation, Inversion(), update_groups = update_groups)
+# initial_params = construct_initial_ensemble(rng, priors, N_ens) 
+ekiobj = EnsembleKalmanProcess(
+    initial_params,
+    observation,
+    Inversion(),
+    update_groups = update_groups
+)
 ```
 
 ## Advice for constructing blocks

--- a/docs/src/update_groups.md
+++ b/docs/src/update_groups.md
@@ -1,0 +1,71 @@
+# [Update Groups] (@id update-groups)
+
+The `UpdateGroup` object facilitates blocked EKP updates, based on a provided updating a series of blocks of paired (parameters and data). As many of the `Process` updates can scale quadraticly in the data dimension, this reduces computational complexity of the update.
+
+##  Recommended construction
+
+The key component to construct update groups starts with constructing the prior, and the observations. Parameter distributions and observations may be constructed in units and given names, and these names are utilized to build the update groups with a convenient constructor.
+
+For example, we take code snippets from the example found in `examples/UpdateGroups/calibrate.jl`. This example is concerned with learning several parameters in a coupled Lorenz 96 multiscale system, by gathering data from moments from the fast `Y` and slow `X` moments.
+
+In this exmaple the parameter distribution we create a prior from several *named* distributions.
+```julia
+param_names = ["F", "G", "h", "c", "b"]
+
+prior_F = ParameterDistribution(
+    Dict(
+        "name" => param_names[1],
+        "distribution" => Parameterized(MvNormal([1.0, 0.0, -2.0], I)),
+        "constraint" => repeat([bounded_below(0)], 3),
+    ),
+) # gives 3-D dist
+prior_G = constrained_gaussian(param_names[2], 5.0, 4.0, 0, Inf)
+prior_h = constrained_gaussian(param_names[3], 5.0, 4.0, 0, Inf)
+prior_c = constrained_gaussian(param_names[4], 5.0, 4.0, 0, Inf)
+prior_b = constrained_gaussian(param_names[5], 5.0, 4.0, 0, Inf)
+priors = combine_distributions([prior_F, prior_G, prior_h, prior_c, prior_b])
+```
+Now we likewise construct blocked observations from several *named* observations
+```julia
+# given a list of vector statistics y and their covariances Γ 
+data_block_names = ["<X>", "<Y>", "<X^2>", "<Y^2>", "<XY>"]
+
+observation_vec = []
+for i in 1:length(data_block_names)
+    push!(
+        observation_vec,
+        Observation(Dict("samples" => y[i], "covariances" => Γ[i], "names" => data_block_names[i])),
+    )
+end
+observation = combine_observations(observation_vec)
+```
+Now we define the update groups of our choice as a dictionary, this is the critical feature of interest here. In this case we create two blocks (though one could create other updates here)
+```julia
+# update parameters F,G with data <X>,<X^2>
+# update parameters h, c, b with data <Y>, <Y^2>, <XY>
+group_identifiers = Dict(
+    ["F", "G"] => ["<X>", "<X^2>"],
+    ["h", "c", "b"] => ["<Y>", "<Y^2>", "<XY>"],
+)
+```
+We then create the update groups with our constructor
+```julia
+update_groups = create_update_groups(prior, observation, group_identifiers)
+```
+and this can then be entered into the `EnsembleKalmanProcess` object as a keyword argument
+```julia
+# ... initial_params = construct_initial_ensemble(rng, priors, N_ens)
+ekiobj = EnsembleKalmanProcess(initial_params, observation, Inversion(), update_groups = update_groups)
+```
+
+## Advice for constructing blocks
+1. The blocks cannot contain repeated parameters (i.e. parameters cannot be updated "twice")
+2. Block structure is user-defined, and directly assumes that there is no correlation between blocks. It is up to the user to confirm if there truly is independence between different blocks. Otherwise convergence properties may suffer.
+3. This can be used in conjunction with minibatching, so long as the defined data objects are available in all data observations.
+
+## What happens internally?
+
+We simply perform an independent `update_ensemble!` for each provided pairing and combine model output and updated parameters afterwards. Note that even without specifying an update group, by default EKP will always be construct one under-the-hood.
+
+!!! note "In future..."
+    In theory this opens up the possibility to have different configurations, or even processes, in different groups. This could be useful when parameter-data pairings are highly heterogeneous and so the user may wish to exploit, for example, the different processes scaling properties. However this has not been implemented.

--- a/docs/src/update_groups.md
+++ b/docs/src/update_groups.md
@@ -3,7 +3,7 @@
 The `UpdateGroup` object facilitates blocked EKP updates, based on a provided updating a series user-defined pairs of parameters and data. This allows users to enforce any *known* (in)dependences between different groups of parameters during the update.
 
 !!! note "This improves scaling at the cost of user-imposed structure"
-    As many of the `Process` updates scale say with ``d^\alpha``, in the data dimension ``d`` and ``\alpha > 1`` (super-linearly),  update groups with ``K`` groups of equal size will improving this scaline to ``K (\frac{d}{K})^\alpha``.
+    As many of the `Process` updates scale say with ``d^\alpha``, in the data dimension ``d`` and ``\alpha > 1`` (super-linearly),  update groups with ``K`` groups of equal size will improving this scaling to ``K (\frac{d}{K})^\alpha``.
 
 ##  Recommended construction - shown by example
 
@@ -12,8 +12,8 @@ The key component to construct update groups starts with constructing the prior,
 For illustration, we take code snippets from the example found in [examples/](https://github.com/CliMA/EnsembleKalmanProcesses.jl/blob/main/examples/UpdateGroups/). This example is concerned with learning several parameters in a coupled two-scale Lorenz 96 system:
 ```math
 \begin{aligned}
- \frac{\partial X_i}{\partial t} && = -X_{i-1}(X_{i-2} - X{i+1}) - X_i - GY_i + F_1 + F_2*sin(2\pi t F_3)\\
- \frac{\partial Y_i}{\partial t} && = -cbY_{i+1}(Y_{i+2} - X{i-1}) - cY_i + \frac{hc}{b} X_i \\
+ \frac{\partial X_i}{\partial t} & = -X_{i-1}(X_{i-2} - X{i+1}) - X_i - GY_i + F_1 + F_2*\sin(2\pi t F_3)\\
+ \frac{\partial Y_i}{\partial t} & = -cbY_{i+1}(Y_{i+2} - X{i-1}) - cY_i + \frac{hc}{b} X_i 
 \end{aligned}
 ```
 Parameters are learnt by fitting moments of a realized `X` and `Y` system, to some target moments.

--- a/docs/src/update_groups.md
+++ b/docs/src/update_groups.md
@@ -1,6 +1,15 @@
 # [Update Groups] (@id update-groups)
 
-The `UpdateGroup` object facilitates blocked EKP updates, based on a provided updating a series user-defined pairs of parameters and data. This allows users to enforce any *known* (in)dependences between different groups of parameters during the update.
+The `UpdateGroup` object facilitates blocked EKP updates, based on a provided updating a series user-defined pairs of parameters and data. This allows users to enforce any *known* (in)dependences between different groups of parameters during the update. For example, 
+```julia
+# update parameter 1 with data 1 and 2
+# update parameters 2 and 3 jointly with data 2, 3, and 4
+Dict(
+    ["parameter_1"] => ["data_1", "data_2"], 
+    ["parameter_2", "parameter_3"] => ["data_2", "data_3", "data_4"], 
+)
+```
+Construction and passing of this into the EnsembleKalmanProcesses is detailed below.
 
 !!! note "This improves scaling at the cost of user-imposed structure"
     As many of the `Process` updates scale say with ``d^\alpha``, in the data dimension ``d`` and ``\alpha > 1`` (super-linearly),  update groups with ``K`` groups of equal size will improving this scaling to ``K (\frac{d}{K})^\alpha``.

--- a/examples/Localization/localization_example_lorenz96.jl
+++ b/examples/Localization/localization_example_lorenz96.jl
@@ -76,8 +76,9 @@ prior = combine_distributions(priors)
 
 initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
 
+
 # Solve problem without localization
-ekiobj_vanilla = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng)
+ekiobj_vanilla = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, scheduler=DefaultScheduler())
 for i in 1:N_iter
     g_ens_vanilla = G(get_ϕ_final(prior, ekiobj_vanilla))
     EKP.update_ensemble!(ekiobj_vanilla, g_ens_vanilla, deterministic_forward_map = true)
@@ -91,6 +92,7 @@ ekiobj_inflated = EKP.EnsembleKalmanProcess(
     Γ,
     Inversion();
     rng = rng,
+    scheduler=DefaultScheduler()
     #  localization_method = BernoulliDropout(0.98),
 )
 
@@ -108,7 +110,7 @@ end
 @info "EKI (inflated) - complete"
 
 # Test SEC
-ekiobj_sec = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SEC(1.0))
+ekiobj_sec = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SEC(1.0), scheduler=DefaultScheduler())
 
 for i in 1:N_iter
     g_ens = G(get_ϕ_final(prior, ekiobj_sec))
@@ -118,7 +120,7 @@ end
 
 # Test SEC with cutoff
 ekiobj_sec_cutoff =
-    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SEC(1.0, 0.1))
+    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SEC(1.0, 0.1), scheduler=DefaultScheduler())
 
 for i in 1:N_iter
     g_ens = G(get_ϕ_final(prior, ekiobj_sec_cutoff))
@@ -128,7 +130,7 @@ end
 
 # Test SECFisher
 ekiobj_sec_fisher =
-    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SECFisher())
+    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SECFisher(), scheduler=DefaultScheduler())
 
 for i in 1:N_iter
     g_ens = G(get_ϕ_final(prior, ekiobj_sec_fisher))
@@ -138,7 +140,7 @@ end
 
 # Test SECNice
 ekiobj_sec_nice =
-    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SECNice())
+    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SECNice(), scheduler=DefaultScheduler())
 
 for i in 1:N_iter
     g_ens = G(get_ϕ_final(prior, ekiobj_sec_nice))
@@ -150,7 +152,8 @@ end
 u_final = get_u_final(ekiobj_sec)
 g_final = get_g_final(ekiobj_sec)
 cov_est = cov([u_final; g_final], [u_final; g_final], dims = 2, corrected = false)
-cov_localized = get_localizer(ekiobj_sec).localize(cov_est)
+# need dimension args too
+cov_localized = get_localizer(ekiobj_sec).localize(cov_est, eltype(g_final), size(u_final,1),size(g_final,1),size(u_final,2))
 
 fig = plot(
     get_error(ekiobj_vanilla),

--- a/examples/Localization/localization_example_lorenz96.jl
+++ b/examples/Localization/localization_example_lorenz96.jl
@@ -78,7 +78,8 @@ initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
 
 
 # Solve problem without localization
-ekiobj_vanilla = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, scheduler=DefaultScheduler())
+ekiobj_vanilla =
+    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, scheduler = DefaultScheduler())
 for i in 1:N_iter
     g_ens_vanilla = G(get_ϕ_final(prior, ekiobj_vanilla))
     EKP.update_ensemble!(ekiobj_vanilla, g_ens_vanilla, deterministic_forward_map = true)
@@ -92,7 +93,7 @@ ekiobj_inflated = EKP.EnsembleKalmanProcess(
     Γ,
     Inversion();
     rng = rng,
-    scheduler=DefaultScheduler()
+    scheduler = DefaultScheduler(),
     #  localization_method = BernoulliDropout(0.98),
 )
 
@@ -110,7 +111,15 @@ end
 @info "EKI (inflated) - complete"
 
 # Test SEC
-ekiobj_sec = EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SEC(1.0), scheduler=DefaultScheduler())
+ekiobj_sec = EKP.EnsembleKalmanProcess(
+    initial_ensemble,
+    y,
+    Γ,
+    Inversion();
+    rng = rng,
+    localization_method = SEC(1.0),
+    scheduler = DefaultScheduler(),
+)
 
 for i in 1:N_iter
     g_ens = G(get_ϕ_final(prior, ekiobj_sec))
@@ -119,8 +128,15 @@ end
 @info "EKI (SEC) - complete"
 
 # Test SEC with cutoff
-ekiobj_sec_cutoff =
-    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SEC(1.0, 0.1), scheduler=DefaultScheduler())
+ekiobj_sec_cutoff = EKP.EnsembleKalmanProcess(
+    initial_ensemble,
+    y,
+    Γ,
+    Inversion();
+    rng = rng,
+    localization_method = SEC(1.0, 0.1),
+    scheduler = DefaultScheduler(),
+)
 
 for i in 1:N_iter
     g_ens = G(get_ϕ_final(prior, ekiobj_sec_cutoff))
@@ -129,8 +145,15 @@ end
 @info "EKI (SEC cut-off) - complete"
 
 # Test SECFisher
-ekiobj_sec_fisher =
-    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SECFisher(), scheduler=DefaultScheduler())
+ekiobj_sec_fisher = EKP.EnsembleKalmanProcess(
+    initial_ensemble,
+    y,
+    Γ,
+    Inversion();
+    rng = rng,
+    localization_method = SECFisher(),
+    scheduler = DefaultScheduler(),
+)
 
 for i in 1:N_iter
     g_ens = G(get_ϕ_final(prior, ekiobj_sec_fisher))
@@ -139,8 +162,15 @@ end
 @info "EKI (SEC Fisher) - complete"
 
 # Test SECNice
-ekiobj_sec_nice =
-    EKP.EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(); rng = rng, localization_method = SECNice(), scheduler=DefaultScheduler())
+ekiobj_sec_nice = EKP.EnsembleKalmanProcess(
+    initial_ensemble,
+    y,
+    Γ,
+    Inversion();
+    rng = rng,
+    localization_method = SECNice(),
+    scheduler = DefaultScheduler(),
+)
 
 for i in 1:N_iter
     g_ens = G(get_ϕ_final(prior, ekiobj_sec_nice))
@@ -153,7 +183,8 @@ u_final = get_u_final(ekiobj_sec)
 g_final = get_g_final(ekiobj_sec)
 cov_est = cov([u_final; g_final], [u_final; g_final], dims = 2, corrected = false)
 # need dimension args too
-cov_localized = get_localizer(ekiobj_sec).localize(cov_est, eltype(g_final), size(u_final,1),size(g_final,1),size(u_final,2))
+cov_localized =
+    get_localizer(ekiobj_sec).localize(cov_est, eltype(g_final), size(u_final, 1), size(g_final, 1), size(u_final, 2))
 
 fig = plot(
     get_error(ekiobj_vanilla),

--- a/examples/UpdateGroups/Project.toml
+++ b/examples/UpdateGroups/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+EnsembleKalmanProcesses = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/examples/UpdateGroups/calibrate.jl
+++ b/examples/UpdateGroups/calibrate.jl
@@ -324,17 +324,13 @@ function main()
     ###
 
     # EKP parameters
-    N_ens = 70 # number of ensemble members
+    N_ens = 40 # number of ensemble members
     N_iter = 5 # number of EKI iterations
     # initial parameters: N_params x N_ens
     initial_params = construct_initial_ensemble(rng, priors, N_ens)
 
-    ekiobj = EKP.EnsembleKalmanProcess(
-        initial_params,
-        full_observation,
-        TransformInversion(),
-        scheduler = DataMisfitController(),
-    )
+    ekiobj =
+        EKP.EnsembleKalmanProcess(initial_params, full_observation, Inversion(), scheduler = DataMisfitController())
     @info "Built EKP object"
 
     # EKI iterations
@@ -413,13 +409,7 @@ function main()
     println("**************")
     println(get_group_id.(update_groups))
 
-    ekiobj_grouped = EKP.EnsembleKalmanProcess(
-        initial_params,
-        observation,
-        Inversion(),
-        verbose = true,
-        update_groups = update_groups,
-    )
+    ekiobj_grouped = EKP.EnsembleKalmanProcess(initial_params, observation, Inversion(), update_groups = update_groups)
     @info "Built grouped EKP object"
 
     # EKI iterations

--- a/examples/UpdateGroups/calibrate.jl
+++ b/examples/UpdateGroups/calibrate.jl
@@ -329,7 +329,12 @@ function main()
     # initial parameters: N_params x N_ens
     initial_params = construct_initial_ensemble(rng, priors, N_ens)
 
-    ekiobj = EKP.EnsembleKalmanProcess(initial_params, full_observation, Inversion(), verbose = true)
+    ekiobj = EKP.EnsembleKalmanProcess(
+        initial_params,
+        full_observation,
+        TransformInversion(),
+        scheduler = DataMisfitController(),
+    )
     @info "Built EKP object"
 
     # EKI iterations

--- a/examples/UpdateGroups/calibrate.jl
+++ b/examples/UpdateGroups/calibrate.jl
@@ -1,0 +1,391 @@
+
+# Import modules
+using Distributions  # probability distributions and associated functions
+using LinearAlgebra
+using CairoMakie, ColorSchemes
+using Random
+using JLD2
+
+# CES 
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.Observations
+using EnsembleKalmanProcesses.DataContainers
+using EnsembleKalmanProcesses.ParameterDistributions
+
+const EKP = EnsembleKalmanProcesses
+
+# includes
+include("lorenz_model.jl") # Contains coupled Lorenz 96 and integrator
+include("data_processing.jl") # Contains processing to produce data and forward map
+
+
+rng_seed = 79453
+rng = Random.seed!(Random.GLOBAL_RNG, rng_seed)
+
+# Output figure save directory
+homedir = pwd()
+println(homedir)
+output_directory = homedir * "/output/"
+if ~isdir(output_directory)
+    mkdir(output_directory)
+end
+
+case = "test"
+
+
+# A function to run the ensemble over ϕ_i, generating trajectories and data
+function run_G_ensemble(state, lsettings, ϕ_i, window, data_dim)
+    N_ens = size(ϕ_i, 2)
+    data_sample = zeros(data_dim, N_ens)
+
+    for j in 1:N_ens
+        # ϕ_i is n_params x n_ens
+        params_i = LParams(
+            ϕ_i[1:3, j], # F
+            ϕ_i[1, j], # G
+            ϕ_i[2, j], # h
+            ϕ_i[3, j], # c
+            ϕ_i[4, j], # b
+        )
+        new_state, new_t = lorenz_solve(state, lsettings, params_i)
+        data_sample[:, j] = process_trajectory_to_data(window, new_state, new_t)
+    end
+    return data_sample
+end
+
+
+function main()
+    # Lorenz 96 multiscale system with 1-slow timescale per slow timescale
+    # Fast: Atmosphere with timescale difference c, nonlinear strength b, coupling y_k 
+    # dy_k/dt = -cby_{k+1}(y_{k+2}-y_{k-1}) - cy_k + (hc/b)x_k
+    # Slow: Ocean is just damping with e.g. seasonal forcing F and coupling strength G
+    # dx_k/dt =  - x_k + (Fm + Fa*cos(Ff*2πt)) - Gy_k
+    # Inspired from the coupled L63 model
+    # Zhang, Liu, Rosati & Delworth (2012)
+    # https://doi.org/10.3402/tellusa.v64i0.10963
+
+    ###
+    ###  Define the (true) parameters
+    ###
+
+    # Time scaling
+    time_scale_factor = 0.05
+    year = 360.0 * time_scale_factor
+    month = year / 12.0 * time_scale_factor
+
+    # Fast 
+    h_true = 10.0
+    c_true = 10.0# timescale difference
+    b_true = 10.0
+
+    # Slow
+    F_true = [8.0, 2.0, 1 / year] # (mean,amplitude,frequency) const for now (maybe add seasonal cycle)
+    G_true = h_true * c_true / b_true # for consistency in coupling terms
+
+    true_params = LParams(F_true, G_true, h_true, c_true, b_true)
+    param_names = ["F", "G", "h", "c", "b"]
+
+    ###
+    ###  Define the parameter priors (needed later for inversion)
+    ###
+
+    prior_F = ParameterDistribution(
+        Dict(
+            "name" => "F",
+            "distribution" => Parameterized(MvNormal([1.0, 0.0, -2.0], I)),
+            "constraint" => repeat([bounded_below(0)], 3),
+        ),
+    ) # gives 3-D dist on the order of~ [12,1,0.08]                                
+    prior_G = constrained_gaussian(param_names[2], 5.0, 4.0, 0, Inf)
+    prior_h = constrained_gaussian(param_names[3], 5.0, 4.0, 0, Inf)
+    prior_c = constrained_gaussian(param_names[4], 5.0, 4.0, 0, Inf)
+    prior_b = constrained_gaussian(param_names[5], 5.0, 4.0, 0, Inf)
+    priors = combine_distributions([prior_F, prior_G, prior_h, prior_c, prior_b])
+
+    ###
+    ### Configuration of the forward map
+    ###
+
+    ## State evolution
+    N = 40 # state size
+    dt = 0.005 # integration dt
+
+
+    ## Spin up
+    spinup = year
+    initial = rand(Normal(0.0, 0.01), 2 * N) # IC for fast and slow
+
+    lsettings_spinup = LSettings(N, dt, spinup, initial)
+
+    ## Gather statistics
+    # e.g. run for 2 years, using last year for data, (& batched monthly)
+    t_solve = 2 * year
+    window_start = t_solve - year
+    window_end = t_solve
+    subwindow_size = Int64(floor(month / dt))
+    slide_or_batch = "batch" #sliding window or disjoint batches
+
+    lsettings = LSettings(N, dt, t_solve, nothing)
+    window = ProcessingWindow(window_start, window_end, subwindow_size, slide_or_batch)
+
+    ###
+    ### Spin up and plot
+    ###
+
+    spunup_state, t = lorenz_solve(lsettings_spinup, true_params)
+    @info "spin-up complete"
+
+    fig = Figure(size = (900, 450))
+
+    afast = Axis(fig[1, 1][1, 1], xlabel = "time", ylabel = "fast")
+    aslow = Axis(fig[2, 1][1, 1], xlabel = "time", ylabel = "slow")
+
+    ss_freq = length(t) / 2010.0
+    ss_rate = Int64(ceil(ss_freq))
+    tplot = t[(10 * ss_rate + 1):ss_rate:end]
+    hm =
+        heatmap!(afast, tplot, 1:N, spunup_state[(N + 1):(2 * N), (10 * ss_rate + 1):ss_rate:end]', colormap = :Oranges)
+    Colorbar(fig[1, 1][1, 2], hm)
+    hm = heatmap!(aslow, tplot, 1:N, spunup_state[1:N, (10 * ss_rate + 1):ss_rate:end]', colormap = :Blues)
+    Colorbar(fig[2, 1][1, 2], hm)
+    
+    # save
+    save(joinpath(output_directory, case * "_spinup_allstate.png"), fig, px_per_unit = 3)
+    save(joinpath(output_directory, case * "_spinup_allstate.pdf"), fig, pt_per_unit = 3)
+    
+    
+    fig = Figure(size = (900, 450))
+    
+    afast = Axis(fig[1, 1][1, 1], xlabel = "time", ylabel = "fast")
+    aslow = Axis(fig[2, 1][1, 1], xlabel = "time", ylabel = "slow")
+    
+    lines!(afast, tplot, spunup_state[N + 1, (10 * ss_rate + 1):ss_rate:end], color = :red)
+    lines!(aslow, tplot, spunup_state[1, (10 * ss_rate + 1):ss_rate:end], color = :blue)
+    
+    # save
+    save(joinpath(output_directory, case * "_spinup_state1.png"), fig, px_per_unit = 3)
+    save(joinpath(output_directory, case * "_spinup_state1.pdf"), fig, pt_per_unit = 3)
+    @info "plotted spin-up"
+    
+    ###
+    ### Generate perfect-model data
+    ###
+    
+    #estimate covariance
+    n_sample_cov = 100
+    
+    new_state, new_t = lorenz_solve(spunup_state, lsettings, true_params)
+    data_sample = process_trajectory_to_data(window, new_state, new_t)
+    
+    data_samples = zeros(size(data_sample, 1), n_sample_cov)
+    data_samples[:, 1] = data_sample
+    
+    fig = Figure(size = (900, 450))
+    afast = Axis(fig[1, 1][1, 1], xlabel = "time", ylabel = "fast")
+    aslow = Axis(fig[2, 1][1, 1], xlabel = "time", ylabel = "slow")
+    
+    for i in 2:n_sample_cov
+        # extend trajectory from end of new_state
+        new_state, new_t = lorenz_solve(new_state, lsettings, true_params) #integrate another window from last state
+        # calculate data sample
+        data_samples[:, i] = process_trajectory_to_data(window, new_state, new_t) # process the window 
+        
+        #plot trajectory
+        ss_freq = length(new_t) / 2010.0
+        ss_rate = Int64(ceil(ss_freq))
+        tplot = new_t[Int64(floor(length(new_t) / 2)):ss_rate:end]
+        
+        lines!(afast, tplot, new_state[N + 1, Int64(floor(length(new_t) / 2)):ss_rate:end], color = :red, alpha = 0.1)
+        lines!(
+            aslow,
+            tplot,
+            new_state[1, Int64(floor(length(new_t) / 2)):ss_rate:end],
+            color = :blue,
+            alpha = 0.1,
+            label = "$(n_sample_cov) samples",
+        )
+        axislegend(aslow, merge = true, unique = true)
+    end
+# save
+save(joinpath(output_directory, case * "_datatrajectory_state1.png"), fig, px_per_unit = 3)
+save(joinpath(output_directory, case * "_datatrajectory_state1.pdf"), fig, pt_per_unit = 3)
+
+Γ = cov(data_samples, dims = 2) # estimate covariance from samples
+# add a little additive and multiplicative inflation
+Γ += 1e4 * eps() * I # 10^-12 just to make things nonzero
+#blocksize = Int64(size(Γ, 1) / 5) # known block structure
+#meanblocks = [mean([Γ[i, i] for i in ((j - 1) * blocksize + 1):(j * blocksize)]) for j in 1:5]
+#Γ += 1e-4* kron(Diagonal(meanblocks),I(blocksize)) # this will add scaled noise to the diagonal scaled by the block
+
+y_mean = mean(data_samples, dims = 2)
+y = data_samples[:, shuffle(rng, 1:n_sample_cov)[1]] # random data point as the data
+fig = Figure(size = (450, 450))
+aΓ = Axis(fig[1, 1][1, 1])
+adata = Axis(fig[2, 1][1, 1])
+
+heatmap!(aΓ, Γ)
+sqrt_inv_Γ = sqrt(inv(Γ))
+series!(adata, (sqrt_inv_Γ*data_samples)', solid_color = :black, label="normalized data") #plots each row as new plot
+# save
+save(joinpath(output_directory, case * "_datasamples.png"), fig, px_per_unit = 3)
+save(joinpath(output_directory, case * "_datasamples.pdf"), fig, pt_per_unit = 3)
+
+@info "constructed and plotted perfect experiment data and noise"
+
+# may need to condition Gamma for posdef etc. or add shrinkage estimation
+
+###
+### (a) Configure and solve ensemble inversion
+###
+
+# EKP parameters
+N_ens = 20 # number of ensemble members
+N_iter = 20 # number of EKI iterations
+# initial parameters: N_params x N_ens
+initial_params = construct_initial_ensemble(rng, priors, N_ens)
+
+ekiobj = EKP.EnsembleKalmanProcess(
+initial_params,
+        y,
+    Γ,
+        Inversion(),
+        scheduler = DataMisfitController(terminate_at = 1e4),
+        failure_handler_method = SampleSuccGauss(),
+        verbose = true,
+    )
+    @info "Built EKP object"
+
+    # EKI iterations
+    println("EKP inversion error:")
+    err = zeros(N_iter)
+    for i in 1:N_iter
+        ϕ_i = get_ϕ_final(priors, ekiobj) # the `ϕ` indicates that the `params_i` are in the constrained space    
+        g_ens = run_G_ensemble(spunup_state, lsettings, ϕ_i, window, length(y))
+        EKP.update_ensemble!(ekiobj, g_ens)
+    end
+    @info "Calibrated parameters with EKP"
+    # EKI results: Has the ensemble collapsed toward the truth?
+    println("True parameters: ")
+    println(true_params)
+
+    println("\nEKI results:")
+    println(get_ϕ_mean_final(priors, ekiobj))
+
+    u_stored = get_u(ekiobj, return_array = false)
+    g_stored = get_g(ekiobj, return_array = false)
+
+    @save output_directory * "parameter_storage.jld2" u_stored
+    @save output_directory * "output_storage.jld2" g_stored Γ
+
+    # Plots
+    fig = Figure(size = (450, 450))
+    aprior = Axis(fig[1, 1][1, 1])
+    apost = Axis(fig[2, 1][1, 1])
+    g_prior = get_g(ekiobj, 1)
+g_post = get_g_final(ekiobj)
+data_std = sqrt.([Γ[i, i] for i in 1:size(Γ, 1)])
+data_dim = length(y)
+dplot = 1:data_dim
+lines!(aprior, dplot, sqrt_inv_Γ*y, color = (:black, 0.5), label = "data") #plots each row as new plot
+lines!(apost, dplot, sqrt_inv_Γ*y, color = (:black, 0.5), label = "data") #plots each row as new plot
+    band!(aprior, dplot, sqrt_inv_Γ*(y_mean - 2 * data_std)[:], sqrt_inv_Γ*(y_mean + 2 * data_std)[:], color = (:grey, 0.2)) #estimated 2*std bands about a mean 
+band!(apost, dplot, sqrt_inv_Γ*(y_mean - 2 * data_std)[:], sqrt_inv_Γ*(y_mean + 2 * data_std)[:], color = (:grey, 0.2))
+for idx in 1:N_ens
+    lines!(aprior, dplot, sqrt_inv_Γ*g_prior[:, idx], color = :orange, alpha = 0.1, label = "prior") #plots each row as new plot
+    lines!(apost, dplot, sqrt_inv_Γ*g_post[:, idx], color = :blue, alpha = 0.1, label = "posterior") #plots each row as new plot
+end
+axislegend(aprior, merge = true, unique = true)
+axislegend(apost, merge = true, unique = true)
+
+# save
+save(joinpath(output_directory, case * "_datasamples-prior-post.png"), fig, px_per_unit = 3)
+save(joinpath(output_directory, case * "_datasamples-prior-post.pdf"), fig, pt_per_unit = 3)
+
+@info "plotted results of perfect experiment"
+
+###
+### (b) Repeat exp (a) with UpdateGroups
+    ###
+
+# We see that 
+bs = Int64(size(Γ, 1) / 5) # known block structure
+
+# recall the parameters are
+# F[1:3],G,h,c,b
+# and the data blocks are
+# <X>, <Y>, <X^2>, <Y^2>, <XY>  X-slow, Y-fast
+
+    # F(3) -> <X>, <X^2>, 
+#    group_slow = UpdateGroup(collect(1:4), reduce(vcat, [collect(1:bs), collect(2 * bs + 1:3 * bs), collect(4*bs+1:5*bs)]))
+    group_slow = UpdateGroup(collect(1:3), reduce(vcat,[collect(1:bs),collect(2*bs+1:3*bs)]))#, collect(4*bs+1:5*bs)]))
+# G,h,c,b -> <Y>, <Y^2>,<XY>
+#group_fast = UpdateGroup(collect(4:7), collect(1:(5 * bs)))
+    group_fast = UpdateGroup(collect(4:7), reduce(vcat,[collect(bs+1:2*bs),collect(3*bs+1:5*bs)])) 
+
+
+
+    
+ekiobj_grouped = EKP.EnsembleKalmanProcess(
+initial_params,
+    y,
+    Γ,
+    Inversion(),
+    scheduler = DataMisfitController(terminate_at = 1e4),
+    failure_handler_method = SampleSuccGauss(),
+    verbose = true,
+    update_groups = [group_slow, group_fast],
+)
+@info "Built grouped EKP object"
+
+# EKI iterations
+println("EKP inversion error:")
+err = zeros(N_iter)
+for i in 1:N_iter
+    ϕ_i = get_ϕ_final(priors, ekiobj_grouped) # the `ϕ` indicates that the `params_i` are in the constrained space    
+    g_ens = run_G_ensemble(spunup_state, lsettings, ϕ_i, window, length(y))
+    EKP.update_ensemble!(ekiobj_grouped, g_ens)
+end
+@info "Calibrated parameters with grouped EKP"
+# EKI results: Has the ensemble collapsed toward the truth?
+println("True parameters: ")
+println(true_params)
+
+println("\nEKI results:")
+println(get_ϕ_mean_final(priors, ekiobj_grouped))
+
+u_stored = get_u(ekiobj_grouped, return_array = false)
+g_stored = get_g(ekiobj_grouped, return_array = false)
+
+@save output_directory * "parameter_storage_grouped.jld2" u_stored
+@save output_directory * "output_storage_grouped.jld2" g_stored
+
+
+# Plots
+fig = Figure(size = (450, 450))
+aprior = Axis(fig[1, 1][1, 1])
+apost = Axis(fig[2, 1][1, 1])
+g_prior = get_g(ekiobj_grouped, 1)
+g_post = get_g_final(ekiobj_grouped)
+data_std = sqrt.([Γ[i, i] for i in 1:size(Γ, 1)])
+data_dim = length(y)
+dplot = 1:data_dim
+lines!(aprior, dplot, sqrt_inv_Γ*y, color = (:black,0.5), label = "data") #plots each row as new plot
+lines!(apost, dplot, sqrt_inv_Γ*y, color = (:black,0.5), label = "data") #plots each row as new plot
+band!(aprior, dplot, sqrt_inv_Γ*(y_mean - 2 * data_std)[:], sqrt_inv_Γ*(y_mean + 2 * data_std)[:], color = (:grey, 0.2)) #estimated 2*std bands about a mean 
+band!(apost, dplot, sqrt_inv_Γ*(y_mean - 2 * data_std)[:], sqrt_inv_Γ*(y_mean + 2 * data_std)[:], color = (:grey, 0.2))
+for idx in 1:N_ens
+    lines!(aprior, dplot, sqrt_inv_Γ*g_prior[:, idx], color = :orange, alpha = 0.1, label = "prior") #plots each row as new plot
+    lines!(apost, dplot, sqrt_inv_Γ*g_post[:, idx], color = :blue, alpha = 0.1, label = "posterior") #plots each row as new plot
+end
+axislegend(aprior, merge = true, unique = true)
+axislegend(apost, merge = true, unique = true)
+
+# save
+save(joinpath(output_directory, case * "_datasamples-prior-post-grouped.png"), fig, px_per_unit = 3)
+save(joinpath(output_directory, case * "_datasamples-prior-post-grouped.pdf"), fig, pt_per_unit = 3)
+
+@info "plotted results of perfect experiment"
+
+end
+
+main()

--- a/examples/UpdateGroups/calibrate.jl
+++ b/examples/UpdateGroups/calibrate.jl
@@ -8,9 +8,10 @@ using JLD2
 
 # CES 
 using EnsembleKalmanProcesses
-using EnsembleKalmanProcesses.Observations
 using EnsembleKalmanProcesses.DataContainers
 using EnsembleKalmanProcesses.ParameterDistributions
+using EnsembleKalmanProcesses.Localizers
+
 
 const EKP = EnsembleKalmanProcesses
 
@@ -239,20 +240,21 @@ save(joinpath(output_directory, case * "_datasamples.pdf"), fig, pt_per_unit = 3
 ###
 
 # EKP parameters
-N_ens = 20 # number of ensemble members
-N_iter = 20 # number of EKI iterations
+N_ens = 30 # number of ensemble members
+N_iter = 10 # number of EKI iterations
 # initial parameters: N_params x N_ens
 initial_params = construct_initial_ensemble(rng, priors, N_ens)
 
 ekiobj = EKP.EnsembleKalmanProcess(
-initial_params,
-        y,
+    initial_params,
+    y,
     Γ,
-        Inversion(),
-        scheduler = DataMisfitController(terminate_at = 1e4),
-        failure_handler_method = SampleSuccGauss(),
-        verbose = true,
-    )
+    Inversion(),
+    localization_method=Localizers.NoLocalization(),
+    scheduler = DataMisfitController(terminate_at = 1e4),
+    failure_handler_method = SampleSuccGauss(),
+    verbose = true,
+)
     @info "Built EKP object"
 
     # EKI iterations
@@ -330,6 +332,7 @@ initial_params,
     y,
     Γ,
     Inversion(),
+    localization_method = Localizers.NoLocalization(),
     scheduler = DataMisfitController(terminate_at = 1e4),
     failure_handler_method = SampleSuccGauss(),
     verbose = true,

--- a/examples/UpdateGroups/data_processing.jl
+++ b/examples/UpdateGroups/data_processing.jl
@@ -1,0 +1,52 @@
+
+struct ProcessingWindow{FT <: AbstractFloat, SS <: AbstractString}
+    "start time of processing window"
+    t_start::FT
+    "end time of processing window"
+    t_end::FT
+    "subwindow size"
+    sw_size::Int
+    "sliding subwindow, or batching subwindow"
+    slide_or_batch::SS
+end
+
+function process_trajectory_to_data(pw::ProcessingWindow, xn, t)
+
+    # Define averaging indices range - relative to trajectory start time
+    indices = findall(x -> (x > pw.t_start) && (x < pw.t_end), t .- minimum(t))
+
+    # Define the subwindows' starts and ends, and the number of them
+    if pw.slide_or_batch == "batch"
+        n_subwindow = Int64(floor(length(indices) / pw.sw_size))
+        sw_start = 1:(pw.sw_size):(n_subwindow * pw.sw_size - 1)
+        sw_end = (pw.sw_size):(pw.sw_size):(n_subwindow * pw.sw_size)
+    elseif pw.slide_or_batch == "slide"
+        n_subwindow = length(indices) - pw.sw_size
+        sw_start = 1:n_subwindow
+        sw_end = (pw.sw_size):(n_subwindow + pw.sw_size)
+    else
+        throw(
+            ArgumentError,
+            "ProcessingWindow.slide_or_batch must be \"slide\" or \"batch\", received $pw.slide_or_batch",
+        )
+    end
+
+    # calculate first and second moments over the subwindows
+    N = Int64(size(xn, 1) / 2)
+    slow_id = 1:N
+    fast_id = (N + 1):(2 * N)
+
+    slow_mean_sw = [mean(vcat(xn[slow_id, indices[sw_start[i]:sw_end[i]]])) for i in 1:n_subwindow]
+    fast_mean_sw = [mean(vcat(xn[fast_id, indices[sw_start[i]:sw_end[i]]])) for i in 1:n_subwindow]
+
+    slow_meansq_sw = [mean(vcat(xn[slow_id, indices[sw_start[i]:sw_end[i]]] .^ 2)) for i in 1:n_subwindow]
+    fast_meansq_sw = [mean(vcat(xn[fast_id, indices[sw_start[i]:sw_end[i]]] .^ 2)) for i in 1:n_subwindow]
+
+    slowfast_mean_sw = [
+        mean(vcat(xn[fast_id, indices[sw_start[i]:sw_end[i]]] .* xn[slow_id, indices[sw_start[i]:sw_end[i]]])) for
+        i in 1:n_subwindow
+    ]
+
+    # Combine (<X>, <Y>, <X^2>, <Y^2>, <XY>)
+    return vcat(slow_mean_sw..., fast_mean_sw..., slow_meansq_sw..., fast_meansq_sw..., slowfast_mean_sw...)
+end

--- a/examples/UpdateGroups/lorenz_model.jl
+++ b/examples/UpdateGroups/lorenz_model.jl
@@ -1,0 +1,125 @@
+struct LSettings
+    # Number of longitude steps
+    N::Int32
+    # Timestep
+    dt::Float64
+    # end time
+    t_end::Float64
+    # Initial perturbation
+    initial::Union{Array{Float64}, Nothing}
+
+end
+
+struct LParams{FT <: AbstractFloat, VV <: AbstractVector}
+    # Slow - Mean forcing
+    F::VV
+    # Slow - Coupling strength
+    G::FT
+    # Fast - Coupling strength
+    h::FT
+    # fast timescale separation
+    c::FT
+    # Fast - Nonlinearity
+    b::FT
+end
+
+
+# Forward pass of the Lorenz 96 model
+#=function lorenz_forward(settings::LSettings, params::LParams)
+    # run the Lorenz simulation
+    xn, t = lorenz_solve(settings, params)
+    # Get statistics
+    gt = stats(settings, xn, t)
+    return gt
+end
+=#
+
+# initial run
+function lorenz_solve(settings::LSettings, params::LParams)
+    X = fill(Float64(0.0), 2 * settings.N, 1) #fast+slow
+    if !isnothing(settings.initial)
+        X = X .+ settings.initial
+    end
+    return lorenz_solve(X, settings, params)
+end
+
+# Solve the Lorenz 96 system 
+function lorenz_solve(X::Matrix, settings::LSettings, params::LParams)
+    X_next = X[:, end] #take the final state
+    # Initialize
+    nstep = Int32(ceil(settings.t_end / settings.dt))
+    xn = zeros(Float64, 2 * settings.N, nstep)
+    t = zeros(Float64, nstep)
+    # March forward in time
+    for j in 1:nstep
+        t[j] = settings.dt * j
+        X_next = RK4(X_next, settings.dt, settings.N, params, t[j])
+        xn[:, j] = X_next
+    end
+    # Output
+    return xn, t
+
+end
+
+# Lorenz-96 system with one substep
+# f = dx/dt
+# Inputs: x: state, N: longitude steps, F: forcing
+function rk_inner(x, N, params, t)
+
+    #get lorenz parameters
+    (F, G, h, c, b) = (params.F, params.G, params.h, params.c, params.b)
+    F_local = params.F[1] + params.F[2] * sin(params.F[3] * 2 * π * t)
+
+    slow_id = 1:N
+    fast_id = (N + 1):(2 * N)
+    xs = x[slow_id]
+    xf = x[fast_id]
+    slow = zeros(Float64, N)
+    fast = zeros(Float64, N)
+    xnew = zeros(size(x))
+    # Loop over N positions
+
+    # dynamics - slow (F,G)
+    #=
+        # Damping system with coupling and force
+        for i = 1:N
+            slow[i] = - xs[i] + F_local - G*xf[i]
+        end
+        =#
+    # Damping system with coupling and force
+    for i in 3:(N - 1)
+        slow[i] = -xs[i - 1] * (xs[i - 2] - xs[i + 1]) - xs[i] + F_local - G * xf[i]
+    end
+    # Periodic BC
+    slow[2] = -xs[1] * (xs[N] - xs[3]) - xs[2] + F_local - G * xf[2]
+    slow[1] = -xs[N] * (xs[N - 1] - xs[2]) - xs[1] + F_local - G * xf[1]
+    slow[N] = -xs[N - 1] * (xs[N - 2] - xs[1]) - xs[N] + F_local - G * xf[N]
+
+    # dynamics - fast (h,c,b)
+    # L96 system  with  coupling to slow
+    for i in 2:(N - 2)
+        fast[i] = -c * b * xf[i + 1] * (xf[i + 2] - xf[i - 1]) - c * xf[i] + h * c / b * xs[i]
+    end
+    # periodic boundary conditions
+    fast[1] = -c * b * xf[2] * (xf[3] - xf[N]) - c * xf[1] + h * c / b * xs[1]
+    fast[N - 1] = -c * b * xf[N] * (xf[1] - xf[N - 2]) - c * xf[N - 1] + h * c / b * xs[N - 1]
+    fast[N] = -c * b * xf[1] * (xf[2] - xf[N - 1]) - c * xf[N] + h * c / b * xs[N]
+
+    # return
+    xnew[slow_id] = slow
+    xnew[fast_id] = fast
+    return xnew
+end
+
+# RK4 solve
+function RK4(xold, dt, N, F, t)
+    # Predictor steps
+    k1 = rk_inner(xold, N, F, t)
+    k2 = rk_inner(xold + k1 * dt / 2.0, N, F, t)
+    k3 = rk_inner(xold + k2 * dt / 2.0, N, F, t)
+    k4 = rk_inner(xold + k3 * dt, N, F, t)
+    # Step
+    xnew = xold + (dt / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4)
+    # Output
+    return xnew
+end

--- a/examples/UpdateGroups/plot_covs.jl
+++ b/examples/UpdateGroups/plot_covs.jl
@@ -1,0 +1,40 @@
+using JLD2, LinearAlgebra, Statistics
+using CairoMakie, ColorSchemes
+using EnsembleKalmanProcesses.DataContainers
+
+
+function main()
+output_directory = "output"
+
+u_iters = JLD2.load(joinpath(output_directory,"parameter_storage.jld2"))["u_stored"]
+g_iters = JLD2.load(joinpath(output_directory,"output_storage.jld2"))["g_stored"]
+
+iters = 1:5
+for iter in iters
+    U = get_data(u_iters[iter])
+    G = get_data(g_iters[iter])
+    
+    Cuu = cov(U,dims=2)
+    Cgg = cov(G,dims=2)
+    Um = mean(U,dims=2)
+    Gm = mean(G,dims=2)
+    Cug = 1/(size(G,2)-1)*((U .- Um)*(G .- Gm)')' # so u are rows
+    
+    
+    fig = Figure(size=(3*450,450)) # size is backwards to what you expect
+    
+    auu = Axis(fig[1,1], title="Cuu")
+    aug = Axis(fig[1,2], title="Cug")
+    agg = Axis(fig[1,3], title="Cgg")
+    
+    heatmap!(auu,Cuu)
+    heatmap!(aug,Cug)
+    heatmap!(agg,Cgg)
+    
+    current_figure()
+    
+    save(joinpath(output_directory, "covs_iter_$iter.png"), fig, px_per_unit = 3)
+end
+end
+
+main()

--- a/examples/UpdateGroups/plot_covs.jl
+++ b/examples/UpdateGroups/plot_covs.jl
@@ -4,37 +4,37 @@ using EnsembleKalmanProcesses.DataContainers
 
 
 function main()
-output_directory = "output"
+    output_directory = "output"
 
-u_iters = JLD2.load(joinpath(output_directory,"parameter_storage.jld2"))["u_stored"]
-g_iters = JLD2.load(joinpath(output_directory,"output_storage.jld2"))["g_stored"]
+    u_iters = JLD2.load(joinpath(output_directory, "parameter_storage.jld2"))["u_stored"]
+    g_iters = JLD2.load(joinpath(output_directory, "output_storage.jld2"))["g_stored"]
 
-iters = 1:5
-for iter in iters
-    U = get_data(u_iters[iter])
-    G = get_data(g_iters[iter])
-    
-    Cuu = cov(U,dims=2)
-    Cgg = cov(G,dims=2)
-    Um = mean(U,dims=2)
-    Gm = mean(G,dims=2)
-    Cug = 1/(size(G,2)-1)*((U .- Um)*(G .- Gm)')' # so u are rows
-    
-    
-    fig = Figure(size=(3*450,450)) # size is backwards to what you expect
-    
-    auu = Axis(fig[1,1], title="Cuu")
-    aug = Axis(fig[1,2], title="Cug")
-    agg = Axis(fig[1,3], title="Cgg")
-    
-    heatmap!(auu,Cuu)
-    heatmap!(aug,Cug)
-    heatmap!(agg,Cgg)
-    
-    current_figure()
-    
-    save(joinpath(output_directory, "covs_iter_$iter.png"), fig, px_per_unit = 3)
-end
+    iters = 1:5
+    for iter in iters
+        U = get_data(u_iters[iter])
+        G = get_data(g_iters[iter])
+
+        Cuu = cov(U, dims = 2)
+        Cgg = cov(G, dims = 2)
+        Um = mean(U, dims = 2)
+        Gm = mean(G, dims = 2)
+        Cug = 1 / (size(G, 2) - 1) * ((U .- Um) * (G .- Gm)')' # so u are rows
+
+
+        fig = Figure(size = (3 * 450, 450)) # size is backwards to what you expect
+
+        auu = Axis(fig[1, 1], title = "Cuu")
+        aug = Axis(fig[1, 2], title = "Cug")
+        agg = Axis(fig[1, 3], title = "Cgg")
+
+        heatmap!(auu, Cuu)
+        heatmap!(aug, Cug)
+        heatmap!(agg, Cgg)
+
+        current_figure()
+
+        save(joinpath(output_directory, "covs_iter_$iter.png"), fig, px_per_unit = 3)
+    end
 end
 
 main()

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -59,7 +59,7 @@ function eki_update(
     cov_est = cov([u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
 
     # Localization - a function taking in (cov, float-type, n_par, n_obs, n_ens)
-    cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u,1), size(g,1), size(u,2))
+    cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u, 1), size(g, 1), size(u, 2))
     cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
 
     # N_obs × N_obs \ [N_obs × N_ens]

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -55,15 +55,15 @@ function eki_update(
     y::AbstractMatrix{FT},
     obs_noise_cov::Union{AbstractMatrix{CT}, UniformScaling{CT}},
 ) where {FT <: Real, IT, CT <: Real}
-
+    
     cov_est = cov([u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
 
     # TODO ENCORPORATE THIS PROPERLY
-    @warn "Removed LOCALIZER IN EKI"
-    cov_localized = cov_est
+    @warn "UpdateGroups don't work with Localizers - removing"
     
     # Localization
-    cov_localized = get_localizer(ekp).localize(cov_est)
+#    cov_localized = get_localizer(ekp).localize(cov_est)
+    cov_localized = cov_est
     cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
 
     # N_obs × N_obs \ [N_obs × N_ens]
@@ -120,19 +120,11 @@ function update_ensemble!(
     # u: N_par × N_ens 
     # g: N_obs × N_ens
     u = get_u_final(ekp)[u_idx, :]
-    N_obs = size(g, 1)[g_idx, :]
+    g = g[g_idx,:]
+    N_obs = length(g_idx)
     obs_noise_cov = get_obs_noise_cov(ekp)[g_idx, g_idx]
     obs_mean = get_obs(ekp)[g_idx]
     
-    if ekp.verbose
-        if get_N_iterations(ekp) == 0
-            @info "Iteration 0 (prior)"
-            @info "Covariance trace: $(tr(cov_init))"
-        end
-
-        @info "Iteration $(get_N_iterations(ekp)+1) (T=$(sum(get_Δt(ekp))))"
-    end
-
     fh = get_failure_handler(ekp)
 
     # Scale noise using Δt

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -55,14 +55,14 @@ function eki_update(
     y::AbstractMatrix{FT},
     obs_noise_cov::Union{AbstractMatrix{CT}, UniformScaling{CT}},
 ) where {FT <: Real, IT, CT <: Real}
-    
+
     cov_est = cov([u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
 
     # TODO ENCORPORATE THIS PROPERLY
     @warn "UpdateGroups don't work with Localizers - removing"
-    
+
     # Localization
-#    cov_localized = get_localizer(ekp).localize(cov_est)
+    #    cov_localized = get_localizer(ekp).localize(cov_est)
     cov_localized = cov_est
     cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
 
@@ -120,11 +120,11 @@ function update_ensemble!(
     # u: N_par × N_ens 
     # g: N_obs × N_ens
     u = get_u_final(ekp)[u_idx, :]
-    g = g[g_idx,:]
+    g = g[g_idx, :]
     N_obs = length(g_idx)
     obs_noise_cov = get_obs_noise_cov(ekp)[g_idx, g_idx]
     obs_mean = get_obs(ekp)[g_idx]
-    
+
     fh = get_failure_handler(ekp)
 
     # Scale noise using Δt

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -58,12 +58,8 @@ function eki_update(
 
     cov_est = cov([u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
 
-    # TODO ENCORPORATE THIS PROPERLY
-    @warn "UpdateGroups don't work with Localizers - removing"
-
-    # Localization
-    #    cov_localized = get_localizer(ekp).localize(cov_est)
-    cov_localized = cov_est
+    # Localization - a function taking in (cov, float-type, n_par, n_obs, n_ens)
+    cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u,1), size(g,1), size(u,2))
     cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
 
     # N_obs × N_obs \ [N_obs × N_ens]

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -246,7 +246,7 @@ function EnsembleKalmanProcess(
     end
     update_group_consistency(groups, N_par, obs_size_for_minibatch) # consistency checks
     VVV = typeof(groups)
-    
+
     scheduler = configuration["scheduler"]
     RS = typeof(scheduler)
 
@@ -335,7 +335,15 @@ function EnsembleKalmanProcess(
         configuration["localization_method"] = localization_method
     end
 
-    return EnsembleKalmanProcess(params, observation_series, process, configuration, update_groups=update_groups, rng = rng, verbose = verbose)
+    return EnsembleKalmanProcess(
+        params,
+        observation_series,
+        process,
+        configuration,
+        update_groups = update_groups,
+        rng = rng,
+        verbose = verbose,
+    )
 end
 
 function EnsembleKalmanProcess(
@@ -905,21 +913,21 @@ function update_ensemble!(
         # with several g_groups we want to do
         # u_n+1 = u_n + sum(update{g_i})
         # but get u_n+1 = sum(u_n + update{g_i}),remove the extra u_ns
-        n_g_groups=length(get_g_group(update_groups))
-        u -= get_u_final(ekp)*(n_g_groups-1) 
-        
+        n_g_groups = length(get_g_group(update_groups))
+        u -= get_u_final(ekp) * (n_g_groups - 1)
+
         if ekp.verbose
             cov_init = get_u_cov_final(ekp)
             if get_N_iterations(ekp) == 0
                 @info "Iteration 0 (prior)"
                 @info "Covariance trace: $(tr(cov_init))"
             end
-            
+
             @info "Iteration $(get_N_iterations(ekp)+1) (T=$(sum(get_Δt(ekp))))"
         end
-        
+
         # update each u_block with every g_block
-#        for (u_idx,g_idx) in zip(get_u_group(update_groups),get_g_group(update_groups))
+        #        for (u_idx,g_idx) in zip(get_u_group(update_groups),get_g_group(update_groups))
         for u_idx in get_u_group(update_groups)
             for g_idx in get_g_group(update_groups)
                 u[u_idx, :] += update_ensemble!(ekp, g, get_process(ekp), u_idx, g_idx; ekp_kwargs...)

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -274,7 +274,7 @@ function EnsembleKalmanProcess(
         @info "Initializing ensemble Kalman process of type $(nameof(typeof(process)))\nNumber of ensemble members: $(N_ens)\nLocalization: $(nameof(typeof(localizer)))\nFailure handler: $(nameof(typeof(failure_handler)))\nScheduler: $(nameof(typeof(scheduler)))\nAccelerator: $(nameof(typeof(accelerator)))"
     end
 
-    EnsembleKalmanProcess{FT, IT, P, RS, AC}(
+    EnsembleKalmanProcess{FT, IT, P, RS, AC, VVV}(
         [init_params],
         observation_series,
         N_ens,
@@ -283,6 +283,7 @@ function EnsembleKalmanProcess(
         scheduler,
         accelerator,
         Δt,
+        groups,
         process,
         rng,
         failure_handler,
@@ -914,7 +915,7 @@ function update_ensemble!(
                 @info "Covariance trace: $(tr(cov_init))"
             end
             
-            @info "Iteration $(get_N_iterations(ekp)+1) (T=$(sum(ekp.Δt)))"
+            @info "Iteration $(get_N_iterations(ekp)+1) (T=$(sum(get_Δt(ekp))))"
         end
         
         # update each u_block with every g_block

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -948,13 +948,13 @@ function update_ensemble!(
         # but get u_n+1 = sum(u_n + update{g_i}),remove the extra u_ns
         #n_g_groups = length(g_groups)
         #u -= get_u_final(ekp) * (n_g_groups - 1)
-        
+
         # update each u_block with every g_block
-        for (u_idx,g_idx) in zip(u_groups,g_groups)
-        #for u_idx in u_groups
-        #    for g_idx in g_groups
-                u[u_idx, :] += update_ensemble!(ekp, g, get_process(ekp), u_idx, g_idx; ekp_kwargs...)
-        #    end
+        for (u_idx, g_idx) in zip(u_groups, g_groups)
+            #for u_idx in u_groups
+            #    for g_idx in g_groups
+            u[u_idx, :] += update_ensemble!(ekp, g, get_process(ekp), u_idx, g_idx; ekp_kwargs...)
+            #    end
         end
 
         accelerate!(ekp, u)

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -267,7 +267,7 @@ function EnsembleKalmanProcess(
     if isa(process, TransformInversion) && !(isa(configuration["localization_method"], NoLocalization))
         throw(ArgumentError("`TransformInversion` cannot currently be used with localization."))
     end
-       
+
     localizer = Localizer(configuration["localization_method"], N_ens, FT)
 
 

--- a/src/EnsembleKalmanProcesses.jl
+++ b/src/EnsembleKalmanProcesses.jl
@@ -8,7 +8,7 @@ include("DataContainers.jl")
 include("Observations.jl")
 include("Localizers.jl")
 include("TOMLInterface.jl")
-
+include("UpdateGroup.jl")
 # algorithmic updates
 include("EnsembleKalmanProcess.jl")
 

--- a/src/EnsembleTransformKalmanInversion.jl
+++ b/src/EnsembleTransformKalmanInversion.jl
@@ -118,32 +118,37 @@ Inputs:
  - ekp :: The EnsembleKalmanProcess to update.
  - g :: Model outputs, they need to be stored as a `N_obs × N_ens` array (i.e data are columms).
  - process :: Type of the EKP.
+ - u_idx :: indices of u to update (see `UpdateGroup`)
+ - g_idx :: indices of g,y,Γ with which to update u (see `UpdateGroup`)
  - failed_ens :: Indices of failed particles. If nothing, failures are computed as columns of `g` with NaN entries.
 """
 function update_ensemble!(
     ekp::EnsembleKalmanProcess{FT, IT, TransformInversion},
     g::AbstractMatrix{FT},
-    process::TransformInversion;
+    process::TransformInversion{FT},
+    u_idx::Vector{Int},
+    g_idx::Vector{Int};
     failed_ens = nothing,
     kwargs...,
 ) where {FT, IT}
 
-    # u: N_par × N_ens 
-    # g: N_obs × N_ens
-    u = get_u_final(ekp)
+    # update only u_idx parameters/ with g_idx data
+    # u: length(u_idx) × N_ens   
+    # g: lenght(g_idx) × N_ens
+    u = get_u_final(ekp)[u_idx, :]
+    g = g[g_idx, :]
+    obs_noise_cov = ekp.obs_noise_cov[g_idx, g_idx]
+    obs_mean = ekp.obs_mean[g_idx]
+    # ISSUE. In general this is not true,
+    # Gamma_inv = ekp.process.Gamma_inv[g_idx,g_idx]
+
     N_obs = size(g, 1)
-    cov_init = cov(u, dims = 2)
-
-    if ekp.verbose
-        if get_N_iterations(ekp) == 0
-            @info "Iteration 0 (prior)"
-            @info "Covariance trace: $(tr(cov_init))"
-        end
-
-        @info "Iteration $(get_N_iterations(ekp)+1) (T=$(sum(get_Δt(ekp))))"
-    end
-
     fh = get_failure_handler(ekp)
+
+    # Scale noise using Δt
+    scaled_obs_noise_cov = obs_noise_cov / ekp.Δt[end]
+
+    y = ekp.obs_mean
 
     if isnothing(failed_ens)
         _, failed_ens = split_indices_by_success(g)
@@ -153,18 +158,6 @@ function update_ensemble!(
     end
 
     u = fh.failsafe_update(ekp, u, g, failed_ens)
-
-    # store new parameters (and model outputs)
-    push!(ekp.g, DataContainer(g, data_are_columns = true))
-    # Store error
-    compute_error!(ekp)
-
-    # Diagnostics
-    cov_new = cov(u, dims = 2)
-
-    if ekp.verbose
-        @info "Covariance-weighted error: $(get_error(ekp)[end])\nCovariance trace: $(tr(cov_new))\nCovariance trace ratio (current/previous): $(tr(cov_new)/tr(cov_init))"
-    end
 
     return u
 end

--- a/src/EnsembleTransformKalmanInversion.jl
+++ b/src/EnsembleTransformKalmanInversion.jl
@@ -125,7 +125,7 @@ Inputs:
 function update_ensemble!(
     ekp::EnsembleKalmanProcess{FT, IT, TransformInversion},
     g::AbstractMatrix{FT},
-    process::TransformInversion{FT},
+    process::TransformInversion,
     u_idx::Vector{Int},
     g_idx::Vector{Int};
     failed_ens = nothing,

--- a/src/EnsembleTransformKalmanInversion.jl
+++ b/src/EnsembleTransformKalmanInversion.jl
@@ -137,8 +137,8 @@ function update_ensemble!(
     # g: lenght(g_idx) × N_ens
     u = get_u_final(ekp)[u_idx, :]
     g = g[g_idx, :]
-    obs_noise_cov = ekp.obs_noise_cov[g_idx, g_idx]
-    obs_mean = ekp.obs_mean[g_idx]
+    obs_noise_cov = get_obs_noise_cov(ekp)[g_idx, g_idx]
+    obs_mean = get_obs(ekp)[g_idx]
     # ISSUE. In general this is not true,
     # Gamma_inv = ekp.process.Gamma_inv[g_idx,g_idx]
 
@@ -146,9 +146,9 @@ function update_ensemble!(
     fh = get_failure_handler(ekp)
 
     # Scale noise using Δt
-    scaled_obs_noise_cov = obs_noise_cov / ekp.Δt[end]
+    scaled_obs_noise_cov = obs_noise_cov / get_Δt(ekp)[end]
 
-    y = ekp.obs_mean
+    y = get_obs(ekp)
 
     if isnothing(failed_ens)
         _, failed_ens = split_indices_by_success(g)

--- a/src/GaussNewtonKalmanInversion.jl
+++ b/src/GaussNewtonKalmanInversion.jl
@@ -73,7 +73,7 @@ function gnki_update(
     N_ens_successful = size(g, 2)
     cov_est = cov([u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
 
-    cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u,1), size(g,1), get_N_ens(ekp))
+    cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u, 1), size(g, 1), get_N_ens(ekp))
     cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
     process = get_process(ekp)
     prior_mean = process.prior_mean

--- a/src/GaussNewtonKalmanInversion.jl
+++ b/src/GaussNewtonKalmanInversion.jl
@@ -73,7 +73,7 @@ function gnki_update(
     N_ens_successful = size(g, 2)
     cov_est = cov([u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
 
-    cov_localized = get_localizer(ekp).localize(cov_est)
+    cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u,1), size(g,1), get_N_ens(ekp))
     cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
     process = get_process(ekp)
     prior_mean = process.prior_mean

--- a/src/GaussNewtonKalmanInversion.jl
+++ b/src/GaussNewtonKalmanInversion.jl
@@ -129,7 +129,9 @@ Inputs:
 function update_ensemble!(
     ekp::EnsembleKalmanProcess{FT, IT, GNI},
     g::AbstractMatrix{FT},
-    process::GNI;
+    process::GNI,
+    u_idx::Vector{Int},
+    g_idx::Vector{Int};
     deterministic_forward_map::Bool = true,
     failed_ens = nothing,
 ) where {FT, IT, GNI <: GaussNewtonInversion}
@@ -141,18 +143,11 @@ function update_ensemble!(
     end
     # u: N_par × N_ens 
     # g: N_obs × N_ens
-    u = get_u_final(ekp)
-    N_obs = size(g, 1)
-    cov_init = cov(u, dims = 2)
-
-    if ekp.verbose
-        if get_N_iterations(ekp) == 0
-            @info "Iteration 0 (prior)"
-            @info "Covariance trace: $(tr(cov_init))"
-        end
-
-        @info "Iteration $(get_N_iterations(ekp)+1) (T=$(sum(get_Δt(ekp))))"
-    end
+    u = get_u_final(ekp)[u_idx, :]
+    g = g[g_idx, :]
+    N_obs = length(g_idx)
+    obs_noise_cov = get_obs_noise_cov(ekp)[g_idx, g_idx]
+    obs_mean = get_obs(ekp)[g_idx]
 
     fh = get_failure_handler(ekp)
 
@@ -172,18 +167,6 @@ function update_ensemble!(
     end
 
     u = fh.failsafe_update(ekp, u, g, y, scaled_obs_noise_cov, failed_ens)
-
-    push!(ekp.g, DataContainer(g, data_are_columns = true))
-
-    # Store error
-    compute_error!(ekp)
-
-    # Diagnostics
-    cov_new = cov(u, dims = 2)
-
-    if ekp.verbose
-        @info "Covariance-weighted error: $(get_error(ekp)[end])\nCovariance trace: $(tr(cov_new))\nCovariance trace ratio (current/previous): $(tr(cov_new)/tr(cov_init))"
-    end
 
     return u
 end

--- a/src/Localizers.jl
+++ b/src/Localizers.jl
@@ -148,18 +148,18 @@ function kernel_function(kernel_ug, T, p, d)
 end
 
 "Uniform kernel constructor" # p::IT, d::IT, J::IT, T = Float64
-function Localizer(localization::NoLocalization, J::Int, T=Float64)
+function Localizer(localization::NoLocalization, J::Int, T = Float64)
     #kernel_ug = ones(T,p,d)
     return Localizer{NoLocalization, T}((cov, T, p, d, J) -> cov)
 end
 
 "Delta kernel localizer constructor"
-function Localizer(localization::Delta, J::Int, T=Float64)
+function Localizer(localization::Delta, J::Int, T = Float64)
     #kernel_ug = T(1) * Matrix(I, p, d)
     return Localizer{Delta, T}((cov, T, p, d, J) -> kernel_function(T(1) * Matrix(I, p, d), T, p, d) .* cov)
 end
 
-function create_rbf(l,T,p,d)
+function create_rbf(l, T, p, d)
     kernel_ug = zeros(T, p, d)
     for i in 1:p
         for j in 1:d
@@ -168,10 +168,12 @@ function create_rbf(l,T,p,d)
     end
     return kernel_ug
 end
-    "RBF kernel localizer constructor"
-function Localizer(localization::RBF, J::Int, T=Float64)
+"RBF kernel localizer constructor"
+function Localizer(localization::RBF, J::Int, T = Float64)
     #kernel_ug = create_rbf(localization.lengthscale,T,p,d)
-    return Localizer{RBF, T}((cov, T, p, d, J) -> kernel_function(create_rbf(localization_lengthscale,T,p,d), T, p, d).* cov)
+    return Localizer{RBF, T}(
+        (cov, T, p, d, J) -> kernel_function(create_rbf(localization_lengthscale, T, p, d), T, p, d) .* cov,
+    )
 end
 
 "Localization kernel with Bernoulli trials as off-diagonal terms (symmetric)"
@@ -197,7 +199,7 @@ end
 Localize using a Schur product with a random draw of a Bernoulli kernel matrix. Only the u–G(u) block is localized.
 """
 function bernoulli_kernel_function(prob, T, p, d)
-    
+
     kernel = ones(T, p + d, p + d)
     kernel_ug = bernoulli_kernel(prob, T, p, d)
     kernel[1:p, (p + 1):end] = kernel_ug
@@ -206,8 +208,10 @@ function bernoulli_kernel_function(prob, T, p, d)
 end
 
 "Randomized Bernoulli dropout kernel localizer constructor"
-function Localizer(localization::BernoulliDropout, J::Int, T=Float64)
-    return Localizer{BernoulliDropout, T}((cov, T, p, d, J) -> bernoulli_kernel_function(localization.prob, T, p, d) .* cov)
+function Localizer(localization::BernoulliDropout, J::Int, T = Float64)
+    return Localizer{BernoulliDropout, T}(
+        (cov, T, p, d, J) -> bernoulli_kernel_function(localization.prob, T, p, d) .* cov,
+    )
 end
 
 """
@@ -226,7 +230,7 @@ function sec(cov, α, r_0)
 end
 
 "Sampling error correction (Lee, 2021) constructor"
-function Localizer(localization::SEC, J::Int, T=Float64)
+function Localizer(localization::SEC, J::Int, T = Float64)
     return Localizer{SEC, T}((cov, T, p, d, J) -> sec(cov, localization.α, localization.r_0))
 end
 
@@ -266,7 +270,7 @@ function sec_fisher(cov, N_ens)
 end
 
 "Sampling error correction (Flowerdew, 2015) constructor"
-function Localizer(localization::SECFisher,J::Int, T=Float64)
+function Localizer(localization::SECFisher, J::Int, T = Float64)
     return Localizer{SECFisher, T}((cov, T, p, d, J) -> sec_fisher(cov, J))
 end
 
@@ -361,7 +365,7 @@ end
 
 
 "Sampling error correction of Vishny, Morzfeld, et al. (2024) constructor"
-function Localizer(localization::SECNice, J::Int, T=Float64)
+function Localizer(localization::SECNice, J::Int, T = Float64)
     if length(localization.std_of_corr) == 0 #i.e. if the user hasn't provided an interpolation
         dr = 0.001
         grid = LinRange(-1, 1, Int(1 / dr + 1))

--- a/src/Localizers.jl
+++ b/src/Localizers.jl
@@ -144,31 +144,34 @@ function kernel_function(kernel_ug, T, p, d)
     kernel = ones(T, p + d, p + d)
     kernel[1:p, (p + 1):end] = kernel_ug
     kernel[(p + 1):end, 1:p] = kernel_ug'
-    return (cov) -> kernel .* cov
+    return kernel
 end
 
-"Uniform kernel constructor"
-function Localizer(localization::NoLocalization, p::IT, d::IT, J::IT, T = Float64) where {IT <: Int}
-    kernel_ug = ones(T, p, d)
-    return Localizer{NoLocalization, T}(kernel_function(kernel_ug, T, p, d))
+"Uniform kernel constructor" # p::IT, d::IT, J::IT, T = Float64
+function Localizer(localization::NoLocalization, J::Int, T=Float64)
+    #kernel_ug = ones(T,p,d)
+    return Localizer{NoLocalization, T}((cov, T, p, d, J) -> cov)
 end
 
 "Delta kernel localizer constructor"
-function Localizer(localization::Delta, p::IT, d::IT, J::IT, T = Float64) where {IT <: Int}
-    kernel_ug = T(1) * Matrix(I, p, d)
-    return Localizer{Delta, T}(kernel_function(kernel_ug, T, p, d))
+function Localizer(localization::Delta, J::Int, T=Float64)
+    #kernel_ug = T(1) * Matrix(I, p, d)
+    return Localizer{Delta, T}((cov, T, p, d, J) -> kernel_function(T(1) * Matrix(I, p, d), T, p, d) .* cov)
 end
 
-"RBF kernel localizer constructor"
-function Localizer(localization::RBF, p::IT, d::IT, J::IT, T = Float64) where {IT <: Int}
-    l = localization.lengthscale
+function create_rbf(l,T,p,d)
     kernel_ug = zeros(T, p, d)
     for i in 1:p
         for j in 1:d
             @inbounds kernel_ug[i, j] = exp(-(i - j) * (i - j) / (2 * l * l))
         end
     end
-    return Localizer{RBF, T}(kernel_function(kernel_ug, T, p, d))
+    return kernel_ug
+end
+    "RBF kernel localizer constructor"
+function Localizer(localization::RBF, J::Int, T=Float64)
+    #kernel_ug = create_rbf(localization.lengthscale,T,p,d)
+    return Localizer{RBF, T}((cov, T, p, d, J) -> kernel_function(create_rbf(localization_lengthscale,T,p,d), T, p, d).* cov)
 end
 
 "Localization kernel with Bernoulli trials as off-diagonal terms (symmetric)"
@@ -194,19 +197,17 @@ end
 Localize using a Schur product with a random draw of a Bernoulli kernel matrix. Only the u–G(u) block is localized.
 """
 function bernoulli_kernel_function(prob, T, p, d)
-    function get_kernel()
-        kernel = ones(T, p + d, p + d)
-        kernel_ug = bernoulli_kernel(prob, T, p, d)
-        kernel[1:p, (p + 1):end] = kernel_ug
-        kernel[(p + 1):end, 1:p] = kernel_ug'
-        return kernel
-    end
-    return (cov) -> get_kernel() .* cov
+    
+    kernel = ones(T, p + d, p + d)
+    kernel_ug = bernoulli_kernel(prob, T, p, d)
+    kernel[1:p, (p + 1):end] = kernel_ug
+    kernel[(p + 1):end, 1:p] = kernel_ug'
+    return kernel
 end
 
 "Randomized Bernoulli dropout kernel localizer constructor"
-function Localizer(localization::BernoulliDropout, p::IT, d::IT, J::IT, T = Float64) where {IT <: Int}
-    return Localizer{BernoulliDropout, T}(bernoulli_kernel_function(localization.prob, T, p, d))
+function Localizer(localization::BernoulliDropout, J::Int, T=Float64)
+    return Localizer{BernoulliDropout, T}((cov, T, p, d, J) -> bernoulli_kernel_function(localization.prob, T, p, d) .* cov)
 end
 
 """
@@ -225,8 +226,8 @@ function sec(cov, α, r_0)
 end
 
 "Sampling error correction (Lee, 2021) constructor"
-function Localizer(localization::SEC, p::IT, d::IT, J::IT, T = Float64) where {IT <: Int}
-    return Localizer{SEC, T}((cov) -> sec(cov, localization.α, localization.r_0))
+function Localizer(localization::SEC, J::Int, T=Float64)
+    return Localizer{SEC, T}((cov, T, p, d, J) -> sec(cov, localization.α, localization.r_0))
 end
 
 """
@@ -265,8 +266,8 @@ function sec_fisher(cov, N_ens)
 end
 
 "Sampling error correction (Flowerdew, 2015) constructor"
-function Localizer(localization::SECFisher, p::IT, d::IT, J::IT, T = Float64) where {IT <: Int}
-    return Localizer{SECFisher, T}((cov) -> sec_fisher(cov, J))
+function Localizer(localization::SECFisher,J::Int, T=Float64)
+    return Localizer{SECFisher, T}((cov, T, p, d, J) -> sec_fisher(cov, J))
 end
 
 """
@@ -360,7 +361,7 @@ end
 
 
 "Sampling error correction of Vishny, Morzfeld, et al. (2024) constructor"
-function Localizer(localization::SECNice, p::IT, d::IT, J::IT, T = Float64) where {IT <: Int}
+function Localizer(localization::SECNice, J::Int, T=Float64)
     if length(localization.std_of_corr) == 0 #i.e. if the user hasn't provided an interpolation
         dr = 0.001
         grid = LinRange(-1, 1, Int(1 / dr + 1))
@@ -369,7 +370,7 @@ function Localizer(localization::SECNice, p::IT, d::IT, J::IT, T = Float64) wher
     end
 
     return Localizer{SECNice, T}(
-        (cov) -> sec_nice(cov, localization.std_of_corr[1], localization.δ_ug, localization.δ_gg, J, p, d),
+        (cov, T, p, d, J) -> sec_nice(cov, localization.std_of_corr[1], localization.δ_ug, localization.δ_gg, J, p, d),
     )
 end
 

--- a/src/Localizers.jl
+++ b/src/Localizers.jl
@@ -172,7 +172,7 @@ end
 function Localizer(localization::RBF, J::Int, T = Float64)
     #kernel_ug = create_rbf(localization.lengthscale,T,p,d)
     return Localizer{RBF, T}(
-        (cov, T, p, d, J) -> kernel_function(create_rbf(localization_lengthscale, T, p, d), T, p, d) .* cov,
+        (cov, T, p, d, J) -> kernel_function(create_rbf(localization.lengthscale, T, p, d), T, p, d) .* cov,
     )
 end
 

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -184,6 +184,8 @@ Inputs:
  - `ekp` :: The EnsembleKalmanProcess to update.
  - `g` :: Model outputs, they need to be stored as a `N_obs × N_ens` array (i.e data are columms).
  - `process` :: Type of the EKP.
+ - `u_idx` :: indices of u to update (see `UpdateGroup`)
+ - `g_idx` :: indices of g,y,Γ with which to update u (see `UpdateGroup`)
  - `deterministic_forward_map` :: Whether output `g` comes from a deterministic model.
  - `failed_ens` :: Indices of failed particles. If nothing, failures are computed as columns of `g`
     with NaN entries.
@@ -191,7 +193,9 @@ Inputs:
 function update_ensemble!(
     ekp::EnsembleKalmanProcess{FT, IT, SparseInversion{FT}},
     g::AbstractMatrix{FT},
-    process::SparseInversion{FT};
+    process::SparseInversion{FT},
+    u_idx::Vector{Int},
+    g_idx::Vector{Int};
     deterministic_forward_map = true,
     failed_ens = nothing,
 ) where {FT, IT}
@@ -219,12 +223,6 @@ function update_ensemble!(
     end
 
     u = fh.failsafe_update(ekp, u, g, y, scaled_obs_noise_cov, failed_ens)
-
-    # store new parameters (and model outputs)
-    push!(ekp.g, DataContainer(g, data_are_columns = true))
-
-    # Store error
-    compute_error!(ekp)
 
     # Check convergence
     cov_new = cov(get_u_final(ekp), dims = 2)

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -133,7 +133,7 @@ function sparse_eki_update(
     cov_est = cov([u; g], [u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
     process = get_process(ekp)
     # Localization
-    cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u,1), size(g,1), get_N_ens(ekp))
+    cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u, 1), size(g, 1), get_N_ens(ekp))
     cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
 
     v = hcat(u', g')

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -133,7 +133,7 @@ function sparse_eki_update(
     cov_est = cov([u; g], [u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
     process = get_process(ekp)
     # Localization
-    cov_localized = get_localizer(ekp).localize(cov_est)
+    cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u,1), size(g,1), get_N_ens(ekp))
     cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
 
     v = hcat(u', g')

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -312,9 +312,6 @@ function FailureHandler(process::Unscented, method::SampleSuccGauss)
         push!(process.obs_pred, g_mean) # N_ens x N_data
         push!(process.u_mean, u_mean) # N_ens x N_params
         push!(process.uu_cov, uu_cov) # N_ens x N_data
-        push!(uki.g, DataContainer(g, data_are_columns = true))
-
-        compute_error!(uki)
 
     end
     function failsafe_update(uki, u, g, failed_ens)
@@ -644,9 +641,6 @@ function update_ensemble_analysis!(
     push!(process.obs_pred, g_mean) # N_ens x N_data
     push!(process.u_mean, u_mean) # N_ens x N_params
     push!(process.uu_cov, uu_cov) # N_ens x N_data
-    push!(uki.g, DataContainer(g, data_are_columns = true))
-
-    compute_error!(uki)
 
 end
 
@@ -664,28 +658,21 @@ Inputs:
  - `uki`        :: The EnsembleKalmanProcess to update.
  - `g_in`       :: Model outputs, they need to be stored as a `N_obs × N_ens` array (i.e data are columms).
  - `process` :: Type of the EKP.
+ - `u_idx` :: indices of u to update (see `UpdateGroup`)
+ - `g_idx` :: indices of g,y,Γ with which to update u (see `UpdateGroup`)
  - `failed_ens` :: Indices of failed particles. If nothing, failures are computed as columns of `g`
     with NaN entries.
 """
 function update_ensemble!(
     uki::EnsembleKalmanProcess{FT, IT, U},
     g_in::AbstractMatrix{FT},
-    process::U;
+    process::U,
+    u_idx::Vector{Int},
+    g_idx::Vector{Int};
     failed_ens = nothing,
 ) where {FT <: AbstractFloat, IT <: Int, U <: Unscented}
     #catch works when g_in non-square 
     u_p_old = get_u_final(uki)
-
-    if uki.verbose
-        cov_init = get_u_cov_final(uki)
-
-        if get_N_iterations(uki) == 0
-            @info "Iteration 0 (prior)"
-            @info "Covariance trace: $(tr(cov_init))"
-        end
-
-        @info "Iteration $(get_N_iterations(uki)+1) (T=$(sum(get_Δt(uki))))"
-    end
 
     fh = get_failure_handler(uki)
 
@@ -697,12 +684,6 @@ function update_ensemble!(
     end
 
     u_p = fh.failsafe_update(uki, u_p_old, g_in, failed_ens)
-
-
-    if uki.verbose
-        cov_new = get_u_cov_final(uki)
-        @info "Covariance-weighted error: $(get_error(uki)[end])\nCovariance trace: $(tr(cov_new))\nCovariance trace ratio (current/previous): $(tr(cov_new)/tr(cov_init))"
-    end
 
     return u_p
 end

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -293,7 +293,8 @@ function FailureHandler(process::Unscented, method::SampleSuccGauss)
         ]
 
         # Localization
-        cov_localized = get_localizer(uki).localize(cov_est)
+        FT = eltype(g_mean)
+        cov_localized = get_localizer(uki).localize(cov_est, FT, size(u_p,1), size(g,1), size(u_p,2))
         uu_p_cov, ug_cov, gg_cov = get_cov_blocks(cov_localized, size(u_p, 1))
 
         if process.impose_prior
@@ -629,7 +630,7 @@ function update_ensemble_analysis!(
         ug_cov' gg_cov
     ]
     # Localization
-    cov_localized = get_localizer(uki).localize(cov_est)
+    cov_localized = get_localizer(uki).localize(cov_est, FT, size(u_p,1), size(g,1), size(u_p,2))
     uu_p_cov, ug_cov, gg_cov = get_cov_blocks(cov_localized, size(u_p)[1])
 
     tmp = ug_cov / gg_cov

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -294,7 +294,7 @@ function FailureHandler(process::Unscented, method::SampleSuccGauss)
 
         # Localization
         FT = eltype(g_mean)
-        cov_localized = get_localizer(uki).localize(cov_est, FT, size(u_p,1), size(g,1), size(u_p,2))
+        cov_localized = get_localizer(uki).localize(cov_est, FT, size(u_p, 1), size(g, 1), size(u_p, 2))
         uu_p_cov, ug_cov, gg_cov = get_cov_blocks(cov_localized, size(u_p, 1))
 
         if process.impose_prior
@@ -630,7 +630,7 @@ function update_ensemble_analysis!(
         ug_cov' gg_cov
     ]
     # Localization
-    cov_localized = get_localizer(uki).localize(cov_est, FT, size(u_p,1), size(g,1), size(u_p,2))
+    cov_localized = get_localizer(uki).localize(cov_est, FT, size(u_p, 1), size(g, 1), size(u_p, 2))
     uu_p_cov, ug_cov, gg_cov = get_cov_blocks(cov_localized, size(u_p)[1])
 
     tmp = ug_cov / gg_cov

--- a/src/UpdateGroup.jl
+++ b/src/UpdateGroup.jl
@@ -27,7 +27,14 @@ struct UpdateGroup
     group_id::Dict
 end
 
-function UpdateGroup(u_group, g_group)
+function UpdateGroup(u_group::VV1, g_group::VV2) where {VV1 <: AbstractVector, VV2 <: AbstractVector}
+    # check there is an index in each group
+    if length(u_group) == 0 
+        throw(ArgumentError("all `UpdateGroup.u_group` must contain at least one parameter identifier"))
+    end
+    if length(g_group) == 0
+        throw(ArgumentError("all `UpdateGroup.g_group` must contain at least one data identifier"))
+    end
     return UpdateGroup(
         u_group,
         g_group,

--- a/src/UpdateGroup.jl
+++ b/src/UpdateGroup.jl
@@ -140,14 +140,9 @@ function create_update_groups(
         push!(update_groups, UpdateGroup(u_group, g_group, Dict(key_vec => val_vec)))
     end
     return update_groups
-    
+
 end
 
 ## Overload ==
-Base.:(==)(a::UG1, b::UG2) where {UG1 <: UpdateGroup, UG2 <: UpdateGroup} = all([
-    get_u_group(a) == get_u_group(b),
-    get_g_group(a) == get_g_group(b),
-    get_group_id(a) == get_group_id(b),
-],
-                                                                                )
-
+Base.:(==)(a::UG1, b::UG2) where {UG1 <: UpdateGroup, UG2 <: UpdateGroup} =
+    all([get_u_group(a) == get_u_group(b), get_g_group(a) == get_g_group(b), get_group_id(a) == get_group_id(b)],)

--- a/src/UpdateGroup.jl
+++ b/src/UpdateGroup.jl
@@ -29,7 +29,7 @@ end
 
 function UpdateGroup(u_group::VV1, g_group::VV2) where {VV1 <: AbstractVector, VV2 <: AbstractVector}
     # check there is an index in each group
-    if length(u_group) == 0 
+    if length(u_group) == 0
         throw(ArgumentError("all `UpdateGroup.u_group` must contain at least one parameter identifier"))
     end
     if length(g_group) == 0

--- a/src/UpdateGroup.jl
+++ b/src/UpdateGroup.jl
@@ -61,14 +61,6 @@ function update_group_consistency(groups::VV, input_dim::Int, output_dim::Int) w
     u_groups = get_u_group.(groups)
     g_groups = get_g_group.(groups)
 
-    # check there is an index in each group
-    if any(length(group) == 0 for group in u_groups)
-        throw(ArgumentError("all `UpdateGroup.u_group` must contain at least one parameter identifier"))
-    end
-    if any(length(group) == 0 for group in g_groups)
-        throw(ArgumentError("all `UpdateGroup.g_group` must contain at least one data identifier"))
-    end
-
     # check for partition (only if indices passed)
     u_flat = reduce(vcat, u_groups)
     if !(1:input_dim == sort(u_flat))
@@ -148,5 +140,14 @@ function create_update_groups(
         push!(update_groups, UpdateGroup(u_group, g_group, Dict(key_vec => val_vec)))
     end
     return update_groups
-
+    
 end
+
+## Overload ==
+Base.:(==)(a::UG1, b::UG2) where {UG1 <: UpdateGroup, UG2 <: UpdateGroup} = all([
+    get_u_group(a) == get_u_group(b),
+    get_g_group(a) == get_g_group(b),
+    get_group_id(a) == get_group_id(b),
+],
+                                                                                )
+

--- a/src/UpdateGroup.jl
+++ b/src/UpdateGroup.jl
@@ -110,14 +110,22 @@ function create_update_groups(
     for (key, val) in pairs(group_identifiers)
         key_vec = isa(key, AbstractString) ? [key] : key # make it iterable
         val_vec = isa(val, AbstractString) ? [val] : val
+        
         u_group = []
         g_group = []
         for pn in key_vec
             pi = param_indices[pn .== param_names]
+            if length(pi) == 0
+                throw(ArgumentError("For group identifiers Dict(X => ...), X should be listed in $(param_names). Got $(pn)."))
+            end
+            
             push!(u_group, isa(pi, Int) ? [pi] : pi)
         end
         for obn in val_vec
             oi = obs_indices[obn .== obs_names]
+            if length(oi) == 0
+                throw(ArgumentError("For group identifiers Dict(... => Y), Y should be listed from $(obs_names). Instead got $(val)."))
+            end
             push!(g_group, isa(oi, Int) ? [oi] : oi)
         end
         u_group = reduce(vcat, reduce(vcat, u_group))

--- a/src/UpdateGroup.jl
+++ b/src/UpdateGroup.jl
@@ -110,21 +110,29 @@ function create_update_groups(
     for (key, val) in pairs(group_identifiers)
         key_vec = isa(key, AbstractString) ? [key] : key # make it iterable
         val_vec = isa(val, AbstractString) ? [val] : val
-        
+
         u_group = []
         g_group = []
         for pn in key_vec
             pi = param_indices[pn .== param_names]
             if length(pi) == 0
-                throw(ArgumentError("For group identifiers Dict(X => ...), X should be listed in $(param_names). Got $(pn)."))
+                throw(
+                    ArgumentError(
+                        "For group identifiers Dict(X => ...), X should be listed in $(param_names). Got $(pn).",
+                    ),
+                )
             end
-            
+
             push!(u_group, isa(pi, Int) ? [pi] : pi)
         end
         for obn in val_vec
             oi = obs_indices[obn .== obs_names]
             if length(oi) == 0
-                throw(ArgumentError("For group identifiers Dict(... => Y), Y should be listed from $(obs_names). Instead got $(val)."))
+                throw(
+                    ArgumentError(
+                        "For group identifiers Dict(... => Y), Y should be listed from $(obs_names). Instead got $(val).",
+                    ),
+                )
             end
             push!(g_group, isa(oi, Int) ? [oi] : oi)
         end

--- a/src/UpdateGroup.jl
+++ b/src/UpdateGroup.jl
@@ -1,0 +1,87 @@
+# EKP implementation of the domain and observation localization from the literature
+
+export UpdateGroup
+export get_u_group, get_g_group, update_group_consistency
+
+"""
+    struct UpdateGroup {VV <: AbstractVector}
+
+Container of indices indicating which parameters (u_group) should be updated by which data (g_group).
+Provide an array of UpdateGroups to partition the parameter space.
+Note this partitioning assumes conditional independence between different sets of `UpdateGroups.u_group`s.
+
+# Fields
+
+$(TYPEDFIELDS)
+
+"""
+struct UpdateGroup
+    "vector of parameter indices, forms part(or all) of a partition of 1:input_dim with other UpdateGroups provided"
+    u_group::Vector{Int}
+    "vector of data indices, must lie within 1:output_dim"
+    g_group::Vector{Int}
+    # process::Process # in future
+    # localizer::Localizer # in future
+    # inflation::Inflation # in future
+end
+
+get_u_group(group::UpdateGroup) = group.u_group
+get_g_group(group::UpdateGroup) = group.g_group
+
+function get_u_group(groups::VV) where {VV <: AbstractVector}
+    u_group = []
+    for group in groups
+        push!(u_group, get_u_group(group))
+    end
+    return u_group
+end
+
+function get_g_group(groups::VV) where {VV <: AbstractVector}
+    g_group = []
+    for group in groups
+        push!(g_group, get_g_group(group))
+    end
+    return g_group
+end
+
+# check an array of update_groups are consistent, i.e. common sizing for u,g, and that u is a partition.
+"""
+$(TYPEDSIGNATURES)
+
+Check the consistency of sizing and partitioning of the `UpdateGroup` array
+"""
+function update_group_consistency(groups::VV, input_dim::Int, output_dim::Int) where {VV <: AbstractVector}
+
+    u_groups = get_u_group(groups)
+    g_groups = get_g_group(groups)
+
+    # check there is an index in each group
+    if any(length(group) == 0 for group in u_groups)
+        throw(ArgumentError("all `UpdateGroup.u_group` must contain at least one parameter index"))
+    end
+    if any(length(group) == 0 for group in g_groups)
+        throw(ArgumentError("all `UpdateGroup.g_group` must contain at least one parameter index"))
+    end
+
+    # check for partition
+    u_flat = reduce(vcat, u_groups)
+    if !(1:input_dim == sort(u_flat))
+        throw(
+            ArgumentError(
+                "The combined 'UpdateGroup.u_group's must partition the indices of the input parameters: 1:$(input_dim), received: $(sort(u_flat))",
+            ),
+        )
+    end
+
+    g_flat = reduce(vcat, g_groups)
+    if any(gf > output_dim for gf in g_flat) || any(gf <= 0 for gf in g_flat)
+        throw(
+            ArgumentError(
+                "The UpdateGroup.g_group must contains values in: 1:$(output_dim), found values outside this range",
+            ),
+        )
+    end
+
+    # pass the tests
+    return true
+end

--- a/test/Inflation/runtests.jl
+++ b/test/Inflation/runtests.jl
@@ -58,6 +58,8 @@ initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
         g_ens = G(get_ϕ_final(prior, ekiobj))
 
         # ensure error is thrown when scaled time step >= 1
+        idx_vec_in = collect(1:size(initial_ensemble, 1))
+        idx_vec_out = collect(1:size(g_ens, 1))
         @test_throws ErrorException EKP.update_ensemble!(ekiobj, g_ens; multiplicative_inflation = true, s = 3.0)
         @test_throws ErrorException EKP.update_ensemble!(ekiobj, g_ens; additive_inflation = true, s = 3.0)
 
@@ -67,7 +69,7 @@ initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
             g_ens = G(get_ϕ_final(prior, ekiobj))
 
             # standard update
-            EKP.update_ensemble!(ekiobj, g_ens, EKP.get_process(ekiobj))
+            EKP.update_ensemble!(ekiobj, g_ens)
             eki_mult_inflation = deepcopy(ekiobj)
             eki_add_inflation = deepcopy(ekiobj)
             eki_add_inflation_prior = deepcopy(ekiobj)

--- a/test/Localizers/runtests.jl
+++ b/test/Localizers/runtests.jl
@@ -101,7 +101,7 @@ const EKP = EnsembleKalmanProcesses
         g_final = get_g_final(ekiobj)
         cov_est = cov([u_final; g_final], dims = 2, corrected = false)
         # The arguments for the localizer
-        T, p, d, J = (eltype(g_final),  size(u_final, 1), size(g_final, 1), size(u_final, 2))
+        T, p, d, J = (eltype(g_final), size(u_final, 1), size(g_final, 1), size(u_final, 2))
         cov_localized = ekiobj.localizer.localize(cov_est, T, p, d, J)
         @test rank(cov_est) < rank(cov_localized)
         # Test localization getter method

--- a/test/Localizers/runtests.jl
+++ b/test/Localizers/runtests.jl
@@ -100,7 +100,7 @@ const EKP = EnsembleKalmanProcesses
         u_final = get_u_final(ekiobj)
         g_final = get_g_final(ekiobj)
         cov_est = cov([u_final; g_final], dims = 2, corrected = false)
-        cov_localized = ekiobj.localizer.localize(cov_est, size(u_final,1), size(g_final,1), size(u,final,2))
+        cov_localized = ekiobj.localizer.localize(cov_est, size(u_final, 1), size(g_final, 1), size(u, final, 2))
         @test rank(cov_est) < rank(cov_localized)
         # Test localization getter method
         @test isa(loc_method, EKP.get_localizer_type(ekiobj))

--- a/test/Localizers/runtests.jl
+++ b/test/Localizers/runtests.jl
@@ -100,7 +100,9 @@ const EKP = EnsembleKalmanProcesses
         u_final = get_u_final(ekiobj)
         g_final = get_g_final(ekiobj)
         cov_est = cov([u_final; g_final], dims = 2, corrected = false)
-        cov_localized = ekiobj.localizer.localize(cov_est, size(u_final, 1), size(g_final, 1), size(u_final, 2))
+        # The arguments for the localizer
+        T, p, d, J = (eltype(g_final),  size(u_final, 1), size(g_final, 1), size(u_final, 2))
+        cov_localized = ekiobj.localizer.localize(cov_est, T, p, d, J)
         @test rank(cov_est) < rank(cov_localized)
         # Test localization getter method
         @test isa(loc_method, EKP.get_localizer_type(ekiobj))

--- a/test/Localizers/runtests.jl
+++ b/test/Localizers/runtests.jl
@@ -100,7 +100,7 @@ const EKP = EnsembleKalmanProcesses
         u_final = get_u_final(ekiobj)
         g_final = get_g_final(ekiobj)
         cov_est = cov([u_final; g_final], dims = 2, corrected = false)
-        cov_localized = ekiobj.localizer.localize(cov_est)
+        cov_localized = ekiobj.localizer.localize(cov_est, size(u_final,1), size(g_final,1), size(u,final,2))
         @test rank(cov_est) < rank(cov_localized)
         # Test localization getter method
         @test isa(loc_method, EKP.get_localizer_type(ekiobj))

--- a/test/Localizers/runtests.jl
+++ b/test/Localizers/runtests.jl
@@ -100,7 +100,7 @@ const EKP = EnsembleKalmanProcesses
         u_final = get_u_final(ekiobj)
         g_final = get_g_final(ekiobj)
         cov_est = cov([u_final; g_final], dims = 2, corrected = false)
-        cov_localized = ekiobj.localizer.localize(cov_est, size(u_final, 1), size(g_final, 1), size(u, final, 2))
+        cov_localized = ekiobj.localizer.localize(cov_est, size(u_final, 1), size(g_final, 1), size(u_final, 2))
         @test rank(cov_est) < rank(cov_localized)
         # Test localization getter method
         @test isa(loc_method, EKP.get_localizer_type(ekiobj))

--- a/test/UpdateGroup/runtests.jl
+++ b/test/UpdateGroup/runtests.jl
@@ -22,7 +22,7 @@ const EKP = EnsembleKalmanProcesses
     group1 = UpdateGroup(u1, g1, Dict("1:8" => "1:20"))
     @test get_u_group(group1) == u1
     @test get_g_group(group1) == g1
-    @test get_group_id(group) == Dict("1:8" => "1:20")
+    @test get_group_id(group1) == Dict("1:8" => "1:20")
 
     u1c = [2, 4, 9, 10]
     g2 = 3:9
@@ -34,10 +34,8 @@ const EKP = EnsembleKalmanProcesses
 
     # break consistency with different ways
     not_u1c = [2, 3, 4, 9, 10]
-    group_bad = UpdateGroup([], g2)
-    @test_throws ArgumentError update_group_consistency([group1, group_bad], input_dim, output_dim)
-    group_bad = UpdateGroup(u1c, [])
-    @test_throws ArgumentError update_group_consistency([group1, group_bad], input_dim, output_dim)
+    @test_throws ArgumentError UpdateGroup([], g2)
+    @test_throws ArgumentError group_bad = UpdateGroup(u1c, [])
     group_bad = UpdateGroup(not_u1c, g2) # [u1,not_u1c] is not a partition of 1:10
     @test_throws ArgumentError update_group_consistency([group1, group_bad], input_dim, output_dim)
     not_inbd_g = [21] # outside of 1:20

--- a/test/UpdateGroup/runtests.jl
+++ b/test/UpdateGroup/runtests.jl
@@ -18,17 +18,17 @@ const EKP = EnsembleKalmanProcesses
     # build a set of consistent update groups
     u1 = [1, 3, 5, 6, 7, 8]
     g1 = 1:20
-    group1 = UpdateGroup(u1, g1)
+    identifier = Dict("1:8" => "1:20")
+    group1 = UpdateGroup(u1, g1, Dict("1:8" => "1:20"))
     @test get_u_group(group1) == u1
     @test get_g_group(group1) == g1
+    @test get_group_id(group) == Dict("1:8" => "1:20")
 
     u1c = [2, 4, 9, 10]
     g2 = 3:9
     group2 = UpdateGroup(u1c, g2)
 
     groups = [group1, group2]
-    @test get_u_group(groups) == [u1, u1c]
-    @test get_g_group(groups) == [g1, g2]
 
     @test update_group_consistency(groups, input_dim, output_dim)
 

--- a/test/UpdateGroup/runtests.jl
+++ b/test/UpdateGroup/runtests.jl
@@ -1,0 +1,47 @@
+using Distributions
+using LinearAlgebra
+using Random
+using Test
+
+using EnsembleKalmanProcesses
+# using EnsembleKalmanProcesses.ParameterDistributions
+const EKP = EnsembleKalmanProcesses
+
+
+@testset "UpdateGroups" begin
+
+    input_dim = 10
+    output_dim = 20
+    u = 1:10
+    g = 1:20
+
+    # build a set of consistent update groups
+    u1 = [1, 3, 5, 6, 7, 8]
+    g1 = 1:20
+    group1 = UpdateGroup(u1, g1)
+    @test get_u_group(group1) == u1
+    @test get_g_group(group1) == g1
+
+    u1c = [2, 4, 9, 10]
+    g2 = 3:9
+    group2 = UpdateGroup(u1c, g2)
+
+    groups = [group1, group2]
+    @test get_u_group(groups) == [u1, u1c]
+    @test get_g_group(groups) == [g1, g2]
+
+    @test update_group_consistency(groups, input_dim, output_dim)
+
+    # break consistency with different ways
+    not_u1c = [2, 3, 4, 9, 10]
+    group_bad = UpdateGroup([], g2)
+    @test_throws ArgumentError update_group_consistency([group1, group_bad], input_dim, output_dim)
+    group_bad = UpdateGroup(u1c, [])
+    @test_throws ArgumentError update_group_consistency([group1, group_bad], input_dim, output_dim)
+    group_bad = UpdateGroup(not_u1c, g2) # [u1,not_u1c] is not a partition of 1:10
+    @test_throws ArgumentError update_group_consistency([group1, group_bad], input_dim, output_dim)
+    not_inbd_g = [21] # outside of 1:20
+    group_bad = UpdateGroup(u1c, not_inbd_g)
+    @test_throws ArgumentError update_group_consistency([group1, group_bad], input_dim, output_dim)
+
+end

--- a/test/UpdateGroup/runtests.jl
+++ b/test/UpdateGroup/runtests.jl
@@ -58,35 +58,35 @@ using EnsembleKalmanProcesses.ParameterDistributions
     # data 
     # given a list of vector statistics y and their covariances Γ 
     data_block_names = ["<X>", "<Y>"]
-    
+
     observation_vec = []
     for i in 1:length(data_block_names)
         push!(
-        observation_vec,
+            observation_vec,
             Observation(Dict("samples" => vec(ones(i)), "covariances" => I(i), "names" => data_block_names[i])),
         )
     end
     observations = combine_observations(observation_vec)
-    group_identifiers = Dict(["F"] => ["<X>"], ["G"] => ["<X>","<Y>"])
+    group_identifiers = Dict(["F"] => ["<X>"], ["G"] => ["<X>", "<Y>"])
     update_groups = create_update_groups(priors, observations, group_identifiers)
 
-    
+
     param_names = get_name(priors)
     param_indices = batch(priors, function_parameter_opt = "dof")
-    
+
     obs_names = get_names(observations)
     obs_indices = get_indices(observations)
 
     update_groups_test = []
-    for (key,val) in group_identifiers
-        
+    for (key, val) in group_identifiers
+
         key_vec = isa(key, AbstractString) ? [key] : key # make it iterable
         val_vec = isa(val, AbstractString) ? [val] : val
 
         u_group = []
         g_group = []
         for pn in key_vec
-            pi = param_indices[pn .== param_names]            
+            pi = param_indices[pn .== param_names]
             push!(u_group, isa(pi, Int) ? [pi] : pi)
         end
         for obn in val_vec
@@ -97,12 +97,12 @@ using EnsembleKalmanProcesses.ParameterDistributions
         g_group = reduce(vcat, reduce(vcat, g_group))
         push!(update_groups_test, UpdateGroup(u_group, g_group, Dict(key_vec => val_vec)))
     end
-    
+
     @test update_groups == update_groups_test
 
     # throw errors
-    bad_group_identifiers = Dict(["FF"] => ["<X>"], ["G"] => ["<X>","<Y>"])    
+    bad_group_identifiers = Dict(["FF"] => ["<X>"], ["G"] => ["<X>", "<Y>"])
     @test_throws ArgumentError create_update_groups(priors, observations, bad_group_identifiers)
-    bad_group_identifiers = Dict(["F"] => ["<XX>"], ["G"] => ["<X>","<Y>"])    
+    bad_group_identifiers = Dict(["F"] => ["<XX>"], ["G"] => ["<X>", "<Y>"])
     @test_throws ArgumentError create_update_groups(priors, observations, bad_group_identifiers)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ end
         "ParameterDistributions",
         "PlotRecipes",
         "Observations",
+        "UpdateGroup",
         "EnsembleKalmanProcess",
         "Localizers",
         "TOMLInterface",


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #377
Indirectly, Closes #288 

To review the PR and see what is going on I would suggest, 
- playing with the `example/UpdateGroups/calibrate.jl`.
- Looking at the `src/UpdateGroups.jl` file
- Looking at `src/EnsembleKalmanProcess.jl` function `update_ensemble!(...)`
- look at the docs page ["Update Groups"](https://clima.github.io/EnsembleKalmanProcesses.jl/previews/PR380/update_groups/)
 
## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- `UpdateGroup` object
- unit tests for `UpdateGroup`
- implemented an interface with all EKP methods, in  particular this necessitated  lifting saving of "g", and verbose flag statements out of the individual updates thus reducing a lot of duplicated code
- implemented functionality for EKI
- Constructed an example based on learning "fast" and "slow" parameters of a coupled L96 model, hopefully improved by the grouping process. 
- Updated to work with new Observations and ObservationSeries framework: In particular, a nice constructor that takes in `prior, observation, dict_in_to_out` and produces a list of `UpdateGroups` that can be passed to EKP. 
- It also now works with minibatching, by repeating index blocks for each observation in the minibatch
- Small refactor to Localizers, (instantiated without dimensionality, then dimensionality is inferred from current ensembles)
- Functionality for: ETKI,UKI,EKS,SEKI
- Docs page "Update Groups"

## Example: Multiscale lorenz 96 with j=k

Parameters (Slow)
`F`: 3-vector of amplitude, frequency and mean of a periodic forcing on slow variables
`G`: Coupling term in slow equation to the fast variables
Parameters (Fast)
`h`: Coupling term in the fast variables
`c`: Timescale separation parameter of the fast variables
`b`: nonlinearity scaling in the fast variables
With labelled observations observed "Independently" I.e. we _assume_ independent with regards to observation (probably untrue)
`<X>, <Y>, <X^2>, <Y^2>, <XY>`
one can define two update groups as
```julia
group_identifiers = Dict(
    ["F"] => ["<X>", "<X^2>"], 
    ["G", "h", "c", "b"] => ["<Y>", "<Y^2>", "<XY>"],
)
update_groups = create_update_groups(priors, observation, group_identifiers) # handles all the indexing 
```
By allowing more correlations in the observations e.g. create `<X><X^2>` and `<Y><Y^2><XY>`one can also define groups by these identifiers
```julia
group_identifiers = Dict(
    ["F"] => ["<X><X^2>"], 
    ["G", "h", "c", "b"] => ["<Y><Y^2><XY>"],
)
update_groups = create_update_groups(priors, observation, group_identifiers)
```
and pass to the EKP object with `update_groups = update_groups` flag
Spin up over a year.
<img src="https://github.com/CliMA/EnsembleKalmanProcesses.jl/assets/47412152/fa4aa35f-fd16-4f2a-a8ba-f98530da6c79" width="350"> <img src="https://github.com/CliMA/EnsembleKalmanProcesses.jl/assets/47412152/8e355a52-4d52-4e11-bc20-56e9002081bd" width="350">
samples of the trajectories used for data
<img src="https://github.com/CliMA/EnsembleKalmanProcesses.jl/assets/47412152/a9a90674-70cd-44ec-ba2b-84f165acffa9" width="350">
forward map used for data (noise covaraince and true data `<X><Y><X^2><Y^2><XY>` nomalized by the noise)
<img src="https://github.com/CliMA/EnsembleKalmanProcesses.jl/assets/47412152/0993e4fe-9eab-4b9c-b3d7-d0e8e8337e19" width="350">
Shown below is the initial and final 50-ensemble (normalized by the noise) pushed through the forward map, over the true sample +/- 2sd (grey), after 5 iterations.
- True parameters `[8.0, 2.0, 0.05555555555555555], 10.0, 10.0, 10.0, 10.0 ]`
- Left: Full calibration, `{F,G,h,c,b}` with all data `{<X><Y><X^2><Y^2><XY>}`. 
```julia
[7.864338120823016, 1.1500565821985165, 0.05883690301359528, 2.7165402443001034, 2.8197381618086217, 6.8072979930231945, 7.978078567957204]
```
- Right: calibration with grouped `{F}`, `{G,h,c,b}` and fast/slow data batches `{<X><X^2>}`, `{<Y><Y^2><XY>}`. 
```julia 
[5.093003061750248, 2.1573021824213985, 0.0060389967710004905, 1.0526243678897405, 0.8561707192010413, 8.331178239855038, 3.594166654372452]
```
<img src="https://github.com/user-attachments/assets/132be7f9-4b7e-4c92-8391-5353efec8be0" width="350"> <img src="https://github.com/user-attachments/assets/7d39bb33-6ddf-45d3-83f1-71db1428d356" width="350">

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->
----
- [ ] I have read and checked the items on the review checklist.
