### PR TITLE
compute_error! bugfix, and add some more error metrics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,3 @@
-
 name = "EnsembleKalmanProcesses"
 uuid = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 authors = ["CLIMA contributors <clima-software@caltech.edu>"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,3 +1,4 @@
+
 name = "EnsembleKalmanProcesses"
 uuid = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 authors = ["CLIMA contributors <clima-software@caltech.edu>"]

--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -23,9 +23,6 @@ get_u_mean_final
 get_u_cov_final
 get_g_mean_final
 get_ϕ_mean_final
-compute_error!
-get_error_metrics
-get_error
 get_N_iterations
 get_N_ens
 get_accelerator
@@ -46,6 +43,19 @@ impute_over_nans
 list_update_groups_over_minibatch
 ```
 
+## [Error metrics](@id errors_api)
+
+```@docs
+compute_average_rmse
+compute_loss_at_mean
+compute_average_unweighted_rmse
+compute_unweighted_loss_at_mean
+compute_bayes_loss_at_mean
+compute_error!
+get_error_metrics
+get_error
+
+```
 ## [Learning Rate Schedulers](@id scheduler_api)
 
 ```@docs

--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -24,6 +24,7 @@ get_u_cov_final
 get_g_mean_final
 get_ϕ_mean_final
 compute_error!
+get_error_metrics
 get_error
 get_N_iterations
 get_N_ens

--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -51,6 +51,7 @@ compute_loss_at_mean
 compute_average_unweighted_rmse
 compute_unweighted_loss_at_mean
 compute_bayes_loss_at_mean
+compute_crps
 compute_error!
 get_error_metrics
 get_error

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -12,8 +12,14 @@ export EnsembleKalmanProcess
 export get_u, get_g, get_ϕ
 export get_u_prior, get_u_final, get_g_final, get_ϕ_final
 export get_N_iterations, get_error_metrics, get_error, get_cov_blocks
+export compute_average_rmse,
+    compute_loss_at_mean,
+    compute_average_unweighted_rmse,
+    compute_unweighted_loss_at_mean,
+    compute_bayes_loss_at_mean
 export get_u_mean, get_u_cov, get_g_mean, get_ϕ_mean
 export get_u_mean_final, get_u_cov_prior, get_u_cov_final, get_g_mean_final, get_ϕ_mean_final
+
 export get_scheduler,
     get_localizer, get_localizer_type, get_accelerator, get_rng, get_Δt, get_failure_handler, get_N_ens, get_process
 export get_nan_tolerance, get_nan_row_values

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -13,7 +13,7 @@ export get_u, get_g, get_ϕ
 export get_u_prior, get_u_final, get_g_final, get_ϕ_final
 export get_N_iterations, get_error_metrics, get_error, get_cov_blocks
 export compute_average_rmse,
-    compute_loss_at_mean, compute_average_unweighted_rmse, compute_unweighted_loss_at_mean, compute_bayes_loss_at_mean
+    compute_loss_at_mean, compute_average_unweighted_rmse, compute_unweighted_loss_at_mean, compute_bayes_loss_at_mean, compute_crps
 export get_u_mean, get_u_cov, get_g_mean, get_ϕ_mean
 export get_u_mean_final, get_u_cov_prior, get_u_cov_final, get_g_mean_final, get_ϕ_mean_final
 
@@ -948,6 +948,31 @@ function compute_bayes_loss_at_mean(ekp::EnsembleKalmanProcess)
 
 end
 
+"""
+$(TYPEDSIGNATURES)
+
+Computes a CRPS (continuous rank probability score) of the ensemble with the observation (performing through a whitening by C^GG, see e.g., Zheng, Sun, 2025).
+"""
+function compute_crps(ekp::EnsembleKalmanProcess)
+    g = get_g_final(ekp)
+    succ_ens, _ = split_indices_by_success(g)
+    g_ens = g[:, succ_ens]
+    mean_g = mean(g_ens, dims = 2)
+    diff = get_obs(ekp) - mean_g
+
+    # get svd of the perturbations from samples
+    g_svd = tsvd_cov_from_samples(g_ens, quiet=true) # Note from this function, .S are evals of cov-g
+    if size(g_svd.U,1) == size(g_svd.U,2) # then work with Vt
+        white_diff = 1 ./ sqrt.(g_svd.S) .* g_svd.Vt * diff # N(0,I)
+    else
+        white_diff = 1 ./ sqrt.(g_svd.S) .* g_svd.U' * diff # N(0,I)
+    end
+    dist = Normal(0,1)
+    indep_crps = white_diff .* (2 .* cdf.(dist, white_diff) .- 1) .+ 2 * pdf.(dist, white_diff) .- 1 ./ sqrt(π)
+    avg_crps = 1 ./ length(g_svd.S) * sum(sqrt.(g_svd.S) .* indep_crps)
+    return avg_crps
+end
+
 
 
 """
@@ -960,6 +985,7 @@ currently available:
 - `unweighed_avg_rmse` computed with `compute_average_unweighted_rmse(ekp)`
 - `unweighted_loss`    computed with `compute_unweighted_loss_at_mean(ekp)`
 - `bayes_loss`         computed with `compute_bayes_loss_at_mean(ekp)`
+- `crps`               computed with `compute_crps(ekp)`
 
 """
 function compute_error!(ekp::EnsembleKalmanProcess)
@@ -969,6 +995,7 @@ function compute_error!(ekp::EnsembleKalmanProcess)
     un_rmse = compute_average_unweighted_rmse(ekp)
     un_loss = compute_unweighted_loss_at_mean(ekp)
     bayes_loss = compute_bayes_loss_at_mean(ekp)
+    crps = compute_crps(ekp)
 
     em = get_error_metrics(ekp)
     if length(keys(em)) == 0
@@ -977,12 +1004,14 @@ function compute_error!(ekp::EnsembleKalmanProcess)
         em["bayes_loss"] = [bayes_loss]
         em["unweighted_avg_rmse"] = [un_rmse]
         em["unweighted_loss"] = [un_loss]
+        em["crps"] = [crps]
     else
         push!(em["avg_rmse"], rmse)
         push!(em["loss"], loss)
         push!(em["bayes_loss"], bayes_loss)
         push!(em["unweighted_avg_rmse"], un_rmse)
         push!(em["unweighted_loss"], un_loss)
+        push!(em["crps"], crps)
     end
 end
 

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -836,10 +836,13 @@ Computes the covariance-weighted error of the mean forward model output, `(ḡ -
 The error is stored within the `EnsembleKalmanProcess`.
 """
 function compute_error!(ekp::EnsembleKalmanProcess)
-    mean_g = dropdims(mean(get_g_final(ekp), dims = 2), dims = 2)
+    g = get_g_final(ekp)
+    succ_ens,_ = split_indices_by_success(g)
+    mean_g = dropdims(mean(g[:,succ_ens], dims = 2), dims = 2)
     diff = get_obs(ekp) - mean_g
     X = lmul_obs_noise_cov_inv(ekp, diff)
-    newerr = dot(diff, X)
+    N_ens = get_N_ens(ekp)
+    newerr = 1.0 / N_ens * dot(diff, X)
     push!(get_error(ekp), newerr)
 end
 

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -888,7 +888,7 @@ end
 $(TYPEDSIGNATURES)
 
 Computes the covariance-weighted error of the mean of the forward model output, normalized by the dimension `1/dim(y) * (ḡ - y)' * Γ⁻¹ * (ḡ - y)`.
-The error is retrievable as `get_error_metrics(ekp)["loss"]`
+The error is retrievable as `get_error_metrics(ekp)["loss"]` or returned from `get_error(ekp)` if a prior is not provided to the process
 """
 function compute_loss_at_mean(ekp::EnsembleKalmanProcess)
     g = get_g_final(ekp)
@@ -921,7 +921,7 @@ $(TYPEDSIGNATURES)
 Computes the bayes loss of the mean of the forward model output, normalized by dimensions `(1/dim(y)*dim(u)) * [(ḡ - y)' * Γ⁻¹ * (ḡ - y) + (̄u - m)' * C⁻¹ * (̄u - m)]`.
 If the prior is not provided to the process on creation of EKP, then `m` and `C` are estimated from the initial ensemble.
 
-The error is retrievable as `get_error_metrics(ekp)["bayes_loss"]`, or `get_error(ekp)`
+The error is retrievable as `get_error_metrics(ekp)["bayes_loss"]` or returned from `get_error(ekp)` if a prior is provided to the process
 """
 function compute_bayes_loss_at_mean(ekp::EnsembleKalmanProcess)
     process = get_process(ekp)

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -13,10 +13,7 @@ export get_u, get_g, get_ϕ
 export get_u_prior, get_u_final, get_g_final, get_ϕ_final
 export get_N_iterations, get_error_metrics, get_error, get_cov_blocks
 export compute_average_rmse,
-    compute_loss_at_mean,
-    compute_average_unweighted_rmse,
-    compute_unweighted_loss_at_mean,
-    compute_bayes_loss_at_mean
+    compute_loss_at_mean, compute_average_unweighted_rmse, compute_unweighted_loss_at_mean, compute_bayes_loss_at_mean
 export get_u_mean, get_u_cov, get_g_mean, get_ϕ_mean
 export get_u_mean_final, get_u_cov_prior, get_u_cov_final, get_g_mean_final, get_ϕ_mean_final
 
@@ -933,22 +930,22 @@ function compute_bayes_loss_at_mean(ekp::EnsembleKalmanProcess)
     # estimate from initial ensemble if we do not have access to them
     # note initial ensemble = prior, for ekp algorithms where prior is not provided
     if isnothing(prior_mean)
-        u_prior = get_u(ekp,1)
-        prior_mean = mean(u_prior, dims=2)
+        u_prior = get_u(ekp, 1)
+        prior_mean = mean(u_prior, dims = 2)
     end
     if isnothing(prior_cov)
-        u_prior = get_u(ekp,1)
-        prior_cov = cov(u_prior, dims=2)
+        u_prior = get_u(ekp, 1)
+        prior_cov = cov(u_prior, dims = 2)
         if !isposdef(prior_cov)
-            prior_cov = posdef_correct(prior_cov)            
+            prior_cov = posdef_correct(prior_cov)
         end
     end
     u = get_u_mean_final(ekp)
-    udiff = reshape(u - prior_mean, : , 1)
+    udiff = reshape(u - prior_mean, :, 1)
     prior_misfit_at_mean = 1.0 / length(u) * dot(udiff, inv(prior_cov) * udiff)
     # indep of input and output size
-    return (1.0 / length(u)) * misfit_at_mean +  (1.0 / size(g,1)) * prior_misfit_at_mean
-    
+    return (1.0 / length(u)) * misfit_at_mean + (1.0 / size(g, 1)) * prior_misfit_at_mean
+
 end
 
 

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -1007,6 +1007,7 @@ function get_error(ekp::EnsembleKalmanProcess)
     else
         return get_error_metrics(ekp)["bayes_loss"]
     end
+end
 
 """
     sample_empirical_gaussian(

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -839,9 +839,13 @@ function compute_average_unweighted_rmse(ekp::EnsembleKalmanProcess)
     g = get_g_final(ekp)
     succ_ens, _ = split_indices_by_success(g)
     diff = get_obs(ekp) .- g[:, succ_ens] # column diff
-    dot_diff = 1.0 / size(g, 1) * [dot(d,d) for d in eachcol(diff)] # trace(diff'*diff)
+    dot_diff = 1.0 / size(g, 1) * [dot(d, d) for d in eachcol(diff)] # trace(diff'*diff)
     if any(dot_diff .< 0)
-        throw(ArgumentError("Found x'*Γ⁻¹*x < 0. This implies Γ⁻¹ not positive semi-definite, \n please modify Γ (a.k.a noise covariance of the observation) to ensure p.s.d. holds."))
+        throw(
+            ArgumentError(
+                "Found x'*Γ⁻¹*x < 0. This implies Γ⁻¹ not positive semi-definite, \n please modify Γ (a.k.a noise covariance of the observation) to ensure p.s.d. holds.",
+            ),
+        )
     end
 
     ens_rmse = sqrt.(dot_diff) # rmse for each ens member
@@ -859,9 +863,13 @@ function compute_average_rmse(ekp::EnsembleKalmanProcess)
     succ_ens, _ = split_indices_by_success(g)
     diff = get_obs(ekp) .- g[:, succ_ens] # column diff
     X = lmul_obs_noise_cov_inv(ekp, diff)
-    weight_diff = 1.0 / size(g, 1) *  [dot(x,d) for (x,d) in zip(eachcol(diff),eachcol(X))] # trace(diff'*X)
+    weight_diff = 1.0 / size(g, 1) * [dot(x, d) for (x, d) in zip(eachcol(diff), eachcol(X))] # trace(diff'*X)
     if any(weight_diff .< 0)
-        throw(ArgumentError("Found x'*Γ⁻¹*x < 0. This implies Γ⁻¹ not positive semi-definite, \n please modify Γ (a.k.a noise covariance of the observation) to ensure p.s.d. holds."))
+        throw(
+            ArgumentError(
+                "Found x'*Γ⁻¹*x < 0. This implies Γ⁻¹ not positive semi-definite, \n please modify Γ (a.k.a noise covariance of the observation) to ensure p.s.d. holds.",
+            ),
+        )
     end
     ens_rmse = sqrt.(sum(weight_diff)) # rmse for each ens member
     avg_rmse = mean(ens_rmse) # average

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -855,7 +855,7 @@ function compute_average_rmse(ekp::EnsembleKalmanProcess)
     succ_ens, _ = split_indices_by_success(g)
     diff = get_obs(ekp) .- g[:, succ_ens] # column diff
     X = lmul_obs_noise_cov_inv(ekp, diff)
-    weight_diff = 1.0 / size(g, 1) * dot(diff, X)
+    weight_diff = 1.0 / size(g, 1) * diff'* X
     ens_rmse = sqrt.(sum(weight_diff, dims = 1)) # rmse for each ens member
     avg_rmse = mean(ens_rmse) # average
     return avg_rmse

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -901,7 +901,7 @@ Computes a variety of error metrics (rmse, weighted rmse, loss etc.) and stores 
 """
 function compute_error!(ekp::EnsembleKalmanProcess)
     rmse = compute_average_rmse(ekp)
-    loss = compute_loss_of_mean(ekp)
+    loss = compute_loss_at_mean(ekp)
     un_rmse = compute_average_unweighted_rmse(ekp)
     un_loss = compute_unweighted_loss_at_mean(ekp)
 

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -832,7 +832,7 @@ construct_initial_ensemble(prior::ParameterDistribution, N_ens::IT) where {IT <:
 """
     compute_error!(ekp::EnsembleKalmanProcess)
 
-Computes the covariance-weighted error of the mean forward model output, `(ḡ - y)'Γ_inv(ḡ - y)`.
+Computes the covariance-weighted error of the mean forward model output, normalized by the dimension `1/dim(y) * (ḡ - y)'Γ_inv(ḡ - y)`.
 The error is stored within the `EnsembleKalmanProcess`.
 """
 function compute_error!(ekp::EnsembleKalmanProcess)
@@ -841,8 +841,7 @@ function compute_error!(ekp::EnsembleKalmanProcess)
     mean_g = dropdims(mean(g[:,succ_ens], dims = 2), dims = 2)
     diff = get_obs(ekp) - mean_g
     X = lmul_obs_noise_cov_inv(ekp, diff)
-    N_ens = get_N_ens(ekp)
-    newerr = 1.0 / N_ens * dot(diff, X)
+    newerr = 1.0 / size(g,1) * dot(diff, X)
     push!(get_error(ekp), newerr)
 end
 

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -840,7 +840,7 @@ function compute_average_unweighted_rmse(ekp::EnsembleKalmanProcess)
     succ_ens, _ = split_indices_by_success(g)
     diff = get_obs(ekp) .- g[:, succ_ens] # column diff
     dot_diff = 1.0 / size(g, 1) * [dot(d,d) for d in eachcol(diff)] # trace(diff'*diff)
-    if any(dot_diff < 0)
+    if any(dot_diff .< 0)
         throw(ArgumentError("Found x'*Γ⁻¹*x < 0. This implies Γ⁻¹ not positive semi-definite, \n please modify Γ (a.k.a noise covariance of the observation) to ensure p.s.d. holds."))
     end
 
@@ -860,7 +860,7 @@ function compute_average_rmse(ekp::EnsembleKalmanProcess)
     diff = get_obs(ekp) .- g[:, succ_ens] # column diff
     X = lmul_obs_noise_cov_inv(ekp, diff)
     weight_diff = 1.0 / size(g, 1) *  [dot(x,d) for (x,d) in zip(eachcol(diff),eachcol(X))] # trace(diff'*X)
-    if any(weight_diff < 0)
+    if any(weight_diff .< 0)
         throw(ArgumentError("Found x'*Γ⁻¹*x < 0. This implies Γ⁻¹ not positive semi-definite, \n please modify Γ (a.k.a noise covariance of the observation) to ensure p.s.d. holds."))
     end
     ens_rmse = sqrt.(sum(weight_diff)) # rmse for each ens member

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -924,10 +924,10 @@ function compute_error!(ekp::EnsembleKalmanProcess)
 
     em = get_error_metrics(ekp)
     if length(keys(em)) == 0
-        em["avg_rmse"] = rmse
-        em["loss"] = loss
-        em["unweighted_avg_rmse"] = un_rmse
-        em["unweighted_loss"] = un_loss
+        em["avg_rmse"] = [rmse]
+        em["loss"] = [loss]
+        em["unweighted_avg_rmse"] = [un_rmse]
+        em["unweighted_loss"] = [un_loss]
     else
         push!(em["avg_rmse"], rmse)
         push!(em["loss"], loss)

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -911,9 +911,15 @@ end
 
 
 """
-    compute_error!(ekp::EnsembleKalmanProcess)
+$(TYPEDSIGNATURES)    compute_error!(ekp::EnsembleKalmanProcess)
 
-Computes a variety of error metrics (rmse, weighted rmse, loss etc.) and stores this in `EnsembleKalmanProcess`. (retrievable with get_error_metrics(ekp))
+Computes a variety of error metrics and stores this in `EnsembleKalmanProcess`. (retrievable with `get_error_metrics(ekp)`)
+currently available:
+- `avg_rmse`           computed with `compute_average_rmse(ekp)`
+- `loss`               computed with `compute_loss_at_mean(ekp)`
+- `unweighed_avg_rmse` computed with `compute_average_unweighted_rmse(ekp)`
+- `unweighted_loss`    computed with `compute_unweighted_loss_at_mean(ekp)`
+
 """
 function compute_error!(ekp::EnsembleKalmanProcess)
 
@@ -939,10 +945,16 @@ end
 """
     get_error_metrics(ekp::EnsembleKalmanProcess)
 
-Returns the loss as a function of algorithmic time.
+Returns the stored `error_metrics`, created with `compute_error!`
 """
 get_error_metrics(ekp::EnsembleKalmanProcess) = ekp.error_metrics
-get_error(ekp::EnsembleKalmanProcess) = get_error_metrics(ekp)["loss"] # for back compatability
+
+"""
+    get_error(ekp::EnsembleKalmanProcess)
+
+[For back compatability only!] Returns `get_error_metrics(ekp)["loss"]`, the loss computed with `compute_loss_at_mean(ekp)`
+"""
+get_error(ekp::EnsembleKalmanProcess) = get_error_metrics(ekp)["loss"] 
 
 
 """

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -11,7 +11,7 @@ using DocStringExtensions
 export EnsembleKalmanProcess
 export get_u, get_g, get_ϕ
 export get_u_prior, get_u_final, get_g_final, get_ϕ_final
-export get_N_iterations, get_error, get_cov_blocks
+export get_N_iterations, get_error_metrics, get_error, get_cov_blocks
 export get_u_mean, get_u_cov, get_g_mean, get_ϕ_mean
 export get_u_mean_final, get_u_cov_prior, get_u_cov_final, get_g_mean_final, get_ϕ_mean_final
 export get_scheduler,

--- a/src/EnsembleKalmanSampler.jl
+++ b/src/EnsembleKalmanSampler.jl
@@ -27,6 +27,9 @@ function Sampler(prior::ParameterDistribution)
     return Sampler{FT}(mean_prior, cov_prior)
 end
 
+get_prior_mean(process::Sampler) = process.prior_mean
+get_prior_cov(process::Sampler) = process.prior_cov
+
 
 function FailureHandler(process::Sampler, method::IgnoreFailures)
     function failsafe_update(ekp, u, g, failed_ens)

--- a/src/GaussNewtonKalmanInversion.jl
+++ b/src/GaussNewtonKalmanInversion.jl
@@ -20,6 +20,10 @@ function GaussNewtonInversion(prior::ParameterDistribution)
     return GaussNewtonInversion(mean_prior, cov_prior)
 end
 
+get_prior_mean(process::GaussNewtonInversion) = process.prior_mean
+get_prior_cov(process::GaussNewtonInversion) = process.prior_cov
+
+
 # failure handling
 function FailureHandler(process::GaussNewtonInversion, method::IgnoreFailures)
     failsafe_update(ekp, u, g, y, obs_noise_cov, failed_ens) = gnki_update(ekp, u, g, y, obs_noise_cov)

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -177,7 +177,7 @@ function tsvd_mat(X; return_inverse = false, quiet = false, tsvd_kwargs...)
             ),
         )
     end
-    return tsvd_mat(X, rank(X); return_inverse = return_inverse, quiet=quiet, tsvd_kwargs...)
+    return tsvd_mat(X, rank(X); return_inverse = return_inverse, quiet = quiet, tsvd_kwargs...)
 end
 
 """

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -130,7 +130,7 @@ $(TYPEDSIGNATURES)
 
 For a given matrix `X` and rank `r`, return the truncated SVD for X as a LinearAlgebra.jl `SVD` object. Setting `return_inverse=true` also return it's psuedoinverse X⁺.
 """
-function tsvd_mat(X, r::Int; return_inverse = false, tsvd_kwargs...)
+function tsvd_mat(X, r::Int; return_inverse = false, quiet = false, tsvd_kwargs...)
     # Note, must only use tsvd approximation when rank < minimum dimension of X or you get very poor approximation.
     if isa(X, UniformScaling)
         if return_inverse
@@ -142,7 +142,7 @@ function tsvd_mat(X, r::Int; return_inverse = false, tsvd_kwargs...)
         rx = rank(X)
         mindim = minimum(size(X))
         if rx <= r
-            if rx < r
+            if rx < r && !quiet
                 @warn(
                     "Requested truncation to rank $(r) for an input matrix of rank $(rx). Performing (truncated) SVD for rank $(rx) matrix."
                 )
@@ -169,7 +169,7 @@ function tsvd_mat(X, r::Int; return_inverse = false, tsvd_kwargs...)
     end
 end
 
-function tsvd_mat(X; return_inverse = false, tsvd_kwargs...)
+function tsvd_mat(X; return_inverse = false, quiet = false, tsvd_kwargs...)
     if isa(X, UniformScaling)
         throw(
             ArgumentError(
@@ -177,7 +177,7 @@ function tsvd_mat(X; return_inverse = false, tsvd_kwargs...)
             ),
         )
     end
-    return tsvd_mat(X, rank(X); return_inverse = return_inverse, tsvd_kwargs...)
+    return tsvd_mat(X, rank(X); return_inverse = return_inverse, quiet=quiet, tsvd_kwargs...)
 end
 
 """
@@ -190,12 +190,13 @@ function tsvd_cov_from_samples(
     r::Int;
     data_are_columns::Bool = true,
     return_inverse = false,
+    quiet = false,
     tsvd_kwargs...,
 ) where {AM <: AbstractMatrix}
 
     mat = data_are_columns ? sample_mat : permutedims(sample_mat, (2, 1))
     N = size(mat, 2)
-    if N > size(mat, 1)
+    if N > size(mat, 1) && !quiet
         @warn(
             "SVD representation is efficient when estimating high-dimensional covariance with few samples. \n here # samples is $(N), while the space dimension is $(size(mat,1)), and representation will be inefficient."
         )
@@ -220,6 +221,7 @@ function tsvd_cov_from_samples(
     sample_mat::AM;
     data_are_columns::Bool = true,
     return_inverse = false,
+    quiet = false,
     tsvd_kwargs...,
 ) where {AM <: AbstractMatrix}
     # (need to compute this to get the rank as debiasing can change it)
@@ -231,6 +233,7 @@ function tsvd_cov_from_samples(
         rk;
         data_are_columns = data_are_columns,
         return_inverse = return_inverse,
+        quiet = quiet,
         tsvd_kwargs...,
     )
 end

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -37,6 +37,10 @@ function SparseInversion(
     return SparseInversion{FT}(γ, threshold_value, uc_idx, reg)
 end
 
+get_prior_mean(process::SparseInversion) = nothing
+get_prior_cov(process::SparseInversion) = nothing
+
+
 function FailureHandler(process::SparseInversion, method::IgnoreFailures)
     failsafe_update(ekp, u, g, y, obs_noise_cov, failed_ens) = sparse_eki_update(ekp, u, g, y, obs_noise_cov)
     return FailureHandler{SparseInversion, IgnoreFailures}(failsafe_update)

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -836,15 +836,23 @@ function get_u_cov(
     return get_process(uki).uu_cov[iteration]
 end
 
-function compute_error!(
+function compute_loss_at_mean(
     uki::EnsembleKalmanProcess{FT, IT, UorTU},
 ) where {FT <: AbstractFloat, IT <: Int, UorTU <: Union{Unscented, TransformUnscented}}
     mean_g = get_process(uki).obs_pred[end]
     diff = get_obs(uki) - mean_g
     X = lmul_obs_noise_cov_inv(uki, diff)
-    g = get_g_final(uki)
     newerr = 1.0 / length(mean_g) * dot(diff, X)
-    push!(get_error(uki), newerr)
+    return newerr
+end
+
+function compute_unweighted_loss_at_mean(
+    uki::EnsembleKalmanProcess{FT, IT, UorTU},
+) where {FT <: AbstractFloat, IT <: Int, UorTU <: Union{Unscented, TransformUnscented}}
+    mean_g = get_process(uki).obs_pred[end]
+    diff = get_obs(uki) - mean_g
+    newerr = 1.0 / length(mean_g) * dot(diff, diff)
+    return newerr
 end
 
 

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -842,7 +842,8 @@ function compute_error!(
     mean_g = get_process(uki).obs_pred[end]
     diff = get_obs(uki) - mean_g
     X = lmul_obs_noise_cov_inv(uki, diff)
-    newerr = dot(diff, X)
+    N_ens = get_N_ens(uki)
+    newerr = 1.0 / N_ens * dot(diff, X)
     push!(get_error(uki), newerr)
 end
 

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -864,7 +864,6 @@ function compute_crps(
     successful_ens, _ = split_indices_by_success(g)
     g_mean = construct_successful_mean(uki, g, successful_ens)
     diff = get_obs(uki) - g_mean
-
     if length(g_mean) > length(successful_ens) # dim > ens
         # get svd directly from the perturbations (not samples) 
         g_perturb = construct_successful_perturbation(uki, g, g_mean, successful_ens)[:, 2:end] # first column zeros
@@ -876,7 +875,7 @@ function compute_crps(
         avg_crps = 1 ./ length(g_svd.S) * sum(g_svd.S .* indep_crps)
         return avg_crps
 
-    else
+    else  # dim < ens
         g_cov = construct_successful_cov(uki, g, g_mean, successful_ens)
         g_svd = svd(g_cov) # Note this svd gives, .S are evals
 

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -288,6 +288,9 @@ function EnsembleKalmanProcess(
     return EnsembleKalmanProcess(observation, process; kwargs...)
 end
 
+get_prior_mean(process::UorTU) where {UorTU <: Union{Unscented, TransformUnscented}} = process.prior_mean
+get_prior_cov(process::UorTU) where {UorTU <: Union{Unscented, TransformUnscented}} = process.prior_cov
+
 function FailureHandler(process::Unscented, method::IgnoreFailures)
     function failsafe_update(uki, u, g, u_idx, g_idx, failed_ens)
         #perform analysis on the model runs

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -836,6 +836,7 @@ function get_u_cov(
     return get_process(uki).uu_cov[iteration]
 end
 
+
 function compute_loss_at_mean(
     uki::EnsembleKalmanProcess{FT, IT, UorTU},
 ) where {FT <: AbstractFloat, IT <: Int, UorTU <: Union{Unscented, TransformUnscented}}
@@ -854,6 +855,26 @@ function compute_unweighted_loss_at_mean(
     newerr = 1.0 / length(mean_g) * dot(diff, diff)
     return newerr
 end
+
+"""
+For Unscented processes it doesn't make sense to average RMSE at sigma points, so it is evaluated at the mean only, where it is exactly equal to `sqrt(compute_loss_at_mean(uki))`
+"""
+function compute_average_rmse(
+    uki::EnsembleKalmanProcess{FT, IT, UorTU},
+) where {FT <: AbstractFloat, IT <: Int, UorTU <: Union{Unscented, TransformUnscented}}
+    return sqrt(compute_loss_at_mean)
+end
+
+"""
+For Unscented processes it doesn't make sense to average unweighted RMSE at sigma points, so it is evaluated at the mean only, where it is exactly equal to `sqrt(compute_unweighted_loss_at_mean(uki))`
+"""
+function compute_average_unweighted_rmse(
+    uki::EnsembleKalmanProcess{FT, IT, UorTU},
+) where {FT <: AbstractFloat, IT <: Int, UorTU <: Union{Unscented, TransformUnscented}}
+    return sqrt(compute_unweighted_loss_at_mean)
+end
+
+
 
 
 function Gaussian_2d(

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -146,8 +146,6 @@ function Unscented(
         cov_weights[1] = λ / (N_par + λ) + 1 - α^2 + 2.0
         cov_weights[2:N_ens] .= 1 / (2 * (N_par + λ))
 
-
-
     elseif sigma_points == "simplex"
         c_weights = zeros(FT, N_par, N_ens)
 
@@ -621,7 +619,7 @@ function construct_perturbation(
     if isa(x, AbstractMatrix{FT})
         @assert isa(x_mean, AbstractVector{FT})
         xx_pert = zeros(size(x))
-        for i in 1:size(xx_pert, 2)
+        for i in 2:size(xx_pert, 2) # first column always zero (as it is the mean)
             xx_pert[:, i] = sqrt(cov_weights[i]) * (x[:, i] .- x_mean)
         end
     else
@@ -629,7 +627,7 @@ function construct_perturbation(
         N_ens = length(x)
         xx_pert = zeros(N_ens)
 
-        for i in 1:N_ens
+        for i in 2:N_ens # first entry always zero (as it is the mean)
             xx_pert[i] += sqrt(cov_weights[i]) * (x[i] .- x_mean)
         end
     end
@@ -857,6 +855,49 @@ function compute_unweighted_loss_at_mean(
     diff = get_obs(uki) - mean_g
     newerr = 1.0 / length(mean_g) * dot(diff, diff)
     return newerr
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Computes a Gaussian approximation of CRPS (continuous rank probability score) of the ensemble with the observation (performing through a whitening by C^GG, see e.g., Zheng, Sun, 2025, https://arxiv.org/abs/2410.09133).
+"""
+function compute_crps(
+    uki::EnsembleKalmanProcess{FT, IT, UorTU},
+) where {FT <: AbstractFloat, IT <: Int, UorTU <: Union{Unscented, TransformUnscented}}
+    g = get_g_final(uki)
+    successful_ens, _ = split_indices_by_success(g)
+    g_mean = construct_successful_mean(uki, g, successful_ens)
+    diff = get_obs(uki) - g_mean
+
+    if length(g_mean) > length(successful_ens) # dim > ens
+        # get svd directly from the perturbations (not samples) 
+        g_perturb = construct_successful_perturbation(uki, g, g_mean, successful_ens)[:, 2:end] # first column zeros
+        g_svd = svd(g_perturb) # Note this svd gives, .S are sqrt-evals of cov-g
+        @info g_svd.S
+        if size(g_svd.U, 1) == size(g_svd.U, 2) # then work with Vt
+            white_diff = 1 ./ g_svd.S .* g_svd.Vt * diff # ~N(0,I)
+        else
+            white_diff = 1 ./ g_svd.S .* g_svd.U' * diff # ~N(0,I)
+        end
+        dist = Normal(0, 1)
+        indep_crps = white_diff .* (2 .* cdf.(dist, white_diff) .- 1) .+ 2 * pdf.(dist, white_diff) .- 1 ./ sqrt(π)
+        avg_crps = 1 ./ length(g_svd.S) * sum(g_svd.S .* indep_crps)
+        return avg_crps
+
+    else
+        g_cov = construct_successful_cov(uki, g, g_mean, successful_ens)
+        g_svd = svd(g_cov) # Note this svd gives, .S are evals
+        @info g_svd.S
+
+        white_diff = 1 ./ sqrt.(g_svd.S) .* g_svd.Vt * diff # ~N(0,I)
+
+        dist = Normal(0, 1)
+        indep_crps = white_diff .* (2 .* cdf.(dist, white_diff) .- 1) .+ 2 * pdf.(dist, white_diff) .- 1 ./ sqrt(π)
+        avg_crps = 1 ./ length(g_svd.S) * sum(sqrt.(g_svd.S) .* indep_crps)
+        return avg_crps
+    end
+
 end
 
 """

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -862,7 +862,7 @@ For Unscented processes it doesn't make sense to average RMSE at sigma points, s
 function compute_average_rmse(
     uki::EnsembleKalmanProcess{FT, IT, UorTU},
 ) where {FT <: AbstractFloat, IT <: Int, UorTU <: Union{Unscented, TransformUnscented}}
-    return sqrt(compute_loss_at_mean)
+    return sqrt(compute_loss_at_mean(uki))
 end
 
 """
@@ -871,7 +871,7 @@ For Unscented processes it doesn't make sense to average unweighted RMSE at sigm
 function compute_average_unweighted_rmse(
     uki::EnsembleKalmanProcess{FT, IT, UorTU},
 ) where {FT <: AbstractFloat, IT <: Int, UorTU <: Union{Unscented, TransformUnscented}}
-    return sqrt(compute_unweighted_loss_at_mean)
+    return sqrt(compute_unweighted_loss_at_mean(uki))
 end
 
 

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -842,8 +842,8 @@ function compute_error!(
     mean_g = get_process(uki).obs_pred[end]
     diff = get_obs(uki) - mean_g
     X = lmul_obs_noise_cov_inv(uki, diff)
-    N_ens = get_N_ens(uki)
-    newerr = 1.0 / N_ens * dot(diff, X)
+    g = get_g_final(uki)
+    newerr = 1.0 / length(mean_g) * dot(diff, X)
     push!(get_error(uki), newerr)
 end
 

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -874,7 +874,6 @@ function compute_crps(
         # get svd directly from the perturbations (not samples) 
         g_perturb = construct_successful_perturbation(uki, g, g_mean, successful_ens)[:, 2:end] # first column zeros
         g_svd = svd(g_perturb) # Note this svd gives, .S are sqrt-evals of cov-g
-        @info g_svd.S
         if size(g_svd.U, 1) == size(g_svd.U, 2) # then work with Vt
             white_diff = 1 ./ g_svd.S .* g_svd.Vt * diff # ~N(0,I)
         else
@@ -888,7 +887,6 @@ function compute_crps(
     else
         g_cov = construct_successful_cov(uki, g, g_mean, successful_ens)
         g_svd = svd(g_cov) # Note this svd gives, .S are evals
-        @info g_svd.S
 
         white_diff = 1 ./ sqrt.(g_svd.S) .* g_svd.Vt * diff # ~N(0,I)
 

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -731,7 +731,7 @@ end
         # get_error should give the appropriate loss
         @test isequal(get_error(ekiobj), get_error_metrics(ekiobj)["loss"])
         @test isequal(get_error(ekiobj_inf), get_error_metrics(ekiobj_inf)["bayes_loss"])
-        
+
         # EKI results: Test if ensemble has collapsed toward the true parameter 
         # values
         eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
@@ -1149,7 +1149,7 @@ end
         @test isequal(get_error(ekiobj), get_error_metrics(ekiobj)["loss"])
         @test isequal(get_error(ekiobj_inf), get_error_metrics(ekiobj_inf)["bayes_loss"])
 
-        
+
         # ETKI results: Test if ensemble has collapsed toward the true parameter 
         # values
         eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -726,8 +726,12 @@ end
         @test get_u(ekiobj) == u_i_vec
         @test isequal(get_g(ekiobj), g_ens_vec)
         @test isequal(get_g_final(ekiobj), g_ens_vec[end])
-        @test isequal(get_error(ekiobj), ekiobj.error)
+        @test isequal(get_error_metrics(ekiobj), ekiobj.error_metrics)
 
+        # get_error should give the appropriate loss
+        @test isequal(get_error(ekiobj), get_error_metrics(ekiobj)["loss"])
+        @test isequal(get_error(ekiobj_inf), get_error_metrics(ekiobj_inf)["bayes_loss"])
+        
         # EKI results: Test if ensemble has collapsed toward the true parameter 
         # values
         eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
@@ -964,7 +968,7 @@ end
             @test get_u(ekpobj) == u_i_vec
             @test isequal(get_g(ekpobj), g_ens_vec)
             @test isequal(get_g_final(ekpobj), g_ens_vec[end])
-            @test isequal(get_error(ekpobj), ekpobj.error)
+            @test isequal(get_error_metrics(ekpobj), ekpobj.error_metrics)
 
             @test isa(construct_mean(ekpobj, rand(rng, 2 * n_par + 1)), Float64)
             @test isa(construct_mean(ekpobj, rand(rng, 5, 2 * n_par + 1)), Vector{Float64})
@@ -1139,8 +1143,13 @@ end
         @test get_u(ekiobj) == u_i_vec
         @test isequal(get_g(ekiobj), g_ens_vec)
         @test isequal(get_g_final(ekiobj), g_ens_vec[end])
-        @test isequal(get_error(ekiobj), ekiobj.error)
+        @test isequal(get_error_metrics(ekiobj), ekiobj.error_metrics)
 
+        # get_error should give the appropriate loss
+        @test isequal(get_error(ekiobj), get_error_metrics(ekiobj)["loss"])
+        @test isequal(get_error(ekiobj_inf), get_error_metrics(ekiobj_inf)["bayes_loss"])
+
+        
         # ETKI results: Test if ensemble has collapsed toward the true parameter 
         # values
         eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))
@@ -1490,7 +1499,7 @@ end
         @test get_u(gnkiobj) == u_i_vec
         @test isequal(get_g(gnkiobj), g_ens_vec) # can deal with NaNs
         @test isequal(get_g_final(gnkiobj), g_ens_vec[end])
-        @test isequal(get_error(gnkiobj), gnkiobj.error)
+        @test isequal(get_error_metrics(gnkiobj), gnkiobj.error_metrics)
 
         # GNKI results: Test if ensemble has collapsed toward the true parameter 
         # values

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -837,9 +837,9 @@ end
             y_obs, Gold, Γy, A = inv_problem
             # input_dim = 2 -> n_ens = 4 or 7
             y_obs = y_obs[1:3]
-            Γy = Γy[1:3,1:3]
-            A = A[1:3,:]
-            G(x) = Gold(x)[1:3,:]
+            Γy = Γy[1:3, 1:3]
+            A = A[1:3, :]
+            G(x) = Gold(x)[1:3, :]
         else
             y_obs, G, Γy, A = inv_problem
         end

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -833,7 +833,16 @@ end
     for (i_prob, inv_problem, impose_prior, update_freq) in
         zip(1:length(inv_problems), inv_problems, impose_priors, update_freqs)
 
-        y_obs, G, Γy, A = inv_problem
+        if i_prob == 1 # we do one of the problems with n_obs < n_ens (for code coverage)
+            y_obs, Gold, Γy, A = inv_problem
+            # input_dim = 2 -> n_ens = 4 or 7
+            y_obs = y_obs[1:3]
+            Γy = Γy[1:3,1:3]
+            A = A[1:3,:]
+            G(x) = Gold(x)[1:3,:]
+        else
+            y_obs, G, Γy, A = inv_problem
+        end
         scheduler = DataMisfitController(on_terminate = "continue") #will need to be copied as stores run information inside
         scheduler_simplex = DefaultScheduler(0.05) #will need to be copied as stores run information inside
 

--- a/test/Observations/runtests.jl
+++ b/test/Observations/runtests.jl
@@ -496,7 +496,7 @@ end
     Γfullinv[13:21, 13:21] = svd_cov.U * Diagonal(1.0 ./ svd_cov.S) * svd_cov.U'
     Γfullinv[22:33, 22:33] = inv(Γfull[22:33, 22:33]) #small enough to compute directly
     Γinv = get_obs_noise_cov_inv(observation_series)
-    @test norm(Γfullinv - Γinv) < 1e-12
+    @test norm(Γfullinv - Γinv) < 1e-11
     # Test utilities for multiplying covariances without building them
     # test lmul_obs_noise_cov
 
@@ -504,13 +504,13 @@ end
     X = randn(size(Γ, 1), 50)
     test1 = Γ * Xvec
     test2 = Γ * X
-    @test norm(test1 - lmul_obs_noise_cov(observation_series, Xvec)) < 1e-12
-    @test norm(test2 - lmul_obs_noise_cov(observation_series, X)) < 1e-12
+    @test norm(test1 - lmul_obs_noise_cov(observation_series, Xvec)) < 1e-11
+    @test norm(test2 - lmul_obs_noise_cov(observation_series, X)) < 1e-11
 
     test1 = Γinv * Xvec
     test2 = Γinv * X
-    @test norm(test1 - lmul_obs_noise_cov_inv(observation_series, Xvec)) < 1e-12
-    @test norm(test2 - lmul_obs_noise_cov_inv(observation_series, X)) < 1e-12
+    @test norm(test1 - lmul_obs_noise_cov_inv(observation_series, Xvec)) < 1e-11
+    @test norm(test2 - lmul_obs_noise_cov_inv(observation_series, X)) < 1e-11
 
     # test the pre-indexed versions:    
     # cov
@@ -522,12 +522,12 @@ end
     # The function is writte to be applied to pre-trimmed "X"s 
     lmul_obs_noise_cov!(out1, observation_series, Xvec[g_idx], g_idx)
     lmul_obs_noise_cov!(out2, observation_series, X[g_idx, :], g_idx)
-    @test norm(test1 - out1) < 1e-12
-    @test norm(test2 - out2) < 1e-12
+    @test norm(test1 - out1) < 1e-11
+    @test norm(test2 - out2) < 1e-11
     lmul_obs_noise_cov!(out1, observation_series, Xvec, g_idx)
     lmul_obs_noise_cov!(out2, observation_series, X, g_idx)
-    @test norm(test1 - out1) < 1e-12
-    @test norm(test2 - out2) < 1e-12
+    @test norm(test1 - out1) < 1e-11
+    @test norm(test2 - out2) < 1e-11
 
 
     # cov_inv
@@ -538,11 +538,11 @@ end
     # In code this is applied to pre-trimmed "X"s or not
     lmul_obs_noise_cov_inv!(out1, observation_series, Xvec[g_idx], g_idx)
     lmul_obs_noise_cov_inv!(out2, observation_series, X[g_idx, :], g_idx)
-    @test norm(test1 - out1) < 1e-12
-    @test norm(test2 - out2) < 1e-12
+    @test norm(test1 - out1) < 1e-11
+    @test norm(test2 - out2) < 1e-11
     lmul_obs_noise_cov_inv!(out1, observation_series, Xvec, g_idx)
     lmul_obs_noise_cov_inv!(out2, observation_series, X, g_idx)
-    @test norm(test1 - out1) < 1e-12
-    @test norm(test2 - out2) < 1e-12
+    @test norm(test1 - out1) < 1e-11
+    @test norm(test2 - out2) < 1e-11
 
 end

--- a/test/SparseInversion/runtests.jl
+++ b/test/SparseInversion/runtests.jl
@@ -124,7 +124,8 @@ include("../EnsembleKalmanProcess/inverse_problem.jl")
         @test get_u(ekiobj) == u_i_vec
         @test isequal(get_g(ekiobj), g_ens_vec)
         @test isequal(get_g_final(ekiobj), g_ens_vec[end])
-        @test isequal(get_error(ekiobj), ekiobj.error)
+        @test isequal(get_error_metrics(ekiobj), ekiobj.error_metrics)
+        @test isequal(get_error(ekiobj), get_error_metrics(ekiobj)["loss"])
 
         # EKI results: Test if ensemble has collapsed toward the true constrained parameter
         # values


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #483 
Closes #488
Also relates to the plotting in #476 


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Bugfix for producing NaNs when computing an error with NaN outputs (even with successful failure handling)

- Add new metrics, that are weighted by the dimension:
  1. `compute_loss_at_mean` (current logic from `compute_error!` )
  2. `compute_unweighted_loss_at_mean` (g_mean- y)' (g_mean - y)
  3. `compute_average_rmse` (average of cov-weighted rmse taken across the ensemble)
  4. `compute_average_unweighted_rmse` (average of unweighted rmse taken across the ensemble)
  5. `compute_bayesian_loss_at_mean` (loss at mean + prior contribution (from provided prior or estimated from initial ensemble)
  6. `compute_crps` (Gaussian-approximated continuous rank probability score for ensemble vs observation)
  
- UKI/UTKI variants have an equivalent metric, based on RMSEs at the mean output
- Improved docstrings for each error metric
- Errors stored in a Dict(String => Vector), and the each key stores a vector of the loss over iterations for easy plotting. users can use `get_error_metrics(ekp)` to access it.
- `get_error(ekp)` is partially back-compatible. In that it provides a scalar error representing the loss. It is also however improved, as it forwards to  correct loss given the EKP setting 
  - `get_error_metrics(ekp)["loss"]` when a prior is not given to the `process` (e.g. finite-time EKI/ETKI) and 
  - `get_error_metrics(ekp)["bayes_loss"]` when a prior is given to the `process` (e.g. infinite-time EKI/ETKI).

## Misc
- Discovered and fixed a bug in computing perturbations for CRPS for UKI/UTKI

## Example `example/Sinusoid`
1. Using `process=Inversion()`, 13 iterations. This process should reduce `"loss"`
```julia
julia> include("sinusoid_example.jl")

julia> get_error_metrics(ensemble_kalman_process)
Dict{String, Vector{Float64}} with 6 entries:
  "unweighted_loss"     => [69.1456, 49.6655, 33.0124, 20.4544, 11.7644, 5.91676, 2.60022, 1.04942, 0.417976, 0.213258, 0.181816, 0.161086, 0.118961]
  "crps"                => [6.47563, 5.7199, 4.86653, 3.91176, 2.83024, 1.70136, 1.36855, 0.868623, 0.504935, 0.362328, 0.388109, 0.325745, 0.240063]
  "bayes_loss"          => [345.835, 248.791, 166.169, 104.38, 62.5483, 35.5328, 21.4513, 16.1228, 15.2505, 15.8957, 16.9484, 17.8264, 18.4198]
  "unweighted_avg_rmse" => [8.34082, 7.0818, 5.79068, 4.57407, 3.4754, 2.46218, 1.62662, 1.02805, 0.646614, 0.465264, 0.428847, 0.402579, 0.345853]
  "avg_rmse"            => [60.3547, 51.1518, 41.6872, 32.7869, 24.8117, 17.5381, 11.5702, 7.30873, 4.59192, 3.29483, 3.06226, 2.89297, 2.49272]
  "loss"                => [691.456, 496.655, 330.124, 204.544, 117.644, 59.1676, 26.0022, 10.4942, 4.17976, 2.13258, 1.81816, 1.61086, 1.18961]


julia> get_error(ensemble_kalman_process) # gives `loss`
13-element Vector{Float64}:
 691.455946205919
 496.65480995017833
 330.124289885421
 204.5444126630253
 117.64367383515089
  59.16761531429667
  26.002243030566532
  10.49419105983456
   4.1797585437794345
   2.1325780841256634
   1.818157342011685
   1.6108566293724835
   1.1896067437257485

```
2. Using `process=Inversion(prior)` 13 iterations. This process should reduce `"bayes_loss"`
```julia
julia> include("sinusoid_example.jl")

julia> get_error_metrics(ensemble_kalman_process)
Dict{String, Vector{Float64}} with 6 entries:
  "unweighted_loss"     => [62.6414, 44.2368, 28.7705, 17.3569, 9.64601, 4.64228, 1.93026, 0.729346, 0.274598, 0.149348, 0.133868, 0.107143, 0.0693921]
  "crps"                => [6.06003, 5.31783, 4.4883, 3.57094, 2.53623, 1.47929, 1.21173, 0.690579, 0.454465, 0.332177, 0.317357, 0.240577, 0.164274]
  "bayes_loss"          => [313.277, 221.203, 143.906, 86.9125, 48.432, 23.4981, 10.0379, 4.13831, 1.96701, 1.40926, 1.38771, 1.30156, 1.15324]
  "unweighted_avg_rmse" => [7.9393, 6.685, 5.40876, 4.21771, 3.15111, 2.18348, 1.40218, 0.856602, 0.524561, 0.390978, 0.368237, 0.328633, 0.265003]
  "avg_rmse"            => [57.5975, 48.4046, 39.0219, 30.284, 22.5248, 15.5684, 9.98219, 6.09489, 3.72416, 2.77685, 2.64788, 2.38016, 1.92458]
  "loss"                => [626.414, 442.368, 287.705, 173.569, 96.4601, 46.4228, 19.3026, 7.29346, 2.74598, 1.49348, 1.33868, 1.07143, 0.693921]


julia> get_error(ensemble_kalman_process) # returns `bayes_loss`
13-element Vector{Float64}:
 313.27711996240464
 221.20309728020672
 143.9064911629231
  86.91249446523096
  48.43199265347761
  23.498054398930957
  10.037934710569187
   4.1383112427963376
   1.9670068960544698
   1.4092630164147009
   1.387708968670417
   1.3015596731263703
   1.1532354014187622
```

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
