### PR TITLE
Bugfix for bounded above distributions

### DIFF
--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -177,9 +177,9 @@ function bounded_above(upper_bound::FT) where {FT <: Real}
     if isinf(upper_bound)
         return no_constraint()
     end
-    c_to_u = (x -> -log(upper_bound - x))
+    c_to_u = (x -> log(upper_bound - x))
     jacobian = (x -> 1.0 / (upper_bound - x))
-    u_to_c = (x -> upper_bound - exp(-x))
+    u_to_c = (x -> upper_bound - exp(x))
     bounds = Dict("upper_bound" => upper_bound)
     return Constraint{BoundedAbove}(c_to_u, jacobian, u_to_c, bounds)
 end

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -227,8 +227,8 @@ using EnsembleKalmanProcesses.ParameterDistributions
         @test get_bounds(c1) == Dict("lower_bound" => 0.2)
 
         c2 = bounded_above(0.2)
-        @test isapprox(c2.constrained_to_unconstrained(-1.0) - (-log(0.2 - -1.0)), 0.0, atol = tol)
-        @test isapprox(c2.unconstrained_to_constrained(10.0) - (0.2 - exp(-10.0)), 0.0, atol = tol)
+        @test isapprox(c2.constrained_to_unconstrained(-1.0) - (log(0.2 - -1.0)), 0.0, atol = tol)
+        @test isapprox(c2.unconstrained_to_constrained(10.0) - (0.2 - exp(10.0)), 0.0, atol = tol)
         @test get_constraint_type(c2) == BoundedAbove
         @test get_bounds(c2) == Dict("upper_bound" => 0.2)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #454


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- found an additional "-" in the definition (which was not even consistent with docstring). so it should do `up bound - exp(x)` not `up bound - exp(-x)` and vice versa.
- modified an incorrect unit test that hid the bug

## Example
```
using Statistics, EnsembleKalmanProcesses
using EnsembleKalmanProcesses.ParameterDistributions
prior = constrained_gaussian("neg",-5,1,-Inf,0)
prior2 = constrained_gaussian("pos",5,1,0,Inf)
```
Then 
```
julia> mean(transform_unconstrained_to_constrained(prior, sample(prior,10000)))
-5.006444836517459

julia> std(transform_unconstrained_to_constrained(prior, sample(prior,10000)))
1.0009663702218747

julia> mean(transform_unconstrained_to_constrained(prior2, sample(prior2,10000)))
4.999637758663166

julia> std(transform_unconstrained_to_constrained(prior2, sample(prior2,10000)))
1.000288875280173
```

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
