### PR TITLE
Use `eltype` instead of `promote_type`

### DIFF
--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -122,7 +122,7 @@ function Observation(obs_dict::Dict)
     if !isa(samples, AbstractVector) # 1 -> [[1]]
         snew = [[samples]]
     else
-        T = promote_type((typeof(s) for s in samples)...)
+        T = eltype(samples)
         samples_tmp = [convert(T, s) for s in samples] # to re-infer eltype  (if the user makes an eltype of "Any")
         if !isa(samples_tmp, AbstractVector{<:AbstractVector}) # [1,2] -> [[1,2]] 
             snew = [samples]


### PR DESCRIPTION
Otherwise we can get a StackOverflow error with large `samples`, eg

```julia
ERROR: LoadError: StackOverflowError:
Stacktrace:
 [1] promote_type(::Type, ::Type, ::Type, ::Type, ::Vararg{Type}) (repeats 600 times)
   @ Base ./promotion.jl:299
 [2] Observation(obs_dict::Dict{String, Any})
   @ EnsembleKalmanProcesses ~/.julia/packages/EnsembleKalmanProcesses/hifDM/src/Observations.jl:125
 [3] include(fname::String)
   @ Base.MainInclude ./client.jl:489
```

(And this may only be an issue on mac!)