### PR TITLE
Update GaussianRandomFields compat, remove Plots dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnsembleKalmanProcesses"
 uuid = "aa8a2aa5-91d8-4396-bcef-d4f2ec43552d"
 authors = ["CLIMA contributors <clima-software@caltech.edu>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
@@ -28,7 +28,7 @@ Convex = "0.15, 0.16"
 Distributions = "0.24.14, 0.25"
 DocStringExtensions = "0.8, 0.9"
 FFMPEG = "0.4"
-GaussianRandomFields = "2"
+GaussianRandomFields = "2.2.6"
 Interpolations = "0.13, 0.14, 0.15"
 LinearAlgebra = "1"
 MathOptInterface = "1"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR removes the implicit dependency on Plots.jl by using the newest GaussianRandomFields release.
```
(EnsembleKalmanProcesses) pkg> st GaussianRandomFields
Project EnsembleKalmanProcesses v2.4.0
Status `~/clima/EnsembleKalmanProcesses.jl/Project.toml`
  [e4b2fa32] GaussianRandomFields v2.2.5

(EnsembleKalmanProcesses) pkg> why Plots
  GaussianRandomFields → Plots
```
Strictly speaking, we don’t need to restrict compatibility, I could manually ensure that I am using GaussianRandomFields 2.2.6 in my workflow. However, I’d prefer to enforce this constraint to prevent Plots from accidentally becoming a dependency, which helps reduce compilation time.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
