### PR TITLE
New Quantification of member failure, and more flexible NaN handling

### DIFF
--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -39,6 +39,7 @@ construct_initial_ensemble
 update_ensemble!
 sample_empirical_gaussian
 split_indices_by_success
+impute_over_nans
 list_update_groups_over_minibatch
 ```
 

--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -35,6 +35,8 @@ get_Δt
 get_failure_handler
 get_localizer
 get_localizer_type
+get_nan_tolerance
+get_nan_row_values
 construct_initial_ensemble
 update_ensemble!
 sample_empirical_gaussian

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -42,7 +42,7 @@ abstract type Accelerator end
 "Failure handling method that ignores forward model failures"
 struct IgnoreFailures <: FailureHandlingMethod end
 
-""""
+"""
     SampleSuccGauss <: FailureHandlingMethod
 
 Failure handling method that substitutes failed ensemble members by new samples from
@@ -964,8 +964,7 @@ Given nan_tolerance = $(nan_tolerance) to determine failed members:
 - Ensemble members failed:      $(sum((sum(nan_loc, dims=1) .> tol))) 
 - NaNs in successful members:   $(sum(nan_loc[:,not_fail])) 
 - row index set for imputation: $(rows_for_imputation) 
-- row index entirely NaN:      $(rows_all_nan)
-    """
+- row index entirely NaN:      $(rows_all_nan)    """
         else
             if length(rows_all_nan) > 0
                 @warn "Detected rows entirely NaN: $(rows_all_nan)"

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -175,7 +175,7 @@ struct EnsembleKalmanProcess{
     LRS <: LearningRateScheduler,
     ACC <: Accelerator,
     VV <: AbstractVector,
-    NorVV <: Union{Nothing, AbstractVector}
+    NorVV <: Union{Nothing, AbstractVector},
 }
     "array of stores for parameters (`u`), each of size [`N_par × N_ens`]"
     u::Array{DataContainer{FT}}
@@ -955,9 +955,9 @@ function impute_over_nans(
     rows_for_imputation = [nan_in_row[i] * i for i in 1:size(out, 1) if nan_in_row[i] > 0]
 
     if length(rows_for_imputation) > 0
-            all_nan = sum(nan_loc, dims = 2) .== size(out, 2)
-            rows_all_nan = [all_nan[i] * i for i in 1:size(out, 1) if all_nan[i] > 0]
-        if verbose            
+        all_nan = sum(nan_loc, dims = 2) .== size(out, 2)
+        rows_all_nan = [all_nan[i] * i for i in 1:size(out, 1) if all_nan[i] > 0]
+        if verbose
             @warn """
 In forward map ensemble g, detected $(sum(nan_loc)) NaNs. 
 Given nan_tolerance = $(nan_tolerance) to determine failed members: 
@@ -967,14 +967,14 @@ Given nan_tolerance = $(nan_tolerance) to determine failed members:
 - row index entirely NaN:      $(rows_all_nan)
     """
         else
-            if length(rows_all_nan)>0
+            if length(rows_all_nan) > 0
                 @warn "Detected rows entirely NaN: $(rows_all_nan)"
             end
         end
         @info "Imputed $(sum(nan_loc[:,not_fail])) NaNs"
 
     end
-    
+
 
     # loop over rows with NaNs that are in successful particles
     for row in rows_for_imputation

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -935,22 +935,27 @@ function impute_over_nans(
     nan_in_row = sum(nan_loc[:, not_fail], dims = 2) .> 0
     rows_for_imputation = [nan_in_row[i] * i for i in 1:size(out, 1) if nan_in_row[i] > 0]
 
-    if verbose
-        if length(rows_for_imputation) > 0
+    if length(rows_for_imputation) > 0
             all_nan = sum(nan_loc, dims = 2) .== size(out, 2)
             rows_all_nan = [all_nan[i] * i for i in 1:size(out, 1) if all_nan[i] > 0]
-
+        if verbose            
             @warn """
 In forward map ensemble g, detected $(sum(nan_loc)) NaNs. 
 Given nan_tolerance = $(nan_tolerance) to determine failed members: 
-- Ensemble members failed:       $(sum((sum(nan_loc, dims=1) .> tol))) 
-- NaNs in successful members:    $(sum(nan_loc[:,not_fail])) 
-- rows index set for imputation: $(rows_for_imputation) 
-- rows index entirely NaN:       $(rows_all_nan)
-"""
+- Ensemble members failed:      $(sum((sum(nan_loc, dims=1) .> tol))) 
+- NaNs in successful members:   $(sum(nan_loc[:,not_fail])) 
+- row index set for imputation: $(rows_for_imputation) 
+- row index entirely NaN:      $(rows_all_nan)
+    """
+        else
+            if length(rows_all_nan)>0
+                @warn "Detected rows entirely NaN: $(rows_all_nan)"
+            end
         end
+        @info "Imputed $(sum(nan_loc[:,not_fail])) NaNs"
 
     end
+    
 
     # loop over rows with NaNs that are in successful particles
     for row in rows_for_imputation

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -917,9 +917,9 @@ end
 $(TYPEDSIGNATURES)
 
 Imputation of "reasonable values" over NaNs in the following manner
-1. Detect failures: check if any column contains NaNs exceeding the fraction `get_nan_tolerance(ekp)`, such members are flagged as failures
+1. Detect failures: check if any column contains NaNs exceeding the fraction `nan_tolerance`, such members are flagged as failures
 2. Impute values in rows with few NaNs: Of the admissible columns, any NaNs are replaced by finite values of the ensemble-mean (without NaNs) over the row. 
-3. Impute a value for row with all NaNs: Of the admissible columns, the value of the observation itself "get_obs(ekp)" is imputed
+3. Impute a value for row with all NaNs: Of the admissible columns, the value of the observation itself "y" is imputed
 """
 function impute_over_nans(g::AM, nan_tolerance::FT, y::AV; verbose=false) where {AM <: AbstractMatrix, AV <: AbstractVector, FT}
     out = copy(g) # or will modify g

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -20,7 +20,7 @@ export get_observation_series, get_obs, get_obs_noise_cov, get_obs_noise_cov_inv
 export compute_error!
 export update_ensemble!
 export list_update_groups_over_minibatch
-export sample_empirical_gaussian, split_indices_by_success
+export sample_empirical_gaussian, split_indices_by_success, impute_over_nans
 export SampleSuccGauss, IgnoreFailures, FailureHandler
 
 
@@ -143,6 +143,7 @@ $(TYPEDFIELDS)
         Δt = FT(1),
         rng::AbstractRNG = Random.GLOBAL_RNG,
         failure_handler_method::FM = IgnoreFailures(),
+        nan_tolerance = 0.1,
         localization_method::LM = NoLocalization(),
         verbose::Bool = false,
     ) where {FT <: AbstractFloat, P <: Process, FM <: FailureHandlingMethod, LM <: LocalizationMethod, OS <: ObservationSeries}
@@ -156,6 +157,7 @@ Inputs:
  - `Δt`                     :: Initial time step or learning rate
  - `rng`                    :: Random number generator
  - `failure_handler_method` :: Method used to handle particle failures
+ - `nan_tolerance`          :: Fraction of allowable NaNs before considered failure (0.1 by default)
  - `localization_method`    :: Method used to localize sample covariances
  - `verbose`                :: Whether to print diagnostic information
 
@@ -197,6 +199,8 @@ struct EnsembleKalmanProcess{
     failure_handler::FailureHandler
     "Localization kernel, implemented for (`Inversion`, `SparseInversion`, `Unscented`)"
     localizer::Localizer
+    "Fraction of allowable `NaN`s in model output before an ensemble member is considered a failed member and handled by failure handler"
+    nan_tolerance::FT
     "Whether to print diagnostics for each EK iteration"
     verbose::Bool
 end
@@ -209,6 +213,7 @@ function EnsembleKalmanProcess(
     configuration::Dict;
     update_groups::Union{Nothing, VV} = nothing,
     rng::AbstractRNG = Random.GLOBAL_RNG,
+    nan_tolerance = 0.1,
     verbose::Bool = false,
 ) where {FT <: AbstractFloat, P <: Process, OS <: ObservationSeries, VV <: AbstractVector}
 
@@ -290,6 +295,7 @@ function EnsembleKalmanProcess(
         rng,
         failure_handler,
         localizer,
+        nan_tolerance,
         verbose,
     )
 end
@@ -305,6 +311,7 @@ function EnsembleKalmanProcess(
     Δt = nothing,
     update_groups::Union{Nothing, VV} = nothing,
     rng::AbstractRNG = Random.GLOBAL_RNG,
+    nan_tolerance = 0.1,
     verbose::Bool = false,
 ) where {
     FT <: AbstractFloat,
@@ -344,6 +351,7 @@ function EnsembleKalmanProcess(
         configuration,
         update_groups = update_groups,
         rng = rng,
+        nan_tolerance = nan_tolerance,
         verbose = verbose,
     )
 end
@@ -573,11 +581,19 @@ function get_Δt(ekp::EnsembleKalmanProcess)
 end
 
 """
-    get_failuer_handler(ekp::EnsembleKalmanProcess)
+    get_failure_handler(ekp::EnsembleKalmanProcess)
 Return `failure_handler` field of EnsembleKalmanProcess.
 """
 function get_failure_handler(ekp::EnsembleKalmanProcess)
     return ekp.failure_handler
+end
+
+"""
+    get_nan_tolerance(ekp::EnsembleKalmanProcess)
+Return `nan_tolerance` field of EnsembleKalmanProcess.
+"""
+function get_nan_tolerance(ekp::EnsembleKalmanProcess)
+    return ekp.nan_tolerance
 end
 
 """
@@ -880,19 +896,61 @@ function additive_inflation!(
     ekp.u[end] = DataContainer(u_updated, data_are_columns = true)
 end
 
+"""
+$(TYPEDSIGNATURES)
 
-
+Throws a warning if any columns of g are exactly repeated.
+The warning indicates that different ensemble members provided identical output (typically due to a bug in the forward map).
+"""
+function warn_on_repeated_columns(g::AM) where {AM <: AbstractMatrix}
+    # check if columns of g are the same (and not NaN)
+    n_nans = sum(isnan.(sum(g, dims = 1)))
+    nan_adjust = (n_nans > 0) ? -n_nans + 1 : 0
+    # as unique reduces NaNs to one column if present. or 0 if not
+    if length(unique(eachcol(g))) < size(g, 2) + nan_adjust
+        nonunique_cols = size(g, 2) + nan_adjust - length(unique(eachcol(g)))
+        @warn "Detected $(nonunique_cols) clashes where forward map evaluations are exactly equal (and not NaN), this is likely to cause `LinearAlgebra` difficulty. Please check forward evaluations for bugs."
+    end
+end
 
 """
-    update_ensemble!(
-        ekp::EnsembleKalmanProcess,
-        g::AbstractMatrix{FT};
-        multiplicative_inflation::Bool = false,
-        additive_inflation::Bool = false,
-        additive_inflation_cov::MorUS = get_u_cov_prior(ekp),
-        s::FT = 0.0,
-        ekp_kwargs...,
-    ) where {FT, IT}
+$(TYPEDSIGNATURES)
+
+Imputation of "reasonable values" over NaNs in the following manner
+1. Detect failures: check if any column contains NaNs exceeding the fraction `get_nan_tolerance(ekp)`, such members are flagged as failures
+2. Impute values in rows with few NaNs: Of the admissible columns, any NaNs are replaced by finite values of the ensemble-mean (without NaNs) over the row. 
+3. Impute a value for row with all NaNs: Of the admissible columns, the value of the observation itself "get_obs(ekp)" is imputed
+"""
+function impute_over_nans(g::AM, nan_tolerance::FT, y::AV) where {AM <: AbstractMatrix, AV <: AbstractVector, FT}
+    out = copy(g) # or will modify g
+    tol = Int(floor(nan_tolerance * size(out,1)))
+    nan_loc = isnan.(out)
+    not_fail = (.! (sum(nan_loc, dims=1) .> tol))[:] # "not" fail vector
+    # find if NaNs are in succesful particles still
+    nan_in_row = sum(nan_loc[:,not_fail], dims=2) .> 0
+    rows_for_imputation = [nan_in_row[i] * i for i in 1:size(out,1) if nan_in_row[i]>0]
+    # loop over rows with NaNs that are in successful particles
+    for row in rows_for_imputation
+        not_nan = .! nan_loc[row, :] # use all non-NaN cols to compute value (if there are some)
+        if sum(not_nan) == 0
+            val = y[row]
+        else
+            val = mean(out[row, not_nan])
+        end
+        suc_and_nan = nan_loc[row, :] .* not_fail  
+        out[row, suc_and_nan] .= val # change values only if not-fail and NaN
+    end
+    
+    return out
+end
+    
+function impute_over_nans(ekp::EnsembleKalmanProcess, g::AM) where {AM <: AbstractMatrix}
+    return impute_over_nans(g, get_nan_tolerance(ekp), get_obs(ekp))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Updates the ensemble according to an Inversion process.
 Inputs:
  - ekp :: The EnsembleKalmanProcess to update.
@@ -906,31 +964,26 @@ Inputs:
 """
 function update_ensemble!(
     ekp::EnsembleKalmanProcess,
-    g::AbstractMatrix{FT};
+    g_in::AM;
     multiplicative_inflation::Bool = false,
     additive_inflation::Bool = false,
     additive_inflation_cov::MorUS = get_u_cov_prior(ekp),
     s::FT = 0.0,
     Δt_new::NFT = nothing,
     ekp_kwargs...,
-) where {FT, NFT <: Union{Nothing, AbstractFloat}, MorUS <: Union{AbstractMatrix, UniformScaling}}
+) where {FT, AM <: AbstractMatrix, NFT <: Union{Nothing, AbstractFloat}, MorUS <: Union{AbstractMatrix, UniformScaling}}
     #catch works when g non-square 
-    if !(size(g)[2] == get_N_ens(ekp))
+    if !(size(g_in)[2] == get_N_ens(ekp))
         throw(
             DimensionMismatch(
-                "ensemble size $(get_N_ens(ekp)) in EnsembleKalmanProcess does not match the columns of g ($(size(g)[2])); try transposing g or check the ensemble size",
+                "ensemble size $(get_N_ens(ekp)) in EnsembleKalmanProcess does not match the columns of g ($(size(g_in)[2])); try transposing g or check the ensemble size",
             ),
         )
     end
-    # check if columns of g are the same (and not NaN)
-    n_nans = sum(isnan.(sum(g, dims = 1)))
-    nan_adjust = (n_nans > 0) ? -n_nans + 1 : 0
-    # as unique reduces NaNs to one column if present. or 0 if not
-    if length(unique(eachcol(g))) < size(g, 2) + nan_adjust
-        nonunique_cols = size(g, 2) + nan_adjust - length(unique(eachcol(g)))
-        @warn "Detected $(nonunique_cols) clashes where forward map evaluations are exactly equal (and not NaN), this is likely to cause `LinearAlgebra` difficulty. Please check forward evaluations for bugs."
-    end
-
+    warn_on_repeated_columns(g_in)
+    
+    g = impute_over_nans(ekp, g_in)
+    
     terminate = calculate_timestep!(ekp, g, Δt_new)
     if isnothing(terminate)
 

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -930,7 +930,7 @@ function impute_over_nans(
     out = copy(g) # or will modify g
     tol = Int(floor(nan_tolerance * size(out, 1)))
     nan_loc = isnan.(out)
-    not_fail = (@. !(sum(nan_loc, dims = 1) .> tol))[:] # "not" fail vector
+    not_fail = (.!(sum(nan_loc, dims = 1) .> tol))[:] # "not" fail vector
     # find if NaNs are in succesful particles still
     nan_in_row = sum(nan_loc[:, not_fail], dims = 2) .> 0
     rows_for_imputation = [nan_in_row[i] * i for i in 1:size(out, 1) if nan_in_row[i] > 0]
@@ -954,7 +954,7 @@ Given nan_tolerance = $(nan_tolerance) to determine failed members:
 
     # loop over rows with NaNs that are in successful particles
     for row in rows_for_imputation
-        not_nan = @. !nan_loc[row, :] # use all non-NaN cols to compute value (if there are some)
+        not_nan = .!nan_loc[row, :] # use all non-NaN cols to compute value (if there are some)
         if sum(not_nan) == 0
             val = y[row]
         else

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -287,8 +287,8 @@ function EnsembleKalmanProcess(
     if verbose
         @info "Initializing ensemble Kalman process of type $(nameof(typeof(process)))\nNumber of ensemble members: $(N_ens)\nLocalization: $(nameof(typeof(loc_method)))\nFailure handler: $(nameof(typeof(fh_method)))\nScheduler: $(nameof(typeof(scheduler)))\nAccelerator: $(nameof(typeof(accelerator)))"
     end
-
-    EnsembleKalmanProcess{FT, IT, P, RS, AC, VVV}(
+    NorVV=typeof(nan_row_values)
+    EnsembleKalmanProcess{FT, IT, P, RS, AC, VVV, NorVV}(
         [init_params],
         observation_series,
         N_ens,

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -939,7 +939,7 @@ function impute_over_nans(g::AM, nan_tolerance::FT, y::AV; verbose=false) where 
 In forward map ensemble g, detected $(sum(nan_loc)) NaNs. 
 Given nan_tolerance = $(nan_tolerance) to determine failed members: 
 - Ensemble members failed:       $(sum((sum(nan_loc, dims=1) .> tol))) 
-- NaNs in successful members:    $(sum(nan_in_row)) 
+- NaNs in successful members:    $(sum(nan_loc[:,not_fail])) 
 - rows index set for imputation: $(rows_for_imputation) 
 - rows index entirely NaN:       $(rows_all_nan)
 """

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -287,7 +287,7 @@ function EnsembleKalmanProcess(
     if verbose
         @info "Initializing ensemble Kalman process of type $(nameof(typeof(process)))\nNumber of ensemble members: $(N_ens)\nLocalization: $(nameof(typeof(loc_method)))\nFailure handler: $(nameof(typeof(fh_method)))\nScheduler: $(nameof(typeof(scheduler)))\nAccelerator: $(nameof(typeof(accelerator)))"
     end
-    NorVV=typeof(nan_row_values)
+    NorVV = typeof(nan_row_values)
     EnsembleKalmanProcess{FT, IT, P, RS, AC, VVV, NorVV}(
         [init_params],
         observation_series,

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -99,7 +99,7 @@ end
     # mat has 2 NaN rows (3&4)
     # mat has column 3 being a failed particle (4/7>nan_tolerance rows failed)
     # mat[1,1] and mat[5,2] are replaceable
-    mat_new = impute_over_nans(mat, nan_tolerance, bad_row_vals)
+    mat_new = impute_over_nans(mat, nan_tolerance, bad_row_vals, verbose=true)
     # check ignored values
     @test sum((mat-mat_new)[.! isnan.(mat-mat_new)]) == 0
     # check there are no "new" NaNs

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -638,8 +638,18 @@ end
             g_ens = G(params_i)
             # Add random failures
             if i in iters_with_failure
+                # fail particle 1
                 g_ens[:, 1] .= NaN
+
+                # add some redeemable failures
+                n_nans = 5
+                make_nan = shuffle!(rng, collect(1:N_ensemble))
+                g_ens[1,make_nan[1:n_nans]] .= NaN
+                make_nan = shuffle!(rng, collect(1:N_ensemble))
+                g_ens[end,make_nan[1:n_nans]] .= NaN
+
             end
+            
             EKP.update_ensemble!(ekiobj, g_ens)
             push!(g_ens_vec, g_ens)
 

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -592,6 +592,8 @@ end
             failure_handler_method = IgnoreFailures(),
             scheduler = deepcopy(scheduler),
             localization_method = deepcopy(localization_method),
+            nan_tolerance = 0.2,
+            nan_row_values = 1.0*collect(1:length(y_obs))
         )
         ekiobj_nonoise_update = EKP.EnsembleKalmanProcess(
             initial_ensemble,
@@ -648,6 +650,12 @@ end
                 make_nan = shuffle!(rng, collect(1:N_ens))
                 g_ens[end, make_nan[1:n_nans]] .= NaN
 
+                # quick getter test
+                @test get_nan_tolerance(ekiobj) == 0.1 # default
+                @test isnothing(get_nan_row_values(ekiobj)) # default
+                @test get_nan_tolerance(ekiobj_unsafe) == 0.2
+                @test get_nan_row_values(ekiobj_unsafe) == 1.0*collect(1:length(y_obs))
+                
             end
 
             EKP.update_ensemble!(ekiobj, g_ens)

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -593,7 +593,7 @@ end
             scheduler = deepcopy(scheduler),
             localization_method = deepcopy(localization_method),
             nan_tolerance = 0.2,
-            nan_row_values = 1.0*collect(1:length(y_obs))
+            nan_row_values = 1.0 * collect(1:length(y_obs)),
         )
         ekiobj_nonoise_update = EKP.EnsembleKalmanProcess(
             initial_ensemble,
@@ -654,8 +654,8 @@ end
                 @test get_nan_tolerance(ekiobj) == 0.1 # default
                 @test isnothing(get_nan_row_values(ekiobj)) # default
                 @test get_nan_tolerance(ekiobj_unsafe) == 0.2
-                @test get_nan_row_values(ekiobj_unsafe) == 1.0*collect(1:length(y_obs))
-                
+                @test get_nan_row_values(ekiobj_unsafe) == 1.0 * collect(1:length(y_obs))
+
             end
 
             EKP.update_ensemble!(ekiobj, g_ens)

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -89,27 +89,27 @@ end
 @testset "NaN imputation" begin
 
     # handling failures.
-    mat = randn(7,4)
-    bad_row_vals = 1.0.*collect(1:size(mat,1)) # value to replace if whole row is NaN
+    mat = randn(7, 4)
+    bad_row_vals = 1.0 .* collect(1:size(mat, 1)) # value to replace if whole row is NaN
     nan_tolerance = 0.5 # threshold fraction of mat to determine bad column
-    mat[3:4,:] .= NaN 
-    mat[2,3] = NaN 
-    mat[1,[1,3]] .= NaN
-    mat[5,2] = NaN
+    mat[3:4, :] .= NaN
+    mat[2, 3] = NaN
+    mat[1, [1, 3]] .= NaN
+    mat[5, 2] = NaN
     # mat has 2 NaN rows (3&4)
     # mat has column 3 being a failed particle (4/7>nan_tolerance rows failed)
     # mat[1,1] and mat[5,2] are replaceable
-    mat_new = impute_over_nans(mat, nan_tolerance, bad_row_vals, verbose=true)
+    mat_new = impute_over_nans(mat, nan_tolerance, bad_row_vals, verbose = true)
     # check ignored values
-    @test sum((mat-mat_new)[.! isnan.(mat-mat_new)]) == 0
+    @test sum((mat - mat_new)[.!isnan.(mat - mat_new)]) == 0
     # check there are no "new" NaNs
-    @test sum((.! isnan.(mat)) .* isnan.(mat_new)) == 0
+    @test sum((.!isnan.(mat)) .* isnan.(mat_new)) == 0
     # check changed NaN values
-    @test mat_new[1,1] == mean([mat[1,2], mat[1,4]])
-    @test mat_new[5,2] == mean([mat[5,1], mat[5,3], mat[5,4]]) # includes mat[5,3]
-    @test all(mat_new[3,[1,2,4]] .== bad_row_vals[3])
-    @test all(mat_new[4,[1,2,4]] .== bad_row_vals[4])
-                             
+    @test mat_new[1, 1] == mean([mat[1, 2], mat[1, 4]])
+    @test mat_new[5, 2] == mean([mat[5, 1], mat[5, 3], mat[5, 4]]) # includes mat[5,3]
+    @test all(mat_new[3, [1, 2, 4]] .== bad_row_vals[3])
+    @test all(mat_new[4, [1, 2, 4]] .== bad_row_vals[4])
+
 end
 
 
@@ -644,12 +644,12 @@ end
                 # add some redeemable failures
                 n_nans = 5
                 make_nan = shuffle!(rng, collect(1:N_ens))
-                g_ens[1,make_nan[1:n_nans]] .= NaN
+                g_ens[1, make_nan[1:n_nans]] .= NaN
                 make_nan = shuffle!(rng, collect(1:N_ens))
-                g_ens[end,make_nan[1:n_nans]] .= NaN
+                g_ens[end, make_nan[1:n_nans]] .= NaN
 
             end
-            
+
             EKP.update_ensemble!(ekiobj, g_ens)
             # fix if added redeemable failues
             imputed_g_ens = impute_over_nans(g_ens, 0.1, y_obs)

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -651,7 +651,9 @@ end
             end
             
             EKP.update_ensemble!(ekiobj, g_ens)
-            push!(g_ens_vec, g_ens)
+            # fix if added redeemable failues
+            imputed_g_ens = impute_over_nans(g_ens, 0.1, y_obs)
+            push!(g_ens_vec, imputed_g_ens)
 
             # repeat with inf-time variant
             params_i_inf = get_ϕ_final(prior, ekiobj_inf)

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -643,9 +643,9 @@ end
 
                 # add some redeemable failures
                 n_nans = 5
-                make_nan = shuffle!(rng, collect(1:N_ensemble))
+                make_nan = shuffle!(rng, collect(1:N_ens))
                 g_ens[1,make_nan[1:n_nans]] .= NaN
-                make_nan = shuffle!(rng, collect(1:N_ensemble))
+                make_nan = shuffle!(rng, collect(1:N_ens))
                 g_ens[end,make_nan[1:n_nans]] .= NaN
 
             end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #460 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- introduced nan preprocessing in line with issue #460
- added unit tests
- when ekp.verbose = true, produce details of NaNs found. false provides less information RE failed NaN rows, and # imputed values
- Allow users to define their fixed vector of values `nan_row_values` as a sensible replacement if they prefer alternate behaviour

## Example imputation from unit testing
Take a matrix `g`
```
g 
7×4 Matrix{Float64}:
 NaN           0.992373   NaN           -0.200025
  -1.37133     0.0527899  NaN           -1.15243
 NaN         NaN          NaN          NaN
 NaN         NaN          NaN          NaN
  -2.28799   NaN            0.614214     1.54217
   0.582582    0.0744582   -1.37219      0.253971
   0.620447    0.441834     0.0641471    0.490588


```
with `nan_tolerance = 0.5`, `nan_row_vals = collect(1:7)`, and then the imputation looks like
```
g_new = impute_over_nans(g, nan_tolerance, nan_row_vals, verbose=true)
┌ Warning: In forward map ensemble g, detected 12 NaNs. 
│ Given nan_tolerance = 0.5 to determine failed members: 
│ - Ensemble members failed:       1 
│ - NaNs in successful members:    8 
│ - rows index set for imputation: [1, 3, 4, 5] 
│ - rows index entirely NaN:       [3, 4]
[ Info: Imputed 8 NaNs
7×4 Matrix{Float64}:
  0.396174   0.992373   NaN          -0.200025     # `g[1, 1]`          -> `mean(g[1, [2, 4] ])`
 -1.37133    0.0527899  NaN          -1.15243
  3.0        3.0        NaN           3.0          #  `g[3, [1, 2, 4]]` -> `3.0`
  4.0        4.0        NaN           4.0          #  `g[4, [1, 2, 4]]` -> `4.0`
 -2.28799   -0.0438687    0.614214    1.54217      #  `g[5, 2]`         -> `mean(g[5, [1, 3, 4])`
  0.582582   0.0744582   -1.37219     0.253971
  0.620447   0.441834     0.0641471   0.490588

```

Within EKP:
-  `nan_tolerance` is a keyword given to `EnsembleKalmanProcess`
-  `nan_row_values` is a keyword given to `EnsembleKalmanProcess` for a user defined value (overriding `get_obs(ekp)` default
-  `verbose` is taken to be `ekp.verbose`



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
