### PR TITLE
Improve DMC scheduler scaling with large observation dimension

### DIFF
--- a/src/LearningRateSchedulers.jl
+++ b/src/LearningRateSchedulers.jl
@@ -118,8 +118,7 @@ The user may also change the `T` with `terminate_at` keyword.
 
 $(TYPEDFIELDS)
 """
-struct DataMisfitController{FT, S} <:
-    LearningRateScheduler where {FT <: AbstractFloat, S <: AbstractString}
+struct DataMisfitController{FT, S} <: LearningRateScheduler where {FT <: AbstractFloat, S <: AbstractString}
     "the current iteration"
     iteration::Vector{Int}
     "the algorithm time for termination, default: 1.0"
@@ -283,7 +282,7 @@ function calculate_timestep!(
     else
         scheduler.iteration[end] += 1
     end
-    
+
     n = scheduler.iteration[end]
     sum_Δt = (n == 1) ? 0.0 : sum(get_Δt(ekp))
     sum_Δt_min1 = (n <= 2) ? 0.0 : sum(get_Δt(ekp)[1:(end - 1)])
@@ -319,7 +318,7 @@ function calculate_timestep!(
         X[idx, :] = γ_inv * diff[idx, :]
         shift[1] = maximum(idx)
     end
-    Φ = [0.5 * dot(diff[:,j],X[:,j]) for j in 1:J]
+    Φ = [0.5 * dot(diff[:, j], X[:, j]) for j in 1:J]
 
     Φ_mean = mean(Φ)
     Φ_var = var(Φ)

--- a/src/LearningRateSchedulers.jl
+++ b/src/LearningRateSchedulers.jl
@@ -122,7 +122,7 @@ struct DataMisfitController{FT, S} <:
     LearningRateScheduler where {FT <: AbstractFloat, S <: AbstractString}
     "the current iteration"
     iteration::Vector{Int}
-    "the inverse square-root of the noise covariance is stored (in reduced form)"
+    "the algorithm time for termination, default: 1.0"
     terminate_at::FT
     "the action on termination, default: \"stop\", "
     on_terminate::S

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -1093,15 +1093,15 @@ end
             plot_inv_problem_ensemble(prior, ekiobj, joinpath(@__DIR__, "ETKI_test_$(i_prob).png"))
         end
     end
-    N_iter=5
+    N_iter = 5
     for (i, n_obs_test) in enumerate([10, 100, 1000, 10_000, 100_000, 1_000_000])
         # first i effectively ignored - just for precompile!
         initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
         initial_ensemble_inf = EKP.construct_initial_ensemble(copy(rng), initial_dist, N_ens)
-        
+
         y_obs_test, G_test, Γ_test, A_test =
             linear_inv_problem(ϕ_star, noise_level, n_obs_test, rng; return_matrix = true)
-        
+
         ekiobj = EKP.EnsembleKalmanProcess(
             initial_ensemble,
             y_obs_test,

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -300,8 +300,6 @@ end
     dmclrs1 = EKP.DataMisfitController()
     @test typeof(dmclrs1.iteration) == Vector{Int}
     @test length(dmclrs1.iteration) == 0
-    @test typeof(dmclrs1.inv_sqrt_noise) == Vector{Matrix{Float64}}
-    @test length(dmclrs1.inv_sqrt_noise) == 0
     @test dmclrs1.terminate_at == Float64(1)
     @test dmclrs1.on_terminate == "stop"
     dmclrs2 = EKP.DataMisfitController(terminate_at = 7, on_terminate = "continue")
@@ -1109,7 +1107,7 @@ end
             TransformInversion();
             rng = rng,
             failure_handler_method = SampleSuccGauss(),
-            scheduler = DataMisfitController(), # (least scalable scheduler in output-space)
+            scheduler = DataMisfitController(terminate_at = 1000), # (least scalable scheduler in output-space)
         )
         ekiobj_inf = EKP.EnsembleKalmanProcess(
             initial_ensemble_inf,
@@ -1118,7 +1116,7 @@ end
             TransformInversion(prior);
             rng = copy(rng),
             failure_handler_method = SampleSuccGauss(),
-            scheduler = DataMisfitController(),
+            scheduler = DataMisfitController(terminate_at = 1000),
         )
         for ekp in [ekiobj, ekiobj_inf]
             T = 0.0

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -1091,7 +1091,7 @@ end
             plot_inv_problem_ensemble(prior, ekiobj, joinpath(@__DIR__, "ETKI_test_$(i_prob).png"))
         end
     end
-    n_iter = 5
+    n_iter = 4
     for (i, n_obs_test) in enumerate([10, 100, 1000, 10_000, 100_000])
         # first i effectively ignored - just for precompile!
         initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
@@ -1107,7 +1107,7 @@ end
             TransformInversion();
             rng = rng,
             failure_handler_method = SampleSuccGauss(),
-            scheduler = DataMisfitController(terminate_at = 1000), # (least scalable scheduler in output-space)
+            scheduler = DataMisfitController(terminate_at = 1e8), # (least scalable scheduler in output-space)
         )
         ekiobj_inf = EKP.EnsembleKalmanProcess(
             initial_ensemble_inf,
@@ -1116,7 +1116,7 @@ end
             TransformInversion(prior);
             rng = copy(rng),
             failure_handler_method = SampleSuccGauss(),
-            scheduler = DataMisfitController(terminate_at = 1000),
+            scheduler = DataMisfitController(terminate_at = 1e8),
         )
         for ekp in [ekiobj, ekiobj_inf]
             T = 0.0
@@ -1130,7 +1130,7 @@ end
             # Skip timing of first due to precompilation
             if i >= 2
                 @info "$n_iter iterations of ETKI with $n_obs_test observations took $T seconds. (avg update: $(T/Float64(n_iter)))"
-                if T / (n_obs_test * Float64(n_iter)) > 4e-6 # tol back-computed from 1_000_000 computation
+                if T / (n_obs_test * Float64(n_iter)) > 5e-6 || n_obs_test < 5_000 # tol back-computed from 1_000_000 computation
                     @error "The ETKI update for $(n_obs_test) observations should take under $(n_obs_test*4e-6) per update, received $(T/Float64(n_iter)). Significant slowdowns encountered in ETKI"
                 end
 

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -85,7 +85,6 @@ inv_problems = [inv_problems..., nl_inv_problems...]
     @test isapprox(norm(y_obs .- A * ϕ_star)^2 - n_obs * noise_level^2, 0; atol = 0.06)
 end
 
-
 @testset "Accelerators" begin
     # Get an inverse problem
     y_obs, G, Γy, _ = inv_problems[end - 2] # additive noise inv problem (deterministic map)
@@ -901,6 +900,7 @@ end
     end
 end
 
+
 @testset "EnsembleTransformKalmanInversion" begin
 
     # Seed for pseudo-random number generator
@@ -1093,15 +1093,15 @@ end
             plot_inv_problem_ensemble(prior, ekiobj, joinpath(@__DIR__, "ETKI_test_$(i_prob).png"))
         end
     end
-
-    for (i, n_obs_test) in enumerate([10, 10, 100, 1000, 10000])
-
+    N_iter=5
+    for (i, n_obs_test) in enumerate([10, 100, 1000, 10_000, 100_000, 1_000_000])
+        # first i effectively ignored - just for precompile!
         initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
         initial_ensemble_inf = EKP.construct_initial_ensemble(copy(rng), initial_dist, N_ens)
-
+        
         y_obs_test, G_test, Γ_test, A_test =
             linear_inv_problem(ϕ_star, noise_level, n_obs_test, rng; return_matrix = true)
-
+        
         ekiobj = EKP.EnsembleKalmanProcess(
             initial_ensemble,
             y_obs_test,
@@ -1109,7 +1109,7 @@ end
             TransformInversion();
             rng = rng,
             failure_handler_method = SampleSuccGauss(),
-            scheduler = DefaultScheduler(1),
+            scheduler = DataMisfitController(), # (least scalable scheduler in output-space)
         )
         ekiobj_inf = EKP.EnsembleKalmanProcess(
             initial_ensemble_inf,
@@ -1118,7 +1118,7 @@ end
             TransformInversion(prior);
             rng = copy(rng),
             failure_handler_method = SampleSuccGauss(),
-            scheduler = DefaultScheduler(1),
+            scheduler = DataMisfitController(),
         )
         for ekp in [ekiobj, ekiobj_inf]
             T = 0.0

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -1091,7 +1091,7 @@ end
             plot_inv_problem_ensemble(prior, ekiobj, joinpath(@__DIR__, "ETKI_test_$(i_prob).png"))
         end
     end
-    N_iter = 5
+    n_iter = 5
     for (i, n_obs_test) in enumerate([10, 100, 1000, 10_000, 100_000, 1_000_000])
         # first i effectively ignored - just for precompile!
         initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
@@ -1120,7 +1120,7 @@ end
         )
         for ekp in [ekiobj, ekiobj_inf]
             T = 0.0
-            for i in 1:N_iter
+            for i in 1:n_iter
                 params_i = get_ϕ_final(prior, ekp)
                 g_ens = G_test(params_i)
                 dt = @elapsed EKP.update_ensemble!(ekp, g_ens)
@@ -1129,9 +1129,9 @@ end
 
             # Skip timing of first due to precompilation
             if i >= 2
-                @info "$N_iter iterations of ETKI with $n_obs_test observations took $T seconds. (avg update: $(T/Float64(N_iter)))"
-                if T / Float64(N_iter) > 0.2
-                    @error "The ETKI update for 10,000 observations should take ~0.02s per update, received $(T/Float64(N_iter)). Significant slowdowns encountered in ETKI"
+                @info "$n_iter iterations of ETKI with $n_obs_test observations took $T seconds. (avg update: $(T/Float64(n_iter)))"
+                if T / Float64(n_iter) > 0.2
+                    @error "The ETKI update for 10,000 observations should take ~0.02s per update, received $(T/Float64(n_iter)). Significant slowdowns encountered in ETKI"
                 end
 
             end

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -1092,7 +1092,7 @@ end
         end
     end
     n_iter = 5
-    for (i, n_obs_test) in enumerate([10, 100, 1000, 10_000, 100_000, 1_000_000])
+    for (i, n_obs_test) in enumerate([10, 100, 1000, 10_000, 100_000])
         # first i effectively ignored - just for precompile!
         initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
         initial_ensemble_inf = EKP.construct_initial_ensemble(copy(rng), initial_dist, N_ens)
@@ -1130,8 +1130,8 @@ end
             # Skip timing of first due to precompilation
             if i >= 2
                 @info "$n_iter iterations of ETKI with $n_obs_test observations took $T seconds. (avg update: $(T/Float64(n_iter)))"
-                if T / Float64(n_iter) > 0.2
-                    @error "The ETKI update for 10,000 observations should take ~0.02s per update, received $(T/Float64(n_iter)). Significant slowdowns encountered in ETKI"
+                if T / (n_obs_test * Float64(n_iter)) > 4e-6 # tol back-computed from 1_000_000 computation
+                    @error "The ETKI update for $(n_obs_test) observations should take under $(n_obs_test*4e-6) per update, received $(T/Float64(n_iter)). Significant slowdowns encountered in ETKI"
                 end
 
             end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #461 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Compute the potential in DMC using `get_obs_noise_cov_inv(ekp, build=false)` rather than `get_obs_noise_cov(ekp)` and so avoiding building the full inverse
- remove the stored `sqrt_inv_\Gamma` previously required (as recently we now store the inverses in reduced form in EKP)
- Add `DataMisfitController()` as the scheduler for the ETKI scaling unit-test

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
