### PR TITLE
ETKI (infinite-version) bugfixes and clarity of logic

### DIFF
--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -757,9 +757,9 @@ function lmul_obs_noise_cov!(
     out::AM,
     ekp::EnsembleKalmanProcess,
     X::AVorM,
-    idx_triple::AV,
+    idx_set::AV,
 ) where {AVorM <: AbstractVecOrMat, AV <: AbstractVector, AM <: AbstractMatrix}
-    return lmul_obs_noise_cov!(out, get_observation_series(ekp), X, idx_triple)
+    return lmul_obs_noise_cov!(out, get_observation_series(ekp), X, idx_set)
 end
 
 """
@@ -775,9 +775,9 @@ function lmul_obs_noise_cov_inv!(
     out::AM,
     ekp::EnsembleKalmanProcess,
     X::AVorM,
-    idx_triple::AV,
+    idx_set::AV,
 ) where {AVorM <: AbstractVecOrMat, AV <: AbstractVector, AM <: AbstractMatrix}
-    return lmul_obs_noise_cov_inv!(out, get_observation_series(ekp), X, idx_triple)
+    return lmul_obs_noise_cov_inv!(out, get_observation_series(ekp), X, idx_set)
 end
 
 """

--- a/src/EnsembleTransformKalmanInversion.jl
+++ b/src/EnsembleTransformKalmanInversion.jl
@@ -270,12 +270,14 @@ function update_ensemble!(
 
     onci_idx = []
     shift = 0
+    int_shift = 0
     for (block_id, (γs, pf)) in enumerate(zip(γ_sizes, prior_flag))
         loc_idx = !(pf) ? intersect(1:γs, g_idx .- shift) : intersect(1:γs, u_idx)
         if !(length(loc_idx) == 0)
-            push!(onci_idx, (block_id, loc_idx, loc_idx .+ shift))
+            push!(onci_idx, (block_id, loc_idx, loc_idx .+ int_shift))
         end
         shift += γs
+        int_shift += length(loc_idx)
     end
     #   obs_noise_cov_inv = [obs_noise_cov_inv[pair[1]][pair[2],pair[2]] for pair in local_intersect] # SLOW
     N_obs = length(g_idx)

--- a/src/EnsembleTransformKalmanInversion.jl
+++ b/src/EnsembleTransformKalmanInversion.jl
@@ -230,7 +230,6 @@ function update_ensemble!(
     # g: lenght(g_idx) × N_ens
     u = get_u_final(ekp)[u_idx, :]
     g = g[g_idx, :]
-    obs_mean = get_obs(ekp)[g_idx]
     # get relevant inverse covariance blocks
     obs_noise_cov_inv = get_obs_noise_cov_inv(ekp, build = false)# NEVER build=true for this - ruins scaling.
     impose_prior = get_impose_prior(get_process(ekp))
@@ -283,7 +282,7 @@ function update_ensemble!(
 
     fh = get_failure_handler(ekp)
 
-    y = get_obs(ekp)
+    y = get_obs(ekp)[g_idx]
 
     if isnothing(failed_ens)
         _, failed_ens = split_indices_by_success(g)

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -1069,7 +1069,12 @@ function lmul_obs_noise_cov!(
 ) where {AVorM <: AbstractVecOrMat, AV <: AbstractVector}
     A = get_obs_noise_cov(os, build = false)
     idx_triple = generate_block_product_subindices(A, idx_set)
-    return lmul_without_build!(out, A, X, idx_triple)
+    if isa(X, AbstractVector)
+        Xtrim = length(X) > length(idx_set) ? X[idx_set] : X
+    else
+        Xtrim = size(X, 1) > length(idx_set) ? X[idx_set, :] : X
+    end
+    return lmul_without_build!(out, A, Xtrim, idx_triple)
 end
 
 function lmul_obs_noise_cov_inv!(
@@ -1080,7 +1085,13 @@ function lmul_obs_noise_cov_inv!(
 ) where {AVorM <: AbstractVecOrMat, AV <: AbstractVector}
     A = get_obs_noise_cov_inv(os, build = false)
     idx_triple = generate_block_product_subindices(A, idx_set)
-    return lmul_without_build!(out, A, X, idx_triple)
+    # trim X if not already, (idx-triple expects it trimmed)
+    if isa(X, AbstractVector)
+        Xtrim = length(X) > length(idx_set) ? X[idx_set] : X
+    else
+        Xtrim = size(X, 1) > length(idx_set) ? X[idx_set, :] : X
+    end
+    return lmul_without_build!(out, A, Xtrim, idx_triple)
 end
 
 function generate_block_product_subindices(Ablocks, idx_set)

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -1065,9 +1065,10 @@ function lmul_obs_noise_cov!(
     out,
     os::ObservationSeries,
     X::AVorM,
-    idx_triple::AV,
+    idx_set::AV,
 ) where {AVorM <: AbstractVecOrMat, AV <: AbstractVector}
     A = get_obs_noise_cov(os, build = false)
+    idx_triple = generate_block_product_subindices(A, idx_set)
     return lmul_without_build!(out, A, X, idx_triple)
 end
 
@@ -1075,12 +1076,40 @@ function lmul_obs_noise_cov_inv!(
     out,
     os::ObservationSeries,
     X::AVorM,
-    idx_triple::AV,
+    idx_set::AV,
 ) where {AVorM <: AbstractVecOrMat, AV <: AbstractVector}
     A = get_obs_noise_cov_inv(os, build = false)
+    idx_triple = generate_block_product_subindices(A, idx_set)
     return lmul_without_build!(out, A, X, idx_triple)
 end
 
+function generate_block_product_subindices(Ablocks, idx_set)
+    A_sizes = zeros(Int, length(Ablocks))
+    for (i, Ai) in enumerate(Ablocks)
+        if isa(Ai, SVD)
+            if size(Ai.U, 1) == size(Ai.U, 2)
+                A_sizes[i] = size(Ai.Vt, 2)
+            else
+                A_sizes[i] = size(Ai.U, 1)
+            end
+        else
+            A_sizes[i] = size(Ai, 1)
+        end
+    end
+
+    idx_triple = []
+    shift = 0
+    int_shift = 0
+    for (block_id, As) in enumerate(A_sizes) 
+        loc_idx = intersect(1:As, idx_set .- shift)
+        if !(length(loc_idx) == 0)
+            push!(idx_triple, (block_id, loc_idx, collect(1:length(loc_idx)) .+ int_shift))
+        end
+        shift += As
+        int_shift += length(loc_idx)
+    end
+    return idx_triple
+end
 
 
 function Base.:(==)(os_a::OS1, os_b::OS2) where {OS1 <: ObservationSeries, OS2 <: ObservationSeries}

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -1100,7 +1100,7 @@ function generate_block_product_subindices(Ablocks, idx_set)
     idx_triple = []
     shift = 0
     int_shift = 0
-    for (block_id, As) in enumerate(A_sizes) 
+    for (block_id, As) in enumerate(A_sizes)
         loc_idx = intersect(1:As, idx_set .- shift)
         if !(length(loc_idx) == 0)
             push!(idx_triple, (block_id, loc_idx, collect(1:length(loc_idx)) .+ int_shift))

--- a/test/Observations/runtests.jl
+++ b/test/Observations/runtests.jl
@@ -426,6 +426,40 @@ end
     @test norm(test1 - lmul_obs_noise_cov_inv(observation_series, Xvec)) < 1e-12
     @test norm(test2 - lmul_obs_noise_cov_inv(observation_series, X)) < 1e-12
 
+    # test the pre-indexed versions:
+    # cov
+    g_idx = [2, 3, 4, 8, 9, 15, 16]
+    Γ = get_obs_noise_cov(observation_series)
+    test1 = Γ[g_idx, g_idx] * Xvec[g_idx]
+    test2 = Γ[g_idx, g_idx] * X[g_idx, :]
+    out1 = zeros(size(test1))
+    out2 = zeros(size(test2))
+    # The function is writte to be applied to pre-trimmed "X"s 
+    lmul_obs_noise_cov!(out1, observation_series, Xvec[g_idx], g_idx)
+    lmul_obs_noise_cov!(out2, observation_series, X[g_idx, :], g_idx)
+    @test norm(test1 - out1) < 1e-12
+    @test norm(test2 - out2) < 1e-12
+    lmul_obs_noise_cov!(out1, observation_series, Xvec, g_idx)
+    lmul_obs_noise_cov!(out2, observation_series, X, g_idx)
+    @test norm(test1 - out1) < 1e-12
+    @test norm(test2 - out2) < 1e-12
+
+    # cov_inv
+    test1 = Γinv[g_idx, g_idx] * Xvec[g_idx]
+    test2 = Γinv[g_idx, g_idx] * X[g_idx, :]
+    out1 = zeros(size(test1))
+    out2 = zeros(size(test2))
+    out1 = zeros(size(test1))
+    out2 = zeros(size(test2))
+    # In code this is applied to pre-trimmed "X"s or not
+    lmul_obs_noise_cov_inv!(out1, observation_series, Xvec[g_idx], g_idx)
+    lmul_obs_noise_cov_inv!(out2, observation_series, X[g_idx, :], g_idx)
+    @test norm(test1 - out1) < 1e-12
+    @test norm(test2 - out2) < 1e-12
+    lmul_obs_noise_cov_inv!(out1, observation_series, Xvec, g_idx)
+    lmul_obs_noise_cov_inv!(out2, observation_series, X, g_idx)
+    @test norm(test1 - out1) < 1e-12
+    @test norm(test2 - out2) < 1e-12
 
 
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- I noticed that the example `loss_minimization_finite_vs_infinite.jl` had changed behaviour from v2.2.0 to v2.3.0. This bug-fixes the indexing issue and clears-up and hides the logic to prevent future index errors.

**v2.3.0** results not comparable with PR #444 (see yellow dashed line - showing ETKI infinite ensemble not collapsing)
<img src="https://github.com/user-attachments/assets/941db871-3e02-48c3-96b7-2e45f2ef51c5" width=350> <img src="https://github.com/user-attachments/assets/5abd09a4-0416-4cd7-a9b8-5d66f49eec0a" width=350>

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- index-shift error fixed, 
- replaced `onci_idx` logic 
- Bugfix prior not being pulled in lmul function. (manually apply prior after)

## Report: 
**New** results are now matching those of PR #444
<img src="https://github.com/user-attachments/assets/74eb2937-880e-4d9e-8ed9-706530b4a9c4" width=350> <img src="https://github.com/user-attachments/assets/f864f46a-d2f9-4369-85c1-9576ca64f138" width=350>


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
