### PR TITLE
Extend observations handle (T)SVD covariance objects efficiently

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+TSVD = "9449cd9e-2762-5aa3-a617-5413e99d722e"
 
 [compat]
 Convex = "0.15, 0.16"
@@ -41,6 +42,7 @@ StableRNGs = "1"
 Statistics = "1"
 StatsBase = "0.33, 0.34"
 TOML = "1"
+TSVD = "0.4.4"
 julia = "1.5"
 
 [extras]

--- a/docs/src/API/Observations.md
+++ b/docs/src/API/Observations.md
@@ -16,6 +16,12 @@ get_obs(o::OB) where {OB <: Observation}
 get_obs_noise_cov(o::OB) where {OB <: Observation}
 get_obs_noise_cov_inv(o::OB) where {OB <: Observation}
 ```
+## Covariance utilities
+```@docs
+tsvd_mat
+tsvd_cov_from_samples
+```
+
 ## Minibatcher
 ```@docs
 FixedMinibatcher


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #452


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Add function `tsvd_mat(X, r,...)` to create SVD objects representing rank `r` approximation of `X` (and optionally its pseudoinverse)
- Add `tsvd_cov_from_samples` function to aid in computing the SVD of `cov(X,dims=2)` from a sample matrix `X`. (rank and return of pseudoinverse can be specified too)
- Add infrastructure for getting covariances via `build=false`, to ensure ETKI can work without disrupting scalability.
- Add unit test to ensure scaling remains modest. And extend test to run 2 iterations up to dim 1_000_000
- code infrastructure for algorithms that get covariances with `build = true` options (e.g. basic EKI) 
- new internal functions `lmul_obs_noise_cov_inv` and `lmul_obs_noise_cov_inv!` to wrap up the increasingly messy linear algebra.

## Example
Case 1: From a matrix `X` of (columnar) samples, build a low rank representation of `cov(X)`
```
Cr = tsvd_cov_from_samples(X)
Cr, Cr_inv = tsvd_cov_from_samples(X, return_inverse=true)
```
Case 2: Given a matrix `Z` and desired rank `r`, generate the low rank representation of `Z`
```
Cr = tsvd_mat(Z, r, return_inverse=true)
Cr, Cr_inv = tsvd_mat(Z, r)
```
Then pass this in as
```
obs = Observation(
    Dict(
        "samples" => y_obs, 
        "covariances" => Cr, 
        "inv_covariances" => Cr_inv,  # optional
        "name" => "y_with_low_rank_noise"
    ),
)

ekpobj = EnsembleKalmanProcess( ..., obs, ...)
```


# From unit tests 
Repeating for `n=10^1,10^2,...10^6`
- Using Diagonal inverse matrix `0.01I(n)`, 
- SVD of Covaraince of  `0.01*randn((n,5))` 
- SVD directly of  `0.01*randn((n,5))`

```
[ Info: 100 iterations of ETKI with 10 observations took 0.00037059 seconds. (avg update: 3.7059e-6)
[ Info: 100 iterations of ETKI with 10 observations took 0.000405835 seconds. (avg update: 4.05835e-6)
[ Info: 100 iterations of ETKI with 10 observations took 0.000317651 seconds. (avg update: 3.1765100000000003e-6)
[ Info: 100 iterations of ETKI with 100 observations took 0.000448395 seconds. (avg update: 4.48395e-6)
[ Info: 100 iterations of ETKI with 100 observations took 0.00045122 seconds. (avg update: 4.5122e-6)
[ Info: 100 iterations of ETKI with 100 observations took 0.000390878 seconds. (avg update: 3.90878e-6)
[ Info: 100 iterations of ETKI with 1000 observations took 0.001878866 seconds. (avg update: 1.8788660000000002e-5)
[ Info: 100 iterations of ETKI with 1000 observations took 0.001865861 seconds. (avg update: 1.865861e-5)
[ Info: 100 iterations of ETKI with 1000 observations took 0.013513966 seconds. (avg update: 0.00013513966000000001)

[ Info: 2 iterations of ETKI with 10000 observations took 0.028718768 seconds. (avg update: 0.014359384)
[ Info: 2 iterations of ETKI with 10000 observations took 0.024819403 seconds. (avg update: 0.0124097015)
[ Info: 2 iterations of ETKI with 10000 observations took 0.022486632 seconds. (avg update: 0.011243316)
[ Info: 2 iterations of ETKI with 100000 observations took 0.5008502 seconds. (avg update: 0.2504251)
[ Info: 2 iterations of ETKI with 100000 observations took 0.373066618 seconds. (avg update: 0.186533309)
[ Info: 2 iterations of ETKI with 100000 observations took 0.398727106 seconds. (avg update: 0.199363553)
[ Info: 2 iterations of ETKI with 1000000 observations took 2.525645219 seconds. (avg update: 1.2628226095)
[ Info: 2 iterations of ETKI with 1000000 observations took 2.07768027 seconds. (avg update: 1.038840135)
[ Info: 2 iterations of ETKI with 1000000 observations took 1.82451017 seconds. (avg update: 0.912255085)
```
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
