### PR TITLE
updated accelerator examples

### DIFF
--- a/examples/Accelerators/DarcyAccelerated/darcy_accelerated.jl
+++ b/examples/Accelerators/DarcyAccelerated/darcy_accelerated.jl
@@ -45,7 +45,7 @@ function main()
     rng = Random.MersenneTwister(seed)
 
     cases = ["const", "dmc", "dmc-loc-small-ens"]
-    case = cases[3]
+    case = cases[1]
 
     @info "running case $case"
     if case == "const"
@@ -158,9 +158,9 @@ function main()
             g_ens_acc = run_G_ensemble(darcy, params_i_acc)
             g_ens_acc_cs = run_G_ensemble(darcy, params_i_acc_cs)
 
-            EKP.update_ensemble!(ekiobj, g_ens, deterministic_forward_map = true)
-            EKP.update_ensemble!(ekiobj_acc, g_ens_acc, deterministic_forward_map = true)
-            EKP.update_ensemble!(ekiobj_acc_cs, g_ens_acc_cs, deterministic_forward_map = true)
+            EKP.update_ensemble!(ekiobj, g_ens, deterministic_forward_map = false)
+            EKP.update_ensemble!(ekiobj_acc, g_ens_acc)
+            EKP.update_ensemble!(ekiobj_acc_cs, g_ens_acc_cs)
 
             err[i] = log.(get_error(ekiobj)[end])
             errs[trial, :] = err

--- a/examples/Accelerators/DarcyAccelerated/darcy_accelerated.jl
+++ b/examples/Accelerators/DarcyAccelerated/darcy_accelerated.jl
@@ -103,7 +103,6 @@ function main()
     prior = pd
 
     # We define some algorithm parameters, here we take ensemble members larger than the dimension of the parameter space
-    N_ens = dofs + 2    # number of ensemble members
     N_iter = 20         # number of EKI iterations
     N_trials = 10       # number of trials 
     @info "obtaining statistics over $N_trials trials"
@@ -123,6 +122,7 @@ function main()
             truth_sample,
             obs_noise_cov,
             Inversion(),
+            accelerator = DefaultAccelerator(),
             scheduler = deepcopy(scheduler),
             localization_method = deepcopy(localization_method),
         )

--- a/examples/Accelerators/DarcyAccelerated/darcy_singletrial.jl
+++ b/examples/Accelerators/DarcyAccelerated/darcy_singletrial.jl
@@ -89,6 +89,7 @@ function main()
         truth_sample,
         obs_noise_cov,
         Inversion(),
+        accelerator = DefaultAccelerator(),
         scheduler = DefaultScheduler(0.1),
     )#,scheduler = DataMisfitController(on_terminate = "continue"))
     eki_acc = EKP.EnsembleKalmanProcess(

--- a/examples/Accelerators/DarcyAccelerated/darcy_singletrial.jl
+++ b/examples/Accelerators/DarcyAccelerated/darcy_singletrial.jl
@@ -111,8 +111,8 @@ function main()
         g_ens = run_G_ensemble(darcy, params_i)
         g_ens_acc = run_G_ensemble(darcy, params_i_acc)
 
-        EKP.update_ensemble!(eki_trad, g_ens, deterministic_forward_map = true)
-        EKP.update_ensemble!(eki_acc, g_ens_acc, deterministic_forward_map = true)
+        EKP.update_ensemble!(eki_trad, g_ens, deterministic_forward_map = false)
+        EKP.update_ensemble!(eki_acc, g_ens_acc)
 
         err[i] = get_error(eki_trad)[end]    # mean((params_true - mean(params_i,dims=2)).^2)
         err_acc[i] = get_error(eki_acc)[end]    # mean((params_true - mean(params_i,dims=2)).^2)

--- a/examples/Accelerators/ExpSinAccelerated/exp_sinusoid_accelerated.jl
+++ b/examples/Accelerators/ExpSinAccelerated/exp_sinusoid_accelerated.jl
@@ -104,6 +104,7 @@ function main()
             Γ,
             Inversion();
             rng = rng,
+            accelerator = DefaultAccelerator(),
             scheduler = deepcopy(scheduler),
             localization_method = deepcopy(localization_method),
         )

--- a/examples/Accelerators/ExpSinAccelerated/exp_sinusoid_accelerated.jl
+++ b/examples/Accelerators/ExpSinAccelerated/exp_sinusoid_accelerated.jl
@@ -45,7 +45,7 @@ end
 function main()
 
     cases = ["const", "dmc", "dmc-loc-small-ens"]
-    case = cases[3]
+    case = cases[1]
 
     @info "running case $case"
     if case == "const"
@@ -147,8 +147,8 @@ function main()
             G_ens_acc_cs = hcat([G(params_i_acc_cs[:, i]) for i in 1:N_ens]...)
 
             EKP.update_ensemble!(ensemble_kalman_process, G_ens, deterministic_forward_map = false)
-            EKP.update_ensemble!(ensemble_kalman_process_acc, G_ens_acc, deterministic_forward_map = false)
-            EKP.update_ensemble!(ensemble_kalman_process_acc_cs, G_ens_acc_cs, deterministic_forward_map = false)
+            EKP.update_ensemble!(ensemble_kalman_process_acc, G_ens_acc)
+            EKP.update_ensemble!(ensemble_kalman_process_acc_cs, G_ens_acc_cs)
 
             convs[i] = cost(mean(params_i, dims = 2))
             convs_acc[i] = cost(mean(params_i_acc, dims = 2))

--- a/examples/Accelerators/LorenzAccelerated/lorenz_accelerated.jl
+++ b/examples/Accelerators/LorenzAccelerated/lorenz_accelerated.jl
@@ -58,7 +58,7 @@ function main()
     D = 20
 
     cases = ["const", "dmc", "dmc-loc-small-ens"]
-    case = cases[3]
+    case = cases[1]
 
     @info "running case $case"
     if case == "const"
@@ -116,7 +116,7 @@ function main()
             Γ,
             Inversion();
             rng = rng,
-            acceleator = DefaultAccelerator(),
+            accelerator = DefaultAccelerator(),
             scheduler = deepcopy(scheduler),
             localization_method = deepcopy(localization_method),
         )
@@ -146,11 +146,11 @@ function main()
         err_acc_cs = zeros(N_iter)
         for i in 1:N_iter
             g_ens_vanilla = G(get_ϕ_final(prior, ekiobj_vanilla))
-            EKP.update_ensemble!(ekiobj_vanilla, g_ens_vanilla, deterministic_forward_map = true)
+            EKP.update_ensemble!(ekiobj_vanilla, g_ens_vanilla, deterministic_forward_map = false)
             g_ens_acc = G(get_ϕ_final(prior, ekiobj_acc))
-            EKP.update_ensemble!(ekiobj_acc, g_ens_acc, deterministic_forward_map = true)
+            EKP.update_ensemble!(ekiobj_acc, g_ens_acc)
             g_ens_acc_cs = G(get_ϕ_final(prior, ekiobj_acc_cs))
-            EKP.update_ensemble!(ekiobj_acc_cs, g_ens_acc_cs, deterministic_forward_map = true)
+            EKP.update_ensemble!(ekiobj_acc_cs, g_ens_acc_cs)
         end
         errs[trial, :] = get_error(ekiobj_vanilla)
         errs_acc[trial, :] = get_error(ekiobj_acc)

--- a/examples/Accelerators/LorenzAccelerated/lorenz_accelerated.jl
+++ b/examples/Accelerators/LorenzAccelerated/lorenz_accelerated.jl
@@ -116,6 +116,7 @@ function main()
             Γ,
             Inversion();
             rng = rng,
+            acceleator = DefaultAccelerator(),
             scheduler = deepcopy(scheduler),
             localization_method = deepcopy(localization_method),
         )

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -105,6 +105,9 @@ function update_ensemble!(
 ) where {FT, IT}
 
     if !(isa(get_accelerator(ekp), DefaultAccelerator))
+        if deterministic_forward_map
+            @warn "Acceleration unstable with `update_ensemble` keyword argument `deterministic_forward_map = true`,\n updating with `deterministic_forward_map = false`..."
+        end
         add_stochastic_perturbation = false # doesn't play well with accelerator, but not needed
     else
         add_stochastic_perturbation = deterministic_forward_map


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #396

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- bug-fix `N_ens` overwrite in Darcy example
- add `accelerator=DefaultAccelerator()` in all "vanilla" configurations in the accelerator examples
- remove `deterministic_forward_map` flags for accelerator as it is overwritten as `false`
- change `deterministic_forward_map=false` in non-accelerated methods for fair comparison
- added warning about the internal change for acceleration if unexpected for user

## Example output 
- ExpSin   (vanilla EKI no-longer accelerated in plot)
![const_exp_sin](https://github.com/user-attachments/assets/ee29539b-db28-4cfe-bee3-435dbb45df26)


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
