### PR TITLE
Add Makie extension for plotting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,12 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 TSVD = "9449cd9e-2762-5aa3-a617-5413e99d722e"
 
+[weakdeps]
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+
+[extensions]
+EnsembleKalmanProcessesMakieExt = "Makie"
+
 [compat]
 Convex = "0.15, 0.16"
 Distributions = "0.24.14, 0.25"
@@ -46,9 +52,10 @@ TSVD = "0.4.4"
 julia = "1.5"
 
 [extras]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StableRNGs", "Test", "Plots"]
+test = ["CairoMakie", "StableRNGs", "Test", "Plots"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 CloudMicrophysics = "6a9e3e04-43cd-43ba-94b9-e8782df3c71b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -91,6 +91,7 @@ pages = [
     "Inflation" => "inflation.md",
     "Parallelism and HPC" => "parallel_hpc.md",
     "Internal data representation" => "internal_data_representation.md",
+    "Visualization" => "visualization.md",
     "Troubleshooting" => "troubleshooting.md",
     "API" => api,
     "Contributing" => "contributing.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,7 @@
 using EnsembleKalmanProcesses,
     Documenter,
     Plots,  # so that Literate.jl does not capture precompilation output
+    CairoMakie,
     Literate
 
 prepend!(LOAD_PATH, [joinpath(@__DIR__, "..")])
@@ -56,6 +57,7 @@ api = [
     "SparseInversion" => "API/SparseInversion.md",
     "TOML Interface" => "API/TOMLInterface.md",
     "Localizers" => "API/Localizers.md",
+    "Visualize" => "API/Visualize.md",
 ]
 
 examples = [
@@ -104,7 +106,7 @@ makedocs(
     authors = "CliMA Contributors",
     format = format,
     pages = pages,
-    modules = [EnsembleKalmanProcesses],
+    modules = [EnsembleKalmanProcesses, Base.get_extension(EnsembleKalmanProcesses, :EnsembleKalmanProcessesMakieExt)],
     doctest = true,
     clean = true,
     checkdocs = :none,

--- a/docs/src/API/Visualize.md
+++ b/docs/src/API/Visualize.md
@@ -1,0 +1,25 @@
+# Visualize
+
+!!! note "Add a Makie-backend package to your Project.toml"
+    Import one of the Makie backends (GLMakie, CairoMakie, WGLMakie, RPRMakie,
+    etc.) to enable these functions!
+
+```@meta
+CurrentModule = EnsembleKalmanProcesses
+```
+
+```@docs
+Visualize.plot_parameter_distribution
+Visualize.plot_error_over_iters
+Visualize.plot_error_over_iters!
+Visualize.plot_error_over_time
+Visualize.plot_error_over_time!
+Visualize.plot_ϕ_over_iters
+Visualize.plot_ϕ_over_iters!
+Visualize.plot_ϕ_over_time
+Visualize.plot_ϕ_over_time!
+Visualize.plot_ϕ_mean_over_iters!
+Visualize.plot_ϕ_mean_over_iters
+Visualize.plot_ϕ_mean_over_time!
+Visualize.plot_ϕ_mean_over_time
+```

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -35,7 +35,10 @@ p = plot(prior)
 
 Plotting functionality is provided by Makie.jl through a package extension. See
 the [documentation](@ref Visualize) for a list of all the available plotting
-functions.
+functions. The plotting functions have the same signature that one would expect
+from Makie plotting functions. See the
+[plot methods section](https://docs.makie.org/dev/explanations/plot_method_signatures)
+in Makie documentation for more information.
 
 ```@setup makie_plots
 # Fix random seed, so plots don't change

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -1,0 +1,166 @@
+# Visualization
+
+We provide some simple plotting features to help users diagnose convergence in
+the algorithm. Through
+
+- Visualizing priors
+- Visualizing slices of parameter ensembles over iterations (or algorithm time) over input space
+- Visualizing the loss function or other computed error metrics from [`compute_error!`](@ref)
+
+*The following documentation provides the overview of what is currently implemented for Plots or Makie backends, these will be expanded in due course.*
+
+## Plots.jl
+
+!!! note "Add Plots.jl to your Project.toml"
+    To enable plotting by Plots.jl, use `using Plots`.
+
+Plotting using Plots.jl supports only plotting distributions. See the example
+below.
+
+```@example
+using EnsembleKalmanProcesses.ParameterDistributions
+prior_u1 = constrained_gaussian("positive_with_mean_2", 2, 1, 0, Inf)
+prior_u2 = constrained_gaussian("four_with_spread_5", 0, 5, -Inf, Inf, repeats=4)
+prior = combine_distributions([prior_u1, prior_u2])
+
+using Plots
+p = plot(prior)
+```
+
+## Makie.jl
+
+!!! note "Add a Makie-backend package to your Project.toml"
+    Import one of the Makie backends (GLMakie, CairoMakie, WGLMakie, RPRMakie,
+    etc.) to enable these functions!
+
+Plotting functionality is provided by Makie.jl through a package extension. See
+the [documentation](@ref Visualize) for a list of all the available plotting
+functions.
+
+```@setup makie_plots
+# Fix random seed, so plots don't change
+import Random
+rng_seed = 1234
+rng = Random.MersenneTwister(rng_seed)
+
+using LinearAlgebra
+using EnsembleKalmanProcesses
+using EnsembleKalmanProcesses.ParameterDistributions
+
+G(u) =
+    [1.0 / abs(u[1]), sum(u[2:3]), u[3], u[1]^2 - u[2] - u[3], u[1], 5.0] .+ 0.1 * randn(6)
+true_u = [3, 1, 2]
+y = G(true_u)
+Γ = (0.1)^2 * I
+
+prior_u1 = constrained_gaussian("positive_with_mean_1", 2, 1, 0, Inf)
+prior_u2 = constrained_gaussian("two_with_spread_2", 0, 5, -Inf, Inf, repeats = 2)
+prior = combine_distributions([prior_u1, prior_u2])
+
+N_ensemble = 30
+initial_ensemble = construct_initial_ensemble(prior, N_ensemble)
+ekp = EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(), verbose = true)
+
+N_iterations = 10
+for i = 1:N_iterations
+    params_i = get_ϕ_final(prior, ekp)
+
+    G_matrix = hcat(
+        [G(params_i[:, i]) for i = 1:N_ensemble]..., # Parallelize here!
+    )
+
+    update_ensemble!(ekp, G_matrix)
+end
+```
+
+### Plot priors
+
+The function `plot_parameter_distribution` will plot the marginal histograms for
+all dimensions of the parameter distribution.
+
+```@example makie_plots
+using CairoMakie # load a Makie backend
+import EnsembleKalmanProcesses.Visualize as viz
+
+fig_priors = CairoMakie.Figure(size = (500, 400))
+viz.plot_parameter_distribution(fig_priors[1, 1], prior)
+
+fig_priors
+```
+
+### Plot errors
+
+The functions `plot_error_over_iters` and `plot_error_over_time` and the
+mutating versions can be used to plot the errors over the number of iterations
+or time respectively. All keyword arguments supported by
+[`Makie.lines`](https://docs.makie.org/dev/reference/plots/lines) are supported
+by these functions too.
+
+Any of the stored error metrics, computed by EnsembleKalmanProcess can be
+plotted by the `error_metric="metric-name"` keyword argument, . See
+[`compute_error!`](@ref) for a list of the computed error metrics and their
+names.
+
+```@example makie_plots
+# Assume that ekp is the EnsembleKalmanProcess object
+using CairoMakie # load a Makie backend
+import EnsembleKalmanProcesses.Visualize as viz
+
+fig_errors = CairoMakie.Figure(size = (300 * 2, 300 * 1))
+viz.plot_error_over_iters(fig_errors[1, 1], ekp, color = :tomato)
+# Error plotting functions support plotting different errors through the
+# error_metric keyword argument
+ax1 = CairoMakie.Axis(fig_errors[1, 2], title = "Average RMSE over iterations", yscale = Makie.pseudolog10)
+viz.plot_error_over_time!(
+    ax1,
+    ekp,
+    linestyle = :dashdotdot,
+    error_metric = "avg_rmse",
+)
+fig_errors
+```
+
+### Plot constrained parameters
+
+#### Plot by a slice of the parameter
+
+The functions `plot_ϕ_over_iters` and `plot_ϕ_over_time` and the mutating
+versions can be used to plot a scatter plot of an individual parameter (dimension) over
+the number of iterations or time respectively. All keyword arguments supported
+by [`Makie.Scatter`](https://docs.makie.org/dev/reference/plots/scatter) are
+supported by these functions too.
+
+Furthermore, there are also `plot_ϕ_mean_over_iters` and `plot_ϕ_mean_over_time`
+and the mutating versions can be used to plot the mean parameter (dimension)
+over the number of iterations or time respectively. All keyword arguments
+supported by [`Makie.Scatter`](https://docs.makie.org/dev/reference/plots/lines)
+are supported by these functions too. Furthermore, there is the keyword argument
+`plot_std = true` which can be used to also plot the standard deviation as well.
+To support plotting both mean and standard deviation, there are also the keyword
+arguments `line_kwargs` and `band_kwargs` for adjusting how the mean and
+standard deviation are plotted. Any keyword arguments accepted by
+[`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines) can be
+passed to `line_kwargs` and any keyword arguments accepted by
+[`Makie.Band`](https://docs.makie.org/dev/reference/plots/band) can be passed to
+`band_kwargs`.
+
+```@example makie_plots
+using CairoMakie # load a Makie backend
+import EnsembleKalmanProcesses.Visualize as viz
+
+fig_ϕ = CairoMakie.Figure(size = (300 * 2, 300 * 2))
+EnsembleKalmanProcesses.Visualize.plot_ϕ_over_time(fig_ϕ[1, 1], ekp, prior, 1, axis = (xscale = Makie.pseudolog10,))
+ax1 = CairoMakie.Axis(fig_ϕ[1, 2])
+viz.plot_ϕ_mean_over_iters!(ax1, ekp, prior, 2)
+viz.plot_ϕ_mean_over_iters(
+            fig_ϕ[2, 1],
+            ekp,
+            prior,
+            3,
+            plot_std = true,
+            line_kwargs = (linestyle = :dash,),
+            band_kwargs = (alpha = 0.2,),
+            color = :purple,
+        )
+fig_ϕ
+```

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -167,3 +167,29 @@ viz.plot_ϕ_mean_over_iters(
         )
 fig_ϕ
 ```
+
+#### Plot by distribution name
+
+It is also possible to plot the constrained (possibly-multidimensional)
+parameters by name. Note that a gridposition per parameter-dimension must be
+provided for plotting. See the example below.
+
+```@example makie_plots
+using CairoMakie # load a Makie backend
+import EnsembleKalmanProcesses.Visualize as viz
+
+fig_ϕ = CairoMakie.Figure(size = (300 * 2, 300 * 2))
+viz.plot_ϕ_over_time(
+    [fig_ϕ[1, 1], fig_ϕ[1, 2]],
+    ekp,
+    prior,
+    "two_with_spread_2",
+    linewidth = 1.5)
+viz.plot_ϕ_mean_over_time(
+    [fig_ϕ[2, 1], fig_ϕ[2, 2]],
+    ekp,
+    prior,
+    "two_with_spread_2",
+    linewidth = 3.0)
+fig_ϕ
+```

--- a/ext/EnsembleKalmanProcessesMakieExt.jl
+++ b/ext/EnsembleKalmanProcessesMakieExt.jl
@@ -125,20 +125,20 @@ end
 # Define the function erroranditersortime whose functionality is
 # implemented by specializing
 # Makie.plot!(plot::ConstrainedParamsAndItersOrTime)
-@recipe(ErrorAndItersOrTime, ekp, xvals) do scene
-    Theme()
+@recipe(ErrorAndItersOrTime, ekp) do scene
+    Attributes(linewidth = 4.5)
 end
 
 """
-    Visualize.plot_error_over_iters(figure, ekp; plot_kwargs...)
+    Visualize.plot_error_over_iters(gridposition, ekp; kwargs...)
 
-Plot the errors from `ekp` against the number of iterations on `figure`.
+Plot the errors from `ekp` against the number of iterations on `gridposition`.
 
 Any keyword arguments is passed to the plotting function which takes in any
 keyword arguments supported by
 [`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines).
 """
-Visualize.plot_error_over_iters(fig, ekp; kwargs...) = _plot_error_over_iters(erroranditersortime, fig, ekp; kwargs...)
+Visualize.plot_error_over_iters(args...; kwargs...) = _plot_error_over_iters(erroranditersortime, args...; kwargs...)
 
 """
     Visualize.plot_error_over_iters!(axis, ekp; kwargs...)
@@ -149,18 +149,25 @@ Any keyword arguments is passed to the plotting function which takes in any
 keyword arguments supported by
 [`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines).
 """
-Visualize.plot_error_over_iters!(ax, ekp; kwargs...) = _plot_error_over_iters(erroranditersortime!, ax, ekp; kwargs...)
+Visualize.plot_error_over_iters!(args...; kwargs...) = _plot_error_over_iters(erroranditersortime!, args...; kwargs...)
 
 """
-    _plot_errors_over_iters(plot_fn, fig_or_ax, ekp; kwargs...)
+    _plot_errors_over_iters(plot_fn, args...; kwargs...)
 
 Helper function to plot the errors against the number of iterations.
+
+The arguments one can expect is `fig_or_ax` and `ekp` or the last argument.
 """
-function _plot_error_over_iters(plot_fn, fig_or_ax, ekp; kwargs...)
+function _plot_error_over_iters(plot_fn, args...; kwargs...)
+    ekp = last(args)
     iters = 1:get_N_iterations(ekp)
     error_metric = _find_appropriate_error(ekp, get(kwargs, :error_metric, nothing))
-    plot = plot_fn(fig_or_ax, ekp, iters; error_metric = error_metric, kwargs...)
-    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    plot = plot_fn(args...; xvals = iters, error_metric = error_metric, kwargs...)
+
+    # If an axis is passed in, it must be the first argument. Otherwise, get the
+    # current axis as determined by Makie. Note that current_axis() does not work
+    # if an axis is passed in.
+    ax = typeof(first(args)) <: Makie.AbstractAxis ? first(args) : Makie.current_axis()
     _modify_axis!(
         ax;
         xlabel = "Iterations",
@@ -172,15 +179,15 @@ function _plot_error_over_iters(plot_fn, fig_or_ax, ekp; kwargs...)
 end
 
 """
-    Visualize.plot_error_over_time(figure, ekp; kwargs...)
+    Visualize.plot_error_over_time(gridposition, ekp; kwargs...)
 
-Plot the errors from `ekp` against time on `figure`.
+Plot the errors from `ekp` against time on `gridposition`.
 
 Any keyword arguments is passed to the plotting function which takes in any
 keyword arguments supported by
 [`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines).
 """
-Visualize.plot_error_over_time(fig, ekp; kwargs...) = _plot_error_over_time(erroranditersortime, fig, ekp; kwargs...)
+Visualize.plot_error_over_time(args...; kwargs...) = _plot_error_over_time(erroranditersortime, args...; kwargs...)
 
 """
     Visualize.plot_error_over_time!(axis, ekp; kwargs...)
@@ -191,18 +198,25 @@ Any keyword arguments is passed to the plotting function which takes in any
 keyword arguments supported by
 [`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines).
 """
-Visualize.plot_error_over_time!(ax, ekp; kwargs...) = _plot_error_over_time(erroranditersortime!, ax, ekp; kwargs...)
+Visualize.plot_error_over_time!(args...; kwargs...) = _plot_error_over_time(erroranditersortime!, args...; kwargs...)
 
 """
     _plot_error_over_time(plot_fn, fig_or_ax, ekp; kwargs...)
 
 Helper function to plot errors over time.
+
+The arguments one can expect is `fig_or_ax` and `ekp` or the last argument.
 """
-function _plot_error_over_time(plot_fn, fig_or_ax, ekp; kwargs...)
+function _plot_error_over_time(plot_fn, args...; kwargs...)
+    ekp = last(args)
     times = get_algorithm_time(ekp)
     error_metric = _find_appropriate_error(ekp, get(kwargs, :error_metric, nothing))
-    plot = plot_fn(fig_or_ax, ekp, times; error_metric = error_metric, kwargs...)
-    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    plot = plot_fn(args...; xvals = times, error_metric = error_metric, kwargs...)
+
+    # If an axis is passed in, it must be the first argument. Otherwise, get the
+    # current axis as determined by Makie. Note that current_axis() does not work
+    # if an axis is passed in.
+    ax = typeof(first(args)) <: Makie.AbstractAxis ? first(args) : Makie.current_axis()
     _modify_axis!(ax; xlabel = "Time", title = "Error over time", ylabel = "$error_metric")
     return plot
 end
@@ -223,21 +237,21 @@ end
 # Define plot recipe for iteration or time vs constrained parameters scatter plots
 # Define the function constrainedparamsanditersortime whose functionality is
 # implemented by specializing Makie.plot!(plot::ConstrainedParamsAndItersOrTime)
-@recipe(ConstrainedParamsAndItersOrTime, ekp, prior, dim_idx, xvals) do scene
+@recipe(ConstrainedParamsAndItersOrTime, ekp, prior, dim_idx) do scene
     Theme()
 end
 
 """
-    Visualize.plot_ϕ_over_iters(figure, ekp, prior, dim_idx; plot_kwargs...)
+    Visualize.plot_ϕ_over_iters(gridposition, ekp, prior, dim_idx; kwargs...)
 
-Plot the constrained parameter of index `dim_idx` against time on `figure`.
+Plot the constrained parameter of index `dim_idx` against time on `gridposition`.
 
 Any keyword arguments is passed to the plotting function which takes in any
 keyword arguments supported by
 (`Makie.Scatter`)[https://docs.makie.org/dev/reference/plots/scatter].
 """
-Visualize.plot_ϕ_over_iters(fig, ekp, prior, dim_idx; kwargs...) =
-    _plot_ϕ_over_iters(constrainedparamsanditersortime, fig, ekp, prior, dim_idx; kwargs...)
+Visualize.plot_ϕ_over_iters(args...; kwargs...) =
+    _plot_ϕ_over_iters(constrainedparamsanditersortime, args...; kwargs...)
 
 """
     Visualize.plot_ϕ_over_iters!(axis, ekp, prior, dim_idx; kwargs...)
@@ -248,18 +262,26 @@ Any keyword arguments is passed to the plotting function which takes in any
 keyword arguments supported by
 (`Makie.Scatter`)[https://docs.makie.org/dev/reference/plots/scatter].
 """
-Visualize.plot_ϕ_over_iters!(ax, ekp, prior, dim_idx; kwargs...) =
-    _plot_ϕ_over_iters(constrainedparamsanditersortime!, ax, ekp, prior, dim_idx; kwargs...)
+Visualize.plot_ϕ_over_iters!(args...; kwargs...) =
+    _plot_ϕ_over_iters(constrainedparamsanditersortime!, args...; kwargs...)
 
 """
-    _plot_ϕ_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
+    _plot_ϕ_over_iters(plot_fn, args...; kwargs...)
 
 Helper function to plot constrained parameters against the number of iterations.
+
+The arguments one can expect is `fig_or_ax`, `ekp`, `prior`, and `dim_idx` or
+the last three arguments.
 """
-function _plot_ϕ_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
+function _plot_ϕ_over_iters(plot_fn, args...; kwargs...)
+    ekp, prior, dim_idx = last(args, 3)
     iters = collect(0:get_N_iterations(ekp))
-    plot = plot_fn(fig_or_ax, ekp, prior, dim_idx, iters; kwargs...)
-    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    plot = plot_fn(args...; xvals = iters, kwargs...)
+
+    # If an axis is passed in, it must be the first argument. Otherwise, get the
+    # current axis as determined by Makie. Note that current_axis() does not work
+    # if an axis is passed in.
+    ax = typeof(first(args)) <: Makie.AbstractAxis ? first(args) : Makie.current_axis()
     _modify_axis!(
         ax;
         xlabel = "Iterations",
@@ -271,16 +293,15 @@ function _plot_ϕ_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
 end
 
 """
-    Visualize.plot_ϕ_over_time(figure, ekp, prior, dim_idx; plot_kwargs...)
+    Visualize.plot_ϕ_over_time(gridposition, ekp, prior, dim_idx; kwargs...)
 
-Plot the constrained parameter of index `dim_idx` against time on `figure`.
+Plot the constrained parameter of index `dim_idx` against time on `gridposition`.
 
 Any keyword arguments is passed to the plotting function which takes in any
 keyword arguments supported by
 (`Makie.Scatter`)[https://docs.makie.org/dev/reference/plots/scatter].
 """
-Visualize.plot_ϕ_over_time(fig, ekp, prior, dim_idx; kwargs...) =
-    _plot_ϕ_over_time(constrainedparamsanditersortime, fig, ekp, prior, dim_idx; kwargs...)
+Visualize.plot_ϕ_over_time(args...; kwargs...) = _plot_ϕ_over_time(constrainedparamsanditersortime, args...; kwargs...)
 
 """
     Visualize.plot_ϕ_over_time!(axis, ekp, prior, dim_idx; kwargs...)
@@ -291,19 +312,27 @@ Any keyword arguments is passed to the plotting function which takes in any
 keyword arguments supported by
 (`Makie.Scatter`)[https://docs.makie.org/dev/reference/plots/scatter].
 """
-Visualize.plot_ϕ_over_time!(ax, ekp, prior, dim_idx; kwargs...) =
-    _plot_ϕ_over_time(constrainedparamsanditersortime!, ax, ekp, prior, dim_idx; kwargs...)
+Visualize.plot_ϕ_over_time!(args...; kwargs...) =
+    _plot_ϕ_over_time(constrainedparamsanditersortime!, args...; kwargs...)
 
 """
-    _plot_ϕ_over_time(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
+    _plot_ϕ_over_time(plot_fn, args...; kwargs...)
 
 Helper function to plot constrained parameter over iterations.
+
+The arguments one can expect is `fig_or_ax`, `ekp`, `prior`, and `dim_idx` or
+the last three arguments.
 """
-function _plot_ϕ_over_time(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
+function _plot_ϕ_over_time(plot_fn, args...; kwargs...)
+    ekp, prior, dim_idx = last(args, 3)
     times = get_algorithm_time(ekp)
     pushfirst!(times, zero(eltype(times)))
-    plot = plot_fn(fig_or_ax, ekp, prior, dim_idx, times; kwargs...)
-    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    plot = plot_fn(args...; xvals = times, kwargs...)
+
+    # If an axis is passed in, it must be the first argument. Otherwise, get the
+    # current axis as determined by Makie. Note that current_axis() does not work
+    # if an axis is passed in.
+    ax = typeof(first(args)) <: Makie.AbstractAxis ? first(args) : Makie.current_axis()
     _modify_axis!(
         ax;
         xlabel = "Time",
@@ -334,8 +363,8 @@ end
 # Define the function constrainedmeanparamsanditersortime whose functionality is
 # implemented by specializing
 # Makie.plot!(plot::ConstrainedMeanParamsAndItersOrTime)
-@recipe(ConstrainedMeanParamsAndItersOrTime, ekp, prior, dim_idx, xvals) do scene
-    Theme()
+@recipe(ConstrainedMeanParamsAndItersOrTime, ekp, prior, dim_idx) do scene
+    Attributes(linewidth = 4.5)
 end
 
 """
@@ -354,17 +383,17 @@ keyword arguments supported by
 `plot_std = true`.
 
 Keyword arguments passed to `line_kwargs` and `band_kwargs` are merged with
-`plot_kwargs` when possible. The keyword arguments in `line_kwargs` and
-`band_kwargs` take priority over the keyword arguments in `plot_kwargs`.
+`kwargs` when possible. The keyword arguments in `line_kwargs` and
+`band_kwargs` take priority over the keyword arguments in `kwargs`.
 """
-Visualize.plot_ϕ_mean_over_iters!(ax, ekp, prior, dim_idx; plot_std = false, kwargs...) =
-    _plot_ϕ_mean_over_iters(constrainedmeanparamsanditersortime!, ax, ekp, prior, dim_idx; plot_std, kwargs...)
+Visualize.plot_ϕ_mean_over_iters!(args...; plot_std = false, kwargs...) =
+    _plot_ϕ_mean_over_iters(constrainedmeanparamsanditersortime!, args...; plot_std, kwargs...)
 
 """
-    Visualize.plot_ϕ_mean_over_iters(figure, ekp, prior, dim_idx; plot_std = false, plot_kwargs...)
+    Visualize.plot_ϕ_mean_over_iters(gridposition, ekp, prior, dim_idx; plot_std = false, kwargs...)
 
 Plot the mean constrained parameter of index `dim_idx` of `prior` against the
-number of iterations on `figure`.
+number of iterations on `gridposition`.
 
 If `plot_std = true`, then the standard deviation of the constrained parameters
 of the ensemble is also plotted.
@@ -376,22 +405,30 @@ keyword arguments supported by
 `plot_std = true`.
 
 Keyword arguments passed to `line_kwargs` and `band_kwargs` are merged with
-`plot_kwargs` when possible. The keyword arguments in `line_kwargs` and
-`band_kwargs` take priority over the keyword arguments in `plot_kwargs`.
+`kwargs` when possible. The keyword arguments in `line_kwargs` and
+`band_kwargs` take priority over the keyword arguments in `kwargs`.
 """
-Visualize.plot_ϕ_mean_over_iters(fig, ekp, prior, dim_idx; plot_std = false, kwargs...) =
-    _plot_ϕ_mean_over_iters(constrainedmeanparamsanditersortime, fig, ekp, prior, dim_idx; plot_std, kwargs...)
+Visualize.plot_ϕ_mean_over_iters(args...; plot_std = false, kwargs...) =
+    _plot_ϕ_mean_over_iters(constrainedmeanparamsanditersortime, args...; plot_std, kwargs...)
 
 """
-    _plot_ϕ_mean_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; plot_std = false, kwargs...)
+    _plot_ϕ_mean_over_iters(plot_fn, args...; plot_std = false, kwargs...)
 
 Helper function to plot mean constrained parameter against the number of
 iterations.
+
+The arguments one can expect is `fig_or_ax`, `ekp`, `prior`, and `dim_idx` or
+the last three arguments.
 """
-function _plot_ϕ_mean_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; plot_std, kwargs...)
+function _plot_ϕ_mean_over_iters(plot_fn, args...; plot_std, kwargs...)
+    ekp, prior, dim_idx = last(args, 3)
     iters = collect(0:get_N_iterations(ekp))
-    plot = plot_fn(fig_or_ax, ekp, prior, dim_idx, iters; plot_std, kwargs...)
-    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    plot = plot_fn(args...; plot_std, xvals = iters, kwargs...)
+
+    # If an axis is passed in, it must be the first argument. Otherwise, get the
+    # current axis as determined by Makie. Note that current_axis() does not work
+    # if an axis is passed in.
+    ax = typeof(first(args)) <: Makie.AbstractAxis ? first(args) : Makie.current_axis()
     if plot_std
         axis_attribs = (
             xlabel = "Iterations",
@@ -412,7 +449,7 @@ function _plot_ϕ_mean_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; plot_
 end
 
 """
-    Visualize.plot_ϕ_mean_over_time!(axis, ekp, prior, dim_idx; plot_std = false, plot_kwargs...)
+    Visualize.plot_ϕ_mean_over_time!(axis, ekp, prior, dim_idx; plot_std = false, kwargs...)
 
 Plot the mean constrained parameter of index `dim_idx` of `prior` against time
 on `axis`.
@@ -427,17 +464,17 @@ keyword arguments supported by
 `plot_std = true`.
 
 Keyword arguments passed to `line_kwargs` and `band_kwargs` are merged with
-`plot_kwargs` when possible. The keyword arguments in `line_kwargs` and
-`band_kwargs` take priority over the keyword arguments in `plot_kwargs`.
+`kwargs` when possible. The keyword arguments in `line_kwargs` and
+`band_kwargs` take priority over the keyword arguments in `kwargs`.
 """
-Visualize.plot_ϕ_mean_over_time!(ax, ekp, prior, dim_idx; plot_std = false, kwargs...) =
-    _plot_ϕ_mean_over_time(constrainedmeanparamsanditersortime!, ax, ekp, prior, dim_idx; plot_std, kwargs...)
+Visualize.plot_ϕ_mean_over_time!(args...; plot_std = false, kwargs...) =
+    _plot_ϕ_mean_over_time(constrainedmeanparamsanditersortime!, args...; plot_std, kwargs...)
 
 """
-    Visualize.plot_ϕ_mean_over_time(figure, ekp, prior, dim_idx; plot_std = false, plot_kwargs...)
+    Visualize.plot_ϕ_mean_over_time(gridposition, ekp, prior, dim_idx; plot_std = false, kwargs...)
 
 Plot the mean constrained parameter of index `dim_idx` of `prior` against time
-on `figure`.
+on `gridposition`.
 
 If `plot_std = true`, then the standard deviation of the constrained parameter
 of the ensemble is also plotted.
@@ -449,22 +486,30 @@ keyword arguments supported by
 `plot_std = true`.
 
 Keyword arguments passed to `line_kwargs` and `band_kwargs` are merged with
-`plot_kwargs` when possible. The keyword arguments in `line_kwargs` and
-`band_kwargs` take priority over the keyword arguments in `plot_kwargs`.
+`kwargs` when possible. The keyword arguments in `line_kwargs` and
+`band_kwargs` take priority over the keyword arguments in `kwargs`.
 """
-Visualize.plot_ϕ_mean_over_time(fig, ekp, prior, dim_idx; plot_std = false, kwargs...) =
-    _plot_ϕ_mean_over_time(constrainedmeanparamsanditersortime, fig, ekp, prior, dim_idx; plot_std, kwargs...)
+Visualize.plot_ϕ_mean_over_time(args...; plot_std = false, kwargs...) =
+    _plot_ϕ_mean_over_time(constrainedmeanparamsanditersortime, args...; plot_std, kwargs...)
 
 """
     _plot_ϕ_mean_over_time(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
 
 Helper function to plot mean constrained parameters against time.
+
+The arguments one can expect is `fig_or_ax`, `ekp`, `prior`, and `dim_idx` or
+the last three arguments.
 """
-function _plot_ϕ_mean_over_time(plot_fn, fig_or_ax, ekp, prior, dim_idx; plot_std, kwargs...)
+function _plot_ϕ_mean_over_time(plot_fn, args...; plot_std, kwargs...)
+    ekp, prior, dim_idx = last(args, 3)
     times = accumulate(+, get_Δt(ekp))
     pushfirst!(times, zero(eltype(times)))
-    plot = plot_fn(fig_or_ax, ekp, prior, dim_idx, times; plot_std, kwargs...)
-    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    plot = plot_fn(args...; plot_std, xvals = times, kwargs...)
+
+    # If an axis is passed in, it must be the first argument. Otherwise, get the
+    # current axis as determined by Makie. Note that current_axis() does not work
+    # if an axis is passed in.
+    ax = typeof(first(args)) <: Makie.AbstractAxis ? first(args) : Makie.current_axis()
     if plot_std
         axis_attribs = (
             xlabel = "Time",

--- a/ext/EnsembleKalmanProcessesMakieExt.jl
+++ b/ext/EnsembleKalmanProcessesMakieExt.jl
@@ -551,6 +551,90 @@ function Makie.plot!(plot::ConstrainedMeanParamsAndItersOrTime)
 end
 
 """
+    Visualize.plot_ϕ_over_iters(gridpositions, ekp, prior, name; kwargs...)
+
+Plot the constrained parameter belonging to distribution `name` against the
+number of iterations on the iterable `gridpositions`.
+
+Any keyword arguments are passed to all plots.
+"""
+Visualize.plot_ϕ_over_iters(
+    gridpositions,
+    ekp::EnsembleKalmanProcess,
+    prior::ParameterDistribution,
+    name::AbstractString;
+    kwargs...,
+) = _plot_ϕ(Visualize.plot_ϕ_over_iters, gridpositions, ekp, prior, name; kwargs...)
+
+"""
+    Visualize.plot_ϕ_over_time(gridpositions, ekp, prior, name; kwargs...)
+
+Plot the constrained parameter belonging to distribution `name` against time on
+the iterable `gridpositions`.
+
+Any keyword arguments are passed to all plots.
+"""
+Visualize.plot_ϕ_over_time(
+    gridpositions,
+    ekp::EnsembleKalmanProcess,
+    prior::ParameterDistribution,
+    name::AbstractString;
+    kwargs...,
+) = _plot_ϕ(Visualize.plot_ϕ_over_time, gridpositions, ekp, prior, name; kwargs...)
+
+"""
+    Visualize.plot_ϕ_mean_over_iters(gridpositions, ekp::EnsembleKalmanProcess, prior, name; kwargs...)
+
+Plot the mean constrained parameter belonging to distribution `name` against the
+number of iterations on the iterable `gridpositions`.
+
+Any keyword arguments are passed to all plots.
+"""
+Visualize.plot_ϕ_mean_over_iters(
+    gridpositions,
+    ekp::EnsembleKalmanProcess,
+    prior::ParameterDistribution,
+    name::AbstractString;
+    kwargs...,
+) = _plot_ϕ(Visualize.plot_ϕ_mean_over_iters, gridpositions, ekp, prior, name; kwargs...)
+
+"""
+    Visualize.plot_ϕ_mean_over_time(gridpositions, ekp, prior, name; kwargs...)
+
+Plot the mean constrained parameter belonging to distribution `name` against
+time on the iterable `gridpositions`.
+
+Any keyword arguments are passed to all plots.
+"""
+Visualize.plot_ϕ_mean_over_time(
+    gridpositions,
+    ekp::EnsembleKalmanProcess,
+    prior::ParameterDistribution,
+    name::AbstractString;
+    kwargs...,
+) = _plot_ϕ(Visualize.plot_ϕ_mean_over_time, gridpositions, ekp, prior, name; kwargs...)
+
+"""
+    _plot_ϕ(plot_fn, gridpositions, ekp, prior, name; kwargs...)
+
+Helper function to plot `ϕ`-related quantities by the name of the distribution.
+"""
+function _plot_ϕ(plot_fn, gridpositions, ekp, prior, name::AbstractString; kwargs...)
+    batch_idx = findfirst(x -> x == name, prior.name)
+    isnothing(batch_idx) &&
+        error("Cannot find a distribution with the name $name; the available distributions are $(prior.name)")
+    dim_indices = batch(prior)[batch_idx]
+    length(dim_indices) == length(gridpositions) || error(
+        "The $name distribution has $(length(dim_indices)) dimensions, but $(length(gridpositions)) gridpositions are passed in",
+    )
+    local plot
+    for (gridposition, dim_idx) in zip(gridpositions, dim_indices)
+        plot = plot_fn(gridposition, ekp, prior, dim_idx; kwargs...)
+    end
+    return plot
+end
+
+"""
     _modify_axis!(ax; kwargs...)
 
 Modify an axis in place.

--- a/ext/EnsembleKalmanProcessesMakieExt.jl
+++ b/ext/EnsembleKalmanProcessesMakieExt.jl
@@ -1,0 +1,551 @@
+module EnsembleKalmanProcessesMakieExt
+
+using Makie
+
+import EnsembleKalmanProcesses.Visualize as Visualize
+import EnsembleKalmanProcesses:
+    EnsembleKalmanProcess,
+    get_N_iterations,
+    get_Δt,
+    get_algorithm_time,
+    get_error_metrics,
+    get_ϕ,
+    get_ϕ_mean,
+    get_process,
+    get_prior_mean,
+    get_prior_cov
+using EnsembleKalmanProcesses.ParameterDistributions
+import Statistics: std
+
+using Random
+
+# Plotting recipe does not support plotting multiple plots, so this is a convience wrapper that
+# plot the priors with no support for passing in keyword arguments
+"""
+    Visualize.plot_parameter_distribution(fig::Union{Makie.Figure, Makie.GridLayout, Makie.GridPosition, Makie.GridSubposition},
+                           pd::ParameterDistribution;
+                           constrained = true,
+                           n_sample = 1e4,
+                           rng = Random.GLOBAL_RNG)
+
+Plot the distributions `pd` on `fig`.
+"""
+function Visualize.plot_parameter_distribution(
+    fig::Union{Makie.Figure, Makie.GridLayout, Makie.GridPosition, Makie.GridSubposition},
+    pd::ParameterDistribution;
+    constrained = true,
+    n_sample = 1e4,
+    rng = Random.GLOBAL_RNG,
+)
+    samples = sample(rng, pd, Int(n_sample))
+    if constrained
+        samples = transform_unconstrained_to_constrained(pd, samples)
+    end
+    n_plots = ndims(pd)
+    batches = batch(pd)
+
+    # Determine the number of cols for the figure
+    cols = Int(ceil(sqrt(n_plots)))
+
+    for i in 1:n_plots
+        r = div(i - 1, cols) + 1
+        c = (i - 1) % cols + 1
+        batch_id = [j for j = 1:length(batches) if i ∈ batches[j]][1]
+        dim_in_batch = i - minimum(batches[batch_id]) + 1 # i.e. if i=5 in batch 3:6, this would be "3"
+        ax = Makie.Axis(
+            fig[r, c],
+            title = pd.name[batch_id] * " (dim " * string(dim_in_batch) * ")",
+            xgridvisible = false,
+            ygridvisible = false,
+        )
+        Makie.ylims!(ax, 0.0, nothing)
+        Makie.hist!(
+            ax,
+            samples[i, :],
+            normalization = :pdf,
+            color = Makie.Cycled(batch_id),
+            strokecolor = (:black, 0.7),
+            strokewidth = 0.7,
+            bins = Int(floor(sqrt(n_sample))),
+        )
+    end
+    return nothing
+end
+
+"""
+    Visualize.plot_parameter_distribution(fig::Union{Makie.Figure, Makie.GridLayout},
+                           pd::PDT;
+                           constrained = true,
+                           n_sample = 1e4,
+                           rng = Random.GLOBAL_RNG)
+                           where {PDT <: ParameterDistributionType}
+
+Plot the distribution on `fig`.
+"""
+function Visualize.plot_parameter_distribution(
+    fig::Union{Makie.Figure, Makie.GridLayout, Makie.GridPosition, Makie.GridSubposition},
+    d::PDT;
+    n_sample = 1e4,
+    rng = Random.GLOBAL_RNG,
+) where {PDT <: ParameterDistributionType}
+    samples = sample(rng, pd, Int(n_sample))
+
+    n_plots = ndims(d)
+
+    # Determine the number of cols for the figure
+    cols = Int(ceil(sqrt(n_plots)))
+
+    for i in 1:n_plots
+        r = div(i - 1, cols) + 1
+        c = (i - 1) % cols + 1
+        batch_id = [j for j = 1:length(batches) if i ∈ batches[j]][1]
+        # i.e. if i=5 in batch 3:6, this would be "3"
+        dim_in_batch = i - minimum(batches[batch_id]) + 1
+        ax = Makie.Axis(
+            fig[r, c],
+            title = pd.name[batch_id] * " (dim " * string(dim_in_batch) * ")",
+            xgridvisible = false,
+            ygridvisible = false,
+        )
+        Makie.ylims!(ax, 0.0, nothing)
+        Makie.hist!(
+            ax,
+            samples[i, :],
+            normalization = :pdf,
+            color = Makie.Cycled(batch_id),
+            strokecolor = (:black, 0.7),
+            strokewidth = 0.7,
+            bins = Int(floor(sqrt(n_sample))),
+        )
+    end
+    return nothing
+end
+
+# Define plot recipe for iterations or time vs errors line plots
+# Define the function erroranditersortime whose functionality is
+# implemented by specializing
+# Makie.plot!(plot::ConstrainedParamsAndItersOrTime)
+@recipe(ErrorAndItersOrTime, ekp, xvals) do scene
+    Theme()
+end
+
+"""
+    Visualize.plot_error_over_iters(figure, ekp; plot_kwargs...)
+
+Plot the errors from `ekp` against the number of iterations on `figure`.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+[`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines).
+"""
+Visualize.plot_error_over_iters(fig, ekp; kwargs...) = _plot_error_over_iters(erroranditersortime, fig, ekp; kwargs...)
+
+"""
+    Visualize.plot_error_over_iters!(axis, ekp; kwargs...)
+
+Plot the errors from `ekp` against the number of iterations on `axis`.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+[`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines).
+"""
+Visualize.plot_error_over_iters!(ax, ekp; kwargs...) = _plot_error_over_iters(erroranditersortime!, ax, ekp; kwargs...)
+
+"""
+    _plot_errors_over_iters(plot_fn, fig_or_ax, ekp; kwargs...)
+
+Helper function to plot the errors against the number of iterations.
+"""
+function _plot_error_over_iters(plot_fn, fig_or_ax, ekp; kwargs...)
+    iters = 1:get_N_iterations(ekp) # off by one error here?, need to check with example and calibration being ran
+    plot = plot_fn(fig_or_ax, ekp, iters; kwargs...)
+    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    _modify_axis!(ax; xlabel = "Iterations", title = "Error over iterations", ylabel = "Error")
+    return plot
+end
+
+"""
+    Visualize.plot_error_over_time(figure, ekp; kwargs...)
+
+Plot the errors from `ekp` against time on `figure`.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+[`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines).
+"""
+Visualize.plot_error_over_time(fig, ekp; kwargs...) = _plot_error_over_time(erroranditersortime, fig, ekp; kwargs...)
+
+"""
+    Visualize.plot_error_over_time!(axis, ekp; kwargs...)
+
+Plot the errors from `ekp` against time on `axis`.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+[`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines).
+"""
+Visualize.plot_error_over_time!(ax, ekp; kwargs...) = _plot_error_over_time(erroranditersortime!, ax, ekp; kwargs...)
+
+"""
+    _plot_error_over_time(plot_fn, fig_or_ax, ekp; kwargs...)
+
+Helper function to plot errors over time.
+"""
+function _plot_error_over_time(plot_fn, fig_or_ax, ekp; kwargs...)
+    times = accumulate(+, get_Δt(ekp))
+    plot = plot_fn(fig_or_ax, ekp, times; kwargs...)
+    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    _modify_axis!(ax; xlabel = "Time", title = "Error over time", ylabel = "Error")
+    return plot
+end
+
+"""
+    Makie.plot!(plot::ErrorAndItersOrTime)
+
+Plot the errors against iteration or time.
+"""
+function Makie.plot!(plot::ErrorAndItersOrTime)
+    xvals = plot.xvals[]
+    errors = get_error(plot.ekp[])
+    valid_attributes = Makie.shared_attributes(plot, Makie.Lines)
+    Makie.lines!(plot, xvals, errors; valid_attributes...)
+    return plot
+end
+
+# Define plot recipe for iteration or time vs constrained parameters scatter plots
+# Define the function constrainedparamsanditersortime whose functionality is
+# implemented by specializing Makie.plot!(plot::ConstrainedParamsAndItersOrTime)
+@recipe(ConstrainedParamsAndItersOrTime, ekp, prior, dim_idx, xvals) do scene
+    Theme()
+end
+
+"""
+    Visualize.plot_ϕ_over_iters(figure, ekp, prior, dim_idx; plot_kwargs...)
+
+Plot the constrained parameter of index `dim_idx` against time on `figure`.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+(`Makie.Scatter`)[https://docs.makie.org/dev/reference/plots/scatter].
+"""
+Visualize.plot_ϕ_over_iters(fig, ekp, prior, dim_idx; kwargs...) =
+    _plot_ϕ_over_iters(constrainedparamsanditersortime, fig, ekp, prior, dim_idx; kwargs...)
+
+"""
+    Visualize.plot_ϕ_over_iters!(axis, ekp, prior, dim_idx; kwargs...)
+
+Plot the constrained parameter of index `dim_idx` against time on `axis`.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+(`Makie.Scatter`)[https://docs.makie.org/dev/reference/plots/scatter].
+"""
+Visualize.plot_ϕ_over_iters!(ax, ekp, prior, dim_idx; kwargs...) =
+    _plot_ϕ_over_iters(constrainedparamsanditersortime!, ax, ekp, prior, dim_idx; kwargs...)
+
+"""
+    _plot_ϕ_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
+
+Helper function to plot constrained parameters against the number of iterations.
+"""
+function _plot_ϕ_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
+    iters = collect(0:get_N_iterations(ekp))
+    plot = plot_fn(fig_or_ax, ekp, prior, dim_idx, iters; kwargs...)
+    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    _modify_axis!(
+        ax;
+        xlabel = "Iterations",
+        title = "ϕ over iterations [dim $(_get_dim_of_dist(prior, dim_idx))]",
+        ylabel = "$(_get_prior_name(prior, dim_idx))",
+        xticks = 0:get_N_iterations(ekp),
+    )
+    return plot
+end
+
+"""
+    Visualize.plot_ϕ_over_time(figure, ekp, prior, dim_idx; plot_kwargs...)
+
+Plot the constrained parameter of index `dim_idx` against time on `figure`.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+(`Makie.Scatter`)[https://docs.makie.org/dev/reference/plots/scatter].
+"""
+Visualize.plot_ϕ_over_time(fig, ekp, prior, dim_idx; kwargs...) =
+    _plot_ϕ_over_time(constrainedparamsanditersortime, fig, ekp, prior, dim_idx; kwargs...)
+
+"""
+    Visualize.plot_ϕ_over_time!(axis, ekp, prior, dim_idx; kwargs...)
+
+Plot the constrained parameter of index `dim_idx` against time on `axis`.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+(`Makie.Scatter`)[https://docs.makie.org/dev/reference/plots/scatter].
+"""
+Visualize.plot_ϕ_over_time!(ax, ekp, prior, dim_idx; kwargs...) =
+    _plot_ϕ_over_time(constrainedparamsanditersortime!, ax, ekp, prior, dim_idx; kwargs...)
+
+"""
+    _plot_ϕ_over_time(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
+
+Helper function to plot constrained parameter over iterations.
+"""
+function _plot_ϕ_over_time(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
+    times = get_algorithm_time(ekp)
+    pushfirst!(times, zero(eltype(times)))
+    plot = plot_fn(fig_or_ax, ekp, prior, dim_idx, times; kwargs...)
+    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    _modify_axis!(
+        ax;
+        xlabel = "Time",
+        title = "ϕ over time [dim $(_get_dim_of_dist(prior, dim_idx))]",
+        ylabel = "$(_get_prior_name(prior, dim_idx))",
+    )
+    return plot
+end
+
+"""
+    Makie.plot!(plot::ConstrainedParamsAndItersOrTime)
+
+Plot the constrained parameter versus iterations or time.
+"""
+function Makie.plot!(plot::ConstrainedParamsAndItersOrTime)
+    ekp, prior, dim_idx, xvals = plot.ekp[], plot.prior[], plot.dim_idx[], plot.xvals[]
+    ϕ = get_ϕ(prior, ekp)
+    ensemble_size = size(first(ϕ))[2]
+    nums = vcat((xval * ones(ensemble_size) for xval in xvals)...)
+    param_nums = vcat((ϕ[idx][dim_idx, :] for idx in eachindex(xvals))...)
+    valid_attributes = Makie.shared_attributes(plot, Makie.Scatter)
+    Makie.scatter!(plot, nums, param_nums; valid_attributes...)
+    return plot
+end
+
+# Define plot recipe for iteration or time vs constrained parameters scatter
+# plots
+# Define the function constrainedmeanparamsanditersortime whose functionality is
+# implemented by specializing
+# Makie.plot!(plot::ConstrainedMeanParamsAndItersOrTime)
+@recipe(ConstrainedMeanParamsAndItersOrTime, ekp, prior, dim_idx, xvals) do scene
+    Theme()
+end
+
+"""
+    Visualize.plot_ϕ_mean_over_iters!(axis, ekp, prior, dim_idx; plot_std = false, kwargs...)
+
+Plot the mean constrained parameter of index `dim_idx` of `prior` against the
+number of iterations on `axis`.
+
+If `plot_std = true`, then the standard deviation of the constrained parameters
+of the ensemble is also plotted.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+[`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines) and
+(`Makie.Band`)[https://docs.makie.org/dev/reference/plots/band] if
+`plot_std = true`.
+
+Keyword arguments passed to `line_kwargs` and `band_kwargs` are merged with
+`plot_kwargs` when possible. The keyword arguments in `line_kwargs` and
+`band_kwargs` take priority over the keyword arguments in `plot_kwargs`.
+"""
+Visualize.plot_ϕ_mean_over_iters!(ax, ekp, prior, dim_idx; plot_std = false, kwargs...) =
+    _plot_ϕ_mean_over_iters(constrainedmeanparamsanditersortime!, ax, ekp, prior, dim_idx; plot_std, kwargs...)
+
+"""
+    Visualize.plot_ϕ_mean_over_iters(figure, ekp, prior, dim_idx; plot_std = false, plot_kwargs...)
+
+Plot the mean constrained parameter of index `dim_idx` of `prior` against the
+number of iterations on `figure`.
+
+If `plot_std = true`, then the standard deviation of the constrained parameters
+of the ensemble is also plotted.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+[`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines) and
+(`Makie.Band`)[https://docs.makie.org/dev/reference/plots/band] if
+`plot_std = true`.
+
+Keyword arguments passed to `line_kwargs` and `band_kwargs` are merged with
+`plot_kwargs` when possible. The keyword arguments in `line_kwargs` and
+`band_kwargs` take priority over the keyword arguments in `plot_kwargs`.
+"""
+Visualize.plot_ϕ_mean_over_iters(fig, ekp, prior, dim_idx; plot_std = false, kwargs...) =
+    _plot_ϕ_mean_over_iters(constrainedmeanparamsanditersortime, fig, ekp, prior, dim_idx; plot_std, kwargs...)
+
+"""
+    _plot_ϕ_mean_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; plot_std = false, kwargs...)
+
+Helper function to plot mean constrained parameter against the number of
+iterations.
+"""
+function _plot_ϕ_mean_over_iters(plot_fn, fig_or_ax, ekp, prior, dim_idx; plot_std, kwargs...)
+    iters = collect(0:get_N_iterations(ekp))
+    plot = plot_fn(fig_or_ax, ekp, prior, dim_idx, iters; plot_std, kwargs...)
+    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    if plot_std
+        axis_attribs = (
+            xlabel = "Iterations",
+            title = "Mean and std of ϕ over iterations [dim $(_get_dim_of_dist(prior, dim_idx))]",
+            ylabel = "$(_get_prior_name(prior, dim_idx))",
+            xticks = 0:get_N_iterations(ekp),
+        )
+    else
+        axis_attribs = (
+            xlabel = "Iterations",
+            title = "Mean ϕ over iterations [dim $(_get_dim_of_dist(prior, dim_idx))]",
+            ylabel = "$(_get_prior_name(prior, dim_idx))",
+            xticks = 0:get_N_iterations(ekp),
+        )
+    end
+    _modify_axis!(ax; axis_attribs...)
+    return plot
+end
+
+"""
+    Visualize.plot_ϕ_mean_over_time!(axis, ekp, prior, dim_idx; plot_std = false, plot_kwargs...)
+
+Plot the mean constrained parameter of index `dim_idx` of `prior` against time
+on `axis`.
+
+If `plot_std = true`, then the standard deviation of the constrained parameter
+of the ensemble is also plotted.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+[`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines) and
+(`Makie.Band`)[https://docs.makie.org/dev/reference/plots/band] if
+`plot_std = true`.
+
+Keyword arguments passed to `line_kwargs` and `band_kwargs` are merged with
+`plot_kwargs` when possible. The keyword arguments in `line_kwargs` and
+`band_kwargs` take priority over the keyword arguments in `plot_kwargs`.
+"""
+Visualize.plot_ϕ_mean_over_time!(ax, ekp, prior, dim_idx; plot_std = false, kwargs...) =
+    _plot_ϕ_mean_over_time(constrainedmeanparamsanditersortime!, ax, ekp, prior, dim_idx; plot_std, kwargs...)
+
+"""
+    Visualize.plot_ϕ_mean_over_time(figure, ekp, prior, dim_idx; plot_std = false, plot_kwargs...)
+
+Plot the mean constrained parameter of index `dim_idx` of `prior` against time
+on `figure`.
+
+If `plot_std = true`, then the standard deviation of the constrained parameter
+of the ensemble is also plotted.
+
+Any keyword arguments is passed to the plotting function which takes in any
+keyword arguments supported by
+[`Makie.Lines`](https://docs.makie.org/dev/reference/plots/lines) and
+(`Makie.Band`)[https://docs.makie.org/dev/reference/plots/band] if
+`plot_std = true`.
+
+Keyword arguments passed to `line_kwargs` and `band_kwargs` are merged with
+`plot_kwargs` when possible. The keyword arguments in `line_kwargs` and
+`band_kwargs` take priority over the keyword arguments in `plot_kwargs`.
+"""
+Visualize.plot_ϕ_mean_over_time(fig, ekp, prior, dim_idx; plot_std = false, kwargs...) =
+    _plot_ϕ_mean_over_time(constrainedmeanparamsanditersortime, fig, ekp, prior, dim_idx; plot_std, kwargs...)
+
+"""
+    _plot_ϕ_mean_over_time(plot_fn, fig_or_ax, ekp, prior, dim_idx; kwargs...)
+
+Helper function to plot mean constrained parameters against time.
+"""
+function _plot_ϕ_mean_over_time(plot_fn, fig_or_ax, ekp, prior, dim_idx; plot_std, kwargs...)
+    times = accumulate(+, get_Δt(ekp))
+    pushfirst!(times, zero(eltype(times)))
+    plot = plot_fn(fig_or_ax, ekp, prior, dim_idx, times; plot_std, kwargs...)
+    ax = typeof(fig_or_ax) <: Makie.AbstractAxis ? fig_or_ax : Makie.current_axis()
+    if plot_std
+        axis_attribs = (
+            xlabel = "Time",
+            title = "Mean and std of ϕ over time [dim $(_get_dim_of_dist(prior, dim_idx))]",
+            ylabel = "$(_get_prior_name(prior, dim_idx))",
+        )
+    else
+        axis_attribs = (
+            xlabel = "Time",
+            title = "Mean ϕ over time [dim $(_get_dim_of_dist(prior, dim_idx))]",
+            ylabel = "$(_get_prior_name(prior, dim_idx))",
+        )
+    end
+    _modify_axis!(ax; axis_attribs...)
+    return plot
+end
+
+"""
+    Makie.plot!(plot::ConstrainedMeanParamsAndItersOrTime)
+
+Plot the mean constrained parameter versus iterations or time.
+"""
+function Makie.plot!(plot::ConstrainedMeanParamsAndItersOrTime)
+    ekp, prior, dim_idx, xvals = plot.ekp[], plot.prior[], plot.dim_idx[], plot.xvals[]
+    ϕ_mean_vals = [get_ϕ_mean(prior, ekp, iter)[dim_idx] for iter in 1:length(xvals)]
+
+    valid_attributes = Makie.shared_attributes(plot, Makie.Lines)
+    hasproperty(plot, :line_kwargs) && (valid_attributes = merge(plot.line_kwargs, valid_attributes))
+    Makie.lines!(plot, xvals, ϕ_mean_vals; valid_attributes...)
+
+    if plot.plot_std[]
+        stds = [std(get_ϕ(prior, ekp, iter)[dim_idx, :]) for iter in 1:length(xvals)]
+
+        valid_attributes = Makie.shared_attributes(plot, Makie.Band)
+        hasproperty(plot, :band_kwargs) && (valid_attributes = merge(plot.band_kwargs, valid_attributes))
+        Makie.band!(plot, xvals, ϕ_mean_vals .- stds, ϕ_mean_vals .+ stds; valid_attributes...)
+    end
+    return plot
+end
+
+"""
+    _modify_axis!(ax; kwargs...)
+
+Modify an axis in place.
+
+This currently supports only `:title`, `:xlabel`, `:ylabel`, and `:xticks`.
+
+This function is hacky as Makie does not currently have support for axis hints.
+
+Note that it is not possible to tell if the user want an empty title or not
+since this function assumes that if the default is used, then it is fine to
+overwrite.
+"""
+function _modify_axis!(ax; kwargs...)
+    defaults = Dict(:title => "", :xlabel => "", :ylabel => "", :xticks => Makie.Automatic())
+    for (attrib, val) in kwargs
+        if attrib in keys(defaults) && getproperty(ax, attrib)[] == defaults[attrib]
+            getproperty(ax, attrib)[] = val
+        end
+    end
+    return nothing
+end
+
+"""
+    _get_dim_of_dist(prior, dim_idx)
+
+Get the dimension of the distribution belonging to `dim_idx` in `prior`.
+"""
+function _get_dim_of_dist(prior, dim_idx)
+    for param_arr in batch(prior)
+        if dim_idx in param_arr
+            return findfirst(x -> x == dim_idx, param_arr)
+        end
+    end
+    error("Could not find name corresponding to parameter $dim_idx")
+end
+
+"""
+    _get_prior_name(prior, dim_idx)
+
+Get name of `dim_idx` parameter from `prior`.
+"""
+function _get_prior_name(prior, dim_idx)
+    for (i, param_arr) in enumerate(batch(prior))
+        if dim_idx in param_arr
+            return get_name(prior)[i]
+        end
+    end
+    error("Could not find name corresponding to parameter $dim_idx")
+end
+
+end

--- a/src/EnsembleKalmanProcesses.jl
+++ b/src/EnsembleKalmanProcesses.jl
@@ -14,4 +14,5 @@ include("EnsembleKalmanProcess.jl")
 
 # Plot recipes
 include("PlotRecipes.jl")
+include("Visualize.jl")
 end # module

--- a/src/Visualize.jl
+++ b/src/Visualize.jl
@@ -1,0 +1,29 @@
+module Visualize
+
+function plot_parameter_distribution end
+
+function plot_error_over_iters end
+
+function plot_error_over_iters! end
+
+function plot_error_over_time end
+
+function plot_error_over_time! end
+
+function plot_ϕ_over_iters end
+
+function plot_ϕ_over_iters! end
+
+function plot_ϕ_over_time end
+
+function plot_ϕ_over_time! end
+
+function plot_ϕ_mean_over_iters! end
+
+function plot_ϕ_mean_over_iters end
+
+function plot_ϕ_mean_over_time! end
+
+function plot_ϕ_mean_over_time end
+
+end

--- a/test/Visualize/runtests.jl
+++ b/test/Visualize/runtests.jl
@@ -1,0 +1,166 @@
+if TEST_PLOT_OUTPUT
+    # Fix seed, so the plots do not differ from run to run
+    import Random
+    rng_seed = 1234
+    rng = Random.MersenneTwister(rng_seed)
+
+    using Test
+    using CairoMakie
+
+    using LinearAlgebra
+    using EnsembleKalmanProcesses
+    using EnsembleKalmanProcesses.ParameterDistributions
+
+    @testset "Helper functions" begin
+        prior_u1 = constrained_gaussian("positive_with_mean_1", 2, 1, 0, Inf)
+        prior_u2 = constrained_gaussian("four_with_spread_3", 0, 5, -Inf, Inf, repeats = 3)
+        prior_u3 = constrained_gaussian("positive_with_mean_1", 0, 3, -Inf, Inf)
+        prior = combine_distributions([prior_u1, prior_u2, prior_u3])
+
+        # Since these functions are not exported, we need to access the
+        # functions like this
+        ext = Base.get_extension(EnsembleKalmanProcesses, :EnsembleKalmanProcessesMakieExt)
+        @test ext._get_dim_of_dist(prior, 1) == 1
+        @test ext._get_dim_of_dist(prior, 2) == 1
+        @test ext._get_dim_of_dist(prior, 3) == 2
+        @test ext._get_dim_of_dist(prior, 4) == 3
+        @test ext._get_dim_of_dist(prior, 5) == 1
+        @test_throws ErrorException ext._get_dim_of_dist(prior, 6)
+
+        @test ext._get_prior_name(prior, 1) == "positive_with_mean_1"
+        @test ext._get_prior_name(prior, 2) == "four_with_spread_3"
+        @test ext._get_prior_name(prior, 3) == "four_with_spread_3"
+        @test ext._get_prior_name(prior, 4) == "four_with_spread_3"
+        @test ext._get_prior_name(prior, 5) == "positive_with_mean_1"
+        @test_throws ErrorException ext._get_prior_name(prior, 6)
+
+    end
+    @testset "Makie ploting" begin
+        # Access plots at tmp_dir
+        tmp_dir = mktempdir(cleanup = false)
+        @info "Tempdir", tmp_dir
+
+        G(u) = [1.0 / abs(u[1]), sum(u[2:3]), u[3], u[1]^2 - u[2] - u[3], u[1], 5.0] .+ 0.1 * randn(6)
+        true_u = [3, 1, 2]
+        y = G(true_u)
+        Γ = (0.1)^2 * I
+
+        prior_u1 = constrained_gaussian("positive_with_mean_1", 2, 1, 0, Inf)
+        prior_u2 = constrained_gaussian("two_with_spread_2", 0, 5, -Inf, Inf, repeats = 2)
+        prior = combine_distributions([prior_u1, prior_u2])
+
+        N_ensemble = 6
+        initial_ensemble = construct_initial_ensemble(prior, N_ensemble)
+        ekp = EnsembleKalmanProcess(initial_ensemble, y, Γ, Inversion(), verbose = true)
+
+        N_iterations = 8
+        for i in 1:N_iterations
+            params_i = get_ϕ_final(prior, ekp)
+
+            G_matrix = hcat(
+                [G(params_i[:, i]) for i in 1:N_ensemble]..., # Parallelize here!
+            )
+
+            update_ensemble!(ekp, G_matrix)
+        end
+
+        # Test functions for plotting distributions and errors over time or iterations
+        fig1 = CairoMakie.Figure(size = (200 * 4, 200 * 7))
+        layout = fig1[1, 1:2] = CairoMakie.GridLayout()
+        EnsembleKalmanProcesses.Visualize.plot_parameter_distribution(layout, prior)
+        EnsembleKalmanProcesses.Visualize.plot_error_over_iters(
+            fig1[2, 1],
+            ekp,
+            color = :tomato,
+            axis = (xlabel = "Iterations [added by axis keyword argument]",),
+        )
+        EnsembleKalmanProcesses.Visualize.plot_error_over_time(
+            fig1[2, 2],
+            ekp,
+            linestyle = :dash,
+            auto_log_scale = true,
+            error_metric = "bayes_loss",
+        )
+        ax1 = CairoMakie.Axis(fig1[3, 1], title = "Error over iterations (called from mutating function)")
+        ax2 = CairoMakie.Axis(fig1[3, 2], title = "Error over time (called from mutating function)")
+        EnsembleKalmanProcesses.Visualize.plot_error_over_iters!(ax1, ekp, color = :aquamarine, auto_log_scale = true)
+        EnsembleKalmanProcesses.Visualize.plot_error_over_time!(
+            ax2,
+            ekp,
+            linestyle = :dashdotdot,
+            auto_log_scale = true,
+            error_metric = "bayes_loss",
+        )
+        save(joinpath(tmp_dir, "priors_and_errors.png"), fig1)
+
+        # Test functions for plotting ϕ over time or iterations
+        fig2 = CairoMakie.Figure(size = (400 * 2, 400 * 2))
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_over_iters(fig2[1, 1], ekp, prior, 1)
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_over_time(fig2[1, 2], ekp, prior, 2)
+        ax1 = CairoMakie.Axis(fig2[2, 1], title = "Constrained parameters (called from mutating function)")
+        ax2 = CairoMakie.Axis(fig2[2, 2], title = "Constrained parameters (called from mutating function)")
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_over_iters!(ax1, ekp, prior, 1)
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_over_time!(ax2, ekp, prior, 2)
+
+        save(joinpath(tmp_dir, "phi.png"), fig2)
+
+        # Test functions for plotting mean ϕ over time or iterations
+        fig3 = CairoMakie.Figure(size = (400 * 2, 400 * 2))
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_iters(fig3[1, 1], ekp, prior, 1)
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_time(fig3[1, 2], ekp, prior, 2)
+        ax1 = CairoMakie.Axis(fig3[2, 1], xlabel = "Iters (called from mutating function)")
+        ax2 = CairoMakie.Axis(fig3[2, 2], xlabel = "Time (called from mutating function)")
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_iters!(ax1, ekp, prior, 1)
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_time!(ax2, ekp, prior, 2)
+        save(joinpath(tmp_dir, "mean_phi.png"), fig3)
+
+        # Test functions for plotting mean and std of ϕ over time or iterations
+        fig4 = CairoMakie.Figure(size = (400 * 2, 400 * 2))
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_iters(
+            fig4[1, 1],
+            ekp,
+            prior,
+            1,
+            plot_std = true,
+            band_kwargs = (alpha = 0.2,),
+            color = :red,
+        )
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_time(
+            fig4[1, 2],
+            ekp,
+            prior,
+            2,
+            plot_std = true,
+            line_kwargs = (linestyle = :dash,),
+            band_kwargs = (alpha = 0.2,),
+            color = :purple,
+        )
+        ax1 = CairoMakie.Axis(fig4[2, 1], xlabel = "Iters (called from mutating function)")
+        ax2 = CairoMakie.Axis(fig4[2, 2], xlabel = "Time (called from mutating function)")
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_iters!(
+            ax1,
+            ekp,
+            prior,
+            1,
+            plot_std = true,
+            band_kwargs = (color = (:blue, 0.2),),
+            color = :red,
+        )
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_time!(
+            ax2,
+            ekp,
+            prior,
+            2,
+            plot_std = true,
+            line_kwargs = (linestyle = :dash,),
+            band_kwargs = (color = (:green, 0.2),),
+            color = :purple,
+        )
+
+        save(joinpath(tmp_dir, "mean_and_std_phi.png"), fig4)
+
+        # Access plots at tmp_dir
+        # Print info again since it is a little tedious to find it if you miss it
+        @info "Tempdir", tmp_dir
+    end
+end

--- a/test/Visualize/runtests.jl
+++ b/test/Visualize/runtests.jl
@@ -159,6 +159,40 @@ if TEST_PLOT_OUTPUT
 
         save(joinpath(tmp_dir, "mean_and_std_phi.png"), fig4)
 
+        # Test plotting functions for plotting ϕ by name
+        fig5 = CairoMakie.Figure(size = (400 * 2, 400 * 4))
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_over_iters((fig5[1, 1], fig5[1, 2]), ekp, prior, "two_with_spread_2")
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_over_time((fig5[2, 1], fig5[2, 2]), ekp, prior, "two_with_spread_2")
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_iters(
+            (fig5[3, 1], fig5[3, 2]),
+            ekp,
+            prior,
+            "two_with_spread_2",
+            linewidth = 1.5,
+        )
+        EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_time(
+            (fig5[4, 1], fig5[4, 2]),
+            ekp,
+            prior,
+            "two_with_spread_2",
+            linewidth = 3,
+        )
+        save(joinpath(tmp_dir, "plot_by_name.png"), fig5)
+
+        # Error handling
+        @test_throws ErrorException EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_time(
+            (fig5[5, 1], fig5[5, 2]),
+            ekp,
+            prior,
+            "name not present",
+        )
+        @test_throws ErrorException EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_time(
+            (fig5[6, 1],),
+            ekp,
+            prior,
+            "two_with_spread_2",
+        )
+
         # Test different plotting signatures
         # We do not test all possible combinations because there are too many to
         # test, so we only test plot_fn(args...; kwargs...)

--- a/test/Visualize/runtests.jl
+++ b/test/Visualize/runtests.jl
@@ -1,9 +1,4 @@
 if TEST_PLOT_OUTPUT
-    # Fix seed, so the plots do not differ from run to run
-    import Random
-    rng_seed = 1234
-    rng = Random.MersenneTwister(rng_seed)
-
     using Test
     using CairoMakie
 
@@ -39,6 +34,11 @@ if TEST_PLOT_OUTPUT
         # Access plots at tmp_dir
         tmp_dir = mktempdir(cleanup = false)
         @info "Tempdir", tmp_dir
+
+        # Fix seed, so the plots do not differ from run to run
+        import Random
+        rng_seed = 1234
+        rng = Random.MersenneTwister(rng_seed)
 
         G(u) = [1.0 / abs(u[1]), sum(u[2:3]), u[3], u[1]^2 - u[2] - u[3], u[1], 5.0] .+ 0.1 * randn(6)
         true_u = [3, 1, 2]
@@ -159,8 +159,33 @@ if TEST_PLOT_OUTPUT
 
         save(joinpath(tmp_dir, "mean_and_std_phi.png"), fig4)
 
+        # Test different plotting signatures
+        # We do not test all possible combinations because there are too many to
+        # test, so we only test plot_fn(args...; kwargs...)
+        mkdir(joinpath(tmp_dir, "diff_plot_signatures"))
+        error_fns = [
+            EnsembleKalmanProcesses.Visualize.plot_error_over_iters,
+            EnsembleKalmanProcesses.Visualize.plot_error_over_time,
+        ]
+        for error_fn in error_fns
+            fig_diff_signs, _, _ = error_fn(ekp)
+            save(joinpath(tmp_dir, "diff_plot_signatures", "$error_fn.png"), fig_diff_signs)
+        end
+
+        ϕ_fns = [
+            EnsembleKalmanProcesses.Visualize.plot_ϕ_over_iters,
+            EnsembleKalmanProcesses.Visualize.plot_ϕ_over_time,
+            EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_iters,
+            EnsembleKalmanProcesses.Visualize.plot_ϕ_mean_over_time,
+        ]
+        for ϕ_fn in ϕ_fns
+            fig_diff_signs, _, _ = ϕ_fn(ekp, prior, 1)
+            save(joinpath(tmp_dir, "diff_plot_signatures", "$ϕ_fn.png"), fig_diff_signs)
+        end
+
         # Access plots at tmp_dir
-        # Print info again since it is a little tedious to find it if you miss it
+        # Print info again since it is a little tedious to find it if you miss
+        # it the first time
         @info "Tempdir", tmp_dir
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ end
         "TOMLInterface",
         "SparseInversion",
         "Inflation",
+        "Visualize",
     ]
         if all_tests || has_submodule(submodule) || "EnsembleKalmanProcesses" in ARGS
             include_test(submodule)


### PR DESCRIPTION
This PR adds a Makie extension for plotting. This is still a work in progress.

## Checklist

- [x] Add plot of priors
- [x] Add plot of constrained parameters vs time/iterations
- [x] Add plot of mean constrained parameters with and without standard deviation vs time/iterations
- [x] Add plot of errors vs time/iterations
- [ ] Add automatic log scale for x and y axis
- [x] Add a visualization section for examples of plots
- [x] After [PR#484](https://github.com/CliMA/EnsembleKalmanProcesses.jl/pulls) is merged, add keyword argument for error plotting function to let the user choose which error they want to plot

## Documentation
The new docs page can be found [here](https://clima.github.io/EnsembleKalmanProcesses.jl/previews/PR482/visualization/)

## Example of use cases

Here are some plots that can be made so far.

<img src="https://github.com/user-attachments/assets/00706625-b7f7-4955-9d7d-73d396f69e4d" width="350"> <img src="https://github.com/user-attachments/assets/805f8460-c3da-489d-a67b-8fbdeee90d3c" width="350">
