### PR TITLE
New getters for observations etc.

### DIFF
--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -4,14 +4,24 @@
 CurrentModule = EnsembleKalmanProcesses
 ```
 
+## Primary objects and functions
 ```@docs
 EnsembleKalmanProcess
-FailureHandler
-SampleSuccGauss
-IgnoreFailures
+construct_initial_ensemble
+update_ensemble!
+```
+## Getter functions
+
+```@docs
 get_u
 get_g
 get_ϕ
+get_obs(ekp::EnsembleKalmanProcess)
+get_obs(ekp::EnsembleKalmanProcess, iteration)
+get_obs_noise_cov(ekp::EnsembleKalmanProcess)
+get_obs_noise_cov(ekp::EnsembleKalmanProcess, iteration)
+get_obs_noise_cov_inv(ekp::EnsembleKalmanProcess)
+get_obs_noise_cov_inv(ekp::EnsembleKalmanProcess, iteration)
 get_u_final
 get_g_final
 get_ϕ_final
@@ -35,14 +45,8 @@ get_localizer
 get_localizer_type
 get_nan_tolerance
 get_nan_row_values
-construct_initial_ensemble
-update_ensemble!
-sample_empirical_gaussian
-split_indices_by_success
-impute_over_nans
 list_update_groups_over_minibatch
 ```
-
 ## [Error metrics](@id errors_api)
 
 ```@docs
@@ -55,7 +59,10 @@ compute_crps
 compute_error!
 get_error_metrics
 get_error
-
+lmul_obs_noise_cov,
+lmul_obs_noise_cov_inv,
+lmul_obs_noise_cov!,
+lmul_obs_noise_cov_inv!
 ```
 ## [Learning Rate Schedulers](@id scheduler_api)
 
@@ -66,7 +73,16 @@ EKSStableScheduler
 DataMisfitController
 calculate_timestep!
 ```
+## Failure and NaN handling 
 
+```@docs
+FailureHandler
+SampleSuccGauss
+IgnoreFailures
+sample_empirical_gaussian
+split_indices_by_success
+impute_over_nans
+```
 
 ## [Process-specific](@id process_api)
 ```@docs

--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -59,9 +59,9 @@ compute_crps
 compute_error!
 get_error_metrics
 get_error
-lmul_obs_noise_cov,
-lmul_obs_noise_cov_inv,
-lmul_obs_noise_cov!,
+lmul_obs_noise_cov
+lmul_obs_noise_cov_inv
+lmul_obs_noise_cov!
 lmul_obs_noise_cov_inv!
 ```
 ## [Learning Rate Schedulers](@id scheduler_api)

--- a/docs/src/API/Observations.md
+++ b/docs/src/API/Observations.md
@@ -55,7 +55,7 @@ update_minibatch!(os::OS) where {OS <: ObservationSeries}
 get_minibatch
 get_current_minibatch(os::OS) where {OS <: ObservationSeries}
 get_obs(os::OS) where {OS <: ObservationSeries}
-get_obs(os::OS, iteration::IorN; build = true) where {OS <: ObservationSeries, IorN <: Union{Int, Nothing}}
+get_obs(os::OS, iteration::IorN) where {OS <: ObservationSeries, IorN <: Union{Int, Nothing}}
 get_obs_noise_cov(os::OS) where {OS <: ObservationSeries}
 get_obs_noise_cov(os::OS, iteration::IorN) where {OS <: ObservationSeries, IorN <: Union{Int, Nothing}}
 get_obs_noise_cov_inv(os::OS) where {OS <: ObservationSeries}

--- a/docs/src/API/Observations.md
+++ b/docs/src/API/Observations.md
@@ -45,13 +45,19 @@ get_minibatches(m::RFSM) where {RFSM <: RandomFixedSizeMinibatcher}
 ```@docs
 ObservationSeries
 get_observations(os::OS) where {OS <: ObservationSeries}
+get_length_epoch(os::OS) where {OS <: ObservationSeries}
 get_minibatches(os::OS) where {OS <: ObservationSeries}
+get_minibatch_index(os::OS, iteration) where {OS <: ObservationSeries}
 get_current_minibatch_index(os::OS) where {OS <: ObservationSeries}
 get_minibatcher(os::OS) where {OS <: ObservationSeries}
 get_metadata
 update_minibatch!(os::OS) where {OS <: ObservationSeries}
+get_minibatch(os::OS, iteration) where {OS <: ObservationSeries}
 get_current_minibatch(os::OS) where {OS <: ObservationSeries}
 get_obs(os::OS) where {OS <: ObservationSeries}
+get_obs(os::OS, iteration) where {OS <: ObservationSeries}
 get_obs_noise_cov(os::OS) where {OS <: ObservationSeries}
+get_obs_noise_cov(os::OS, iteration) where {OS <: ObservationSeries}
 get_obs_noise_cov_inv(os::OS) where {OS <: ObservationSeries}
+get_obs_noise_cov_inv(os::OS, iteration) where {OS <: ObservationSeries}
 ```

--- a/docs/src/API/Observations.md
+++ b/docs/src/API/Observations.md
@@ -47,17 +47,17 @@ ObservationSeries
 get_observations(os::OS) where {OS <: ObservationSeries}
 get_length_epoch(os::OS) where {OS <: ObservationSeries}
 get_minibatches(os::OS) where {OS <: ObservationSeries}
-get_minibatch_index(os::OS, iteration) where {OS <: ObservationSeries}
+get_minibatch_index
 get_current_minibatch_index(os::OS) where {OS <: ObservationSeries}
 get_minibatcher(os::OS) where {OS <: ObservationSeries}
 get_metadata
 update_minibatch!(os::OS) where {OS <: ObservationSeries}
-get_minibatch(os::OS, iteration) where {OS <: ObservationSeries}
+get_minibatch
 get_current_minibatch(os::OS) where {OS <: ObservationSeries}
 get_obs(os::OS) where {OS <: ObservationSeries}
-get_obs(os::OS, iteration) where {OS <: ObservationSeries}
+get_obs(os::OS, iteration::IorN; build = true) where {OS <: ObservationSeries, IorN <: Union{Int, Nothing}}
 get_obs_noise_cov(os::OS) where {OS <: ObservationSeries}
-get_obs_noise_cov(os::OS, iteration) where {OS <: ObservationSeries}
+get_obs_noise_cov(os::OS, iteration::IorN) where {OS <: ObservationSeries, IorN <: Union{Int, Nothing}}
 get_obs_noise_cov_inv(os::OS) where {OS <: ObservationSeries}
-get_obs_noise_cov_inv(os::OS, iteration) where {OS <: ObservationSeries}
+get_obs_noise_cov_inv(os::OS, iteration::IorN) where {OS <: ObservationSeries, IorN <: Union{Int, Nothing}}
 ```

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -770,7 +770,7 @@ build=false:, returns a vector of blocks,
 build=true: returns a block matrix,
 """
 function get_obs_noise_cov_inv(ekp::EnsembleKalmanProcess; build = true)
-    return get_obs_noise_cov_inv(get_observation_series(ekp), build = build)
+    return get_obs_noise_cov_inv(get_observation_series(ekp); build = build)
 end
 
 """
@@ -856,7 +856,7 @@ build=false: returns a vector of vectors,
 build=true: returns a concatenated vector,
 """
 function get_obs(ekp::EnsembleKalmanProcess, iteration; build = true)
-    return get_obs(get_observation_series(ekp, iteration), build = build)
+    return get_obs(get_observation_series(ekp), iteration; build = build)
 end
 
 

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -22,7 +22,15 @@ export get_u_mean, get_u_cov, get_g_mean, get_ϕ_mean
 export get_u_mean_final, get_u_cov_prior, get_u_cov_final, get_g_mean_final, get_ϕ_mean_final
 
 export get_scheduler,
-    get_localizer, get_localizer_type, get_accelerator, get_rng, get_Δt, get_failure_handler, get_N_ens, get_process
+    get_localizer,
+    get_localizer_type,
+    get_accelerator,
+    get_rng,
+    get_Δt,
+    get_algorithm_time,
+    get_failure_handler,
+    get_N_ens,
+    get_process
 export get_nan_tolerance, get_nan_row_values
 export get_observation_series,
     get_obs,
@@ -608,10 +616,19 @@ end
 
 """
     get_Δt(ekp::EnsembleKalmanProcess)
-Return `Δt` field of EnsembleKalmanProcess.
+Return `Δt` field of EnsembleKalmanProcess. 
 """
 function get_Δt(ekp::EnsembleKalmanProcess)
     return ekp.Δt
+end
+
+"""
+$(TYPEDSIGNATURES) 
+
+Get the accumulated Δt over iterations, also known as algorithm- or pseudo-time.
+"""
+function get_algorithm_time(ekp::EnsembleKalmanProcess)
+    return [sum(get_Δt(ekp)[1:i]) for i in 1:length(get_Δt(ekp))]
 end
 
 """
@@ -724,23 +741,47 @@ function get_observation_series(ekp::EnsembleKalmanProcess)
 end
 
 """
-    get_obs_noise_cov(ekp::EnsembleKalmanProcess; build=true)
-convenience function to get the obs_noise_cov from the current batch in ObservationSeries
+$(TYPEDSIGNATURES)
+
+Get the `obs_noise_cov` from the current batch in `ObservationSeries`
 build=false:, returns a vector of blocks,
 build=true: returns a block matrix,
 """
 function get_obs_noise_cov(ekp::EnsembleKalmanProcess; build = true)
-    return get_obs_noise_cov(get_observation_series(ekp), build = build)
+    return get_obs_noise_cov(get_observation_series(ekp); build = build)
 end
 
 """
-    get_obs_noise_cov_inv(ekp::EnsembleKalmanProcess; build=true)
-convenience function to get the obs_noise_cov (inverse) from the current batch in ObservationSeries
+$(TYPEDSIGNATURES)
+
+Get the `obs_noise_cov` for `iteration` from the `ObservationSeries`
+build=false:, returns a vector of blocks,
+build=true: returns a block matrix,
+"""
+function get_obs_noise_cov(ekp::EnsembleKalmanProcess, iteration; build = true)
+    return get_obs_noise_cov(get_observation_series(ekp), iteration; build = build)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Get the `obs_noise_cov` inverse from the current batch in `ObservationSeries`
 build=false:, returns a vector of blocks,
 build=true: returns a block matrix,
 """
 function get_obs_noise_cov_inv(ekp::EnsembleKalmanProcess; build = true)
     return get_obs_noise_cov_inv(get_observation_series(ekp), build = build)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Get the obs_noise_cov inverse for `iteration` from the `ObservationSeries`
+build=false:, returns a vector of blocks,
+build=true: returns a block matrix,
+"""
+function get_obs_noise_cov_inv(ekp::EnsembleKalmanProcess, iteration; build = true)
+    return get_obs_noise_cov_inv(get_observation_series(ekp), iteration; build = build)
 end
 
 """
@@ -797,14 +838,27 @@ function lmul_obs_noise_cov_inv!(
 end
 
 """
-    get_obs(ekp::EnsembleKalmanProcess; build=true)
-Get the observation from the current batch in ObservationSeries
+$(TYPEDSIGNATURES)
+
+Get the observation from the current batch in `ObservationSeries`
 build=false: returns a vector of vectors,
 build=true: returns a concatenated vector,
 """
 function get_obs(ekp::EnsembleKalmanProcess; build = true)
-    return get_obs(get_observation_series(ekp), build = build)
+    return get_obs(get_observation_series(ekp); build = build)
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Get the observation for `iteration` from the `ObservationSeries`
+build=false: returns a vector of vectors,
+build=true: returns a concatenated vector,
+"""
+function get_obs(ekp::EnsembleKalmanProcess, iteration; build = true)
+    return get_obs(get_observation_series(ekp, iteration), build = build)
+end
+
 
 """
     update_minibatch!(ekp::EnsembleKalmanProcess)

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -628,7 +628,7 @@ $(TYPEDSIGNATURES)
 Get the accumulated Δt over iterations, also known as algorithm- or pseudo-time.
 """
 function get_algorithm_time(ekp::EnsembleKalmanProcess)
-    return [sum(get_Δt(ekp)[1:i]) for i in 1:length(get_Δt(ekp))]
+    return accumulate(+, get_Δt(ekp))
 end
 
 """

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -25,10 +25,13 @@ export get_samples,
     get_method,
     get_rng,
     get_minibatch_size,
+    get_length_epoch,
     get_observations,
+    get_minibatch_index,
     get_current_minibatch_index,
     get_minibatcher,
     update_minibatch!,
+    get_minibatch,
     get_current_minibatch,
     no_minibatcher,
     tsvd_mat,
@@ -1060,15 +1063,34 @@ end
 """
 $(TYPEDSIGNATURES)
 
+gets the number of minibatches in an epoch
+"""
+function get_length_epoch(os::OS) where {OS <: ObservationSeries}
+    return length(get_minibatches(os)[1])
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+returns the minibatch_index `Dict("epoch"=> x, "minibatch" => y)`, for a given `iteration` 
+"""
+function get_minibatch_index(os::OS, iteration::Int) where {OS <: ObservationSeries}
+    len_epoch = get_length_epoch(os)
+    return Dict("epoch" => iteration ÷ len_epoch, "minibatch" => iteration % len_epoch)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
 Within an epoch: iterates the current minibatch index by one.
 At the end of an epoch: obtains a new epoch of minibatches from the `Minibatcher` updates the epoch index by one, and minibatch index to one.
 """
 function update_minibatch!(os::OS) where {OS <: ObservationSeries}
     index = get_current_minibatch_index(os)
-    minibatches_in_epoch = get_minibatches(os)[index["epoch"]]
+    len_epoch = get_length_epoch(os)
 
     # take new batch
-    if length(minibatches_in_epoch) >= index["minibatch"] + 1
+    if len_epoch >= index["minibatch"] + 1
         index["minibatch"] += 1 #update by 1
     else
         index["minibatch"] = 1 # set to 1
@@ -1078,7 +1100,23 @@ function update_minibatch!(os::OS) where {OS <: ObservationSeries}
         new_epoch = create_new_epoch!(minibatcher, collect(1:length(get_observations(os)))) # create a new sweep of minibatches
         push!(minibatches, new_epoch)
     end
+end
 
+"""
+$(TYPEDSIGNATURES)
+
+get the minibatch for a given minibatch index (`Dict("epoch"=> x, "minibatch" => y)`), or iteration `Int`. If `nothing` is provided as an iteration then the current minibatch is returned
+"""
+function get_minibatch(os::IS, it_or_mbi::IorDorN) where {OS <: ObservationSeries, IorD <: Union{Int, Dict, Nothing}}
+    if isnothing(it_or_mbi)
+        return get_current_minibatch(os)
+    else
+        index = isa(int_or_dict, Dict) ? it_or_mbi : get_minibatch_index(os, it_or_mbi)
+        minibatches = get_minibatches(os)
+        epoch = index["epoch"]
+        mini = index["minibatch"]
+        return minibatches[epoch][mini]
+    end
 end
 
 # stored as vector of vectors
@@ -1096,10 +1134,10 @@ end
 """
 $(TYPEDSIGNATURES)
 
-if `build=true` then gets the observed sample, stacked over the current minibatch. `build=false` lists the `samples` for all observations 
+if `build=true` then gets the observed sample, stacked over the minibatch at `iteration`. `build=false` lists the `samples` for all observations. If `isnothing(iteration)` or not defined then the current iteration is used.
 """
-function get_obs(os::OS; build = true) where {OS <: ObservationSeries}
-    minibatch = get_current_minibatch(os) # gives the indices of the minibatch
+function get_obs(os::OS, iteration; build = true) where {OS <: ObservationSeries}
+    minibatch = get_minibatch(os, iteration)
     minibatch_length = length(minibatch)
     observations_vec = get_observations(os)[minibatch] # gives observation objects
     if minibatch_length == 1
@@ -1123,10 +1161,18 @@ end
 """
 $(TYPEDSIGNATURES)
 
-if `build=true` then gets the observation covariance matrix, blocked over the current minibatch. `build=false` lists the `covs` for all observations 
+if `build=true` then gets the observed sample, stacked over the current minibatch. `build=false` lists the `samples` for all observations. 
 """
-function get_obs_noise_cov(os::OS; build = true) where {OS <: ObservationSeries}
-    minibatch = get_current_minibatch(os) # gives the indices of the minibatch
+get_obs(os::OS; kwargs...) = get_obs(os, nothing; kwargs...)
+
+
+"""
+$(TYPEDSIGNATURES)
+
+if `build=true` then gets the observation covariance matrix, blocked over the minibatch at `iteration`. `build=false` lists the `covs` for all observations. If `isnothing(iteration)` or not defined then the current iteration is used.
+"""
+function get_obs_noise_cov(os::OS, iteration; build = true) where {OS <: ObservationSeries}
+    minibatch = get_minibatch(os, iteration)
     minibatch_length = length(minibatch)
     observations_vec = get_observations(os)[minibatch] # gives observation objects
     if minibatch_length == 1 # if only 1 sample then return it
@@ -1157,10 +1203,18 @@ end
 """
 $(TYPEDSIGNATURES)
 
-if `build=true` then gets the inverse of the observation covariance matrix, blocked over the current minibatch. `build=false` lists the `inv_covs` for all observations 
+if `build=true` then gets the observation covariance matrix, blocked over the current minibatch. `build=false` lists the `covs` for all observations 
+"""
+get_obs_noise_cov(os::OS; kwargs...) = get_obs_noise_cov(os, nothing; kwargs...)
+
+
+"""
+$(TYPEDSIGNATURES)
+
+if `build=true` then gets the inverse of the observation covariance matrix, blocked over minibatch at `iteration`. `build=false` lists the `inv_covs` for all observations. If `isnothing(iteration)` or not defined then the current iteration is used.
 """
 function get_obs_noise_cov_inv(os::OS; build = true) where {OS <: ObservationSeries}
-    minibatch = get_current_minibatch(os) # gives the indices of the minibatch
+    minibatch = get_minibatch(os, iteration)
     minibatch_length = length(minibatch)
     observations_vec = get_observations(os)[minibatch] # gives observation objects
     if minibatch_length == 1 # if only 1 sample then return it
@@ -1187,6 +1241,13 @@ function get_obs_noise_cov_inv(os::OS; build = true) where {OS <: ObservationSer
     end
 
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+if `build=true` then gets the inverse of the observation covariance matrix, blocked over the current minibatch. `build=false` lists the `inv_covs` for all observations. 
+"""
+get_obs_noise_cov_inv(os::OS; kwargs...) = get_obs_noise_cov_inv(os, nothing; kwargs...)
 
 
 get_cov_size(am::AM) where {AM <: AbstractMatrix} = size(am, 1)

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -1076,7 +1076,7 @@ returns the minibatch_index `Dict("epoch"=> x, "minibatch" => y)`, for a given `
 """
 function get_minibatch_index(os::OS, iteration::Int) where {OS <: ObservationSeries}
     len_epoch = get_length_epoch(os)
-    return Dict("epoch" => iteration ÷ len_epoch, "minibatch" => iteration % len_epoch)
+    return Dict("epoch" => ((iteration - 1) ÷ len_epoch) + 1, "minibatch" => ((iteration - 1) % len_epoch) + 1)
 end
 
 """
@@ -1107,11 +1107,11 @@ $(TYPEDSIGNATURES)
 
 get the minibatch for a given minibatch index (`Dict("epoch"=> x, "minibatch" => y)`), or iteration `Int`. If `nothing` is provided as an iteration then the current minibatch is returned
 """
-function get_minibatch(os::IS, it_or_mbi::IorDorN) where {OS <: ObservationSeries, IorD <: Union{Int, Dict, Nothing}}
+function get_minibatch(os::OS, it_or_mbi::IorDorN) where {OS <: ObservationSeries, IorDorN <: Union{Int, Dict, Nothing}}
     if isnothing(it_or_mbi)
         return get_current_minibatch(os)
     else
-        index = isa(int_or_dict, Dict) ? it_or_mbi : get_minibatch_index(os, it_or_mbi)
+        index = isa(it_or_mbi, Dict) ? it_or_mbi : get_minibatch_index(os, it_or_mbi)
         minibatches = get_minibatches(os)
         epoch = index["epoch"]
         mini = index["minibatch"]
@@ -1136,7 +1136,7 @@ $(TYPEDSIGNATURES)
 
 if `build=true` then gets the observed sample, stacked over the minibatch at `iteration`. `build=false` lists the `samples` for all observations. If `isnothing(iteration)` or not defined then the current iteration is used.
 """
-function get_obs(os::OS, iteration; build = true) where {OS <: ObservationSeries}
+function get_obs(os::OS, iteration::IorN; build = true) where {OS <: ObservationSeries, IorN <: Union{Int, Nothing}}
     minibatch = get_minibatch(os, iteration)
     minibatch_length = length(minibatch)
     observations_vec = get_observations(os)[minibatch] # gives observation objects
@@ -1163,7 +1163,7 @@ $(TYPEDSIGNATURES)
 
 if `build=true` then gets the observed sample, stacked over the current minibatch. `build=false` lists the `samples` for all observations. 
 """
-get_obs(os::OS; kwargs...) = get_obs(os, nothing; kwargs...)
+get_obs(os::OS; kwargs...) where {OS <: ObservationSeries} = get_obs(os, nothing; kwargs...)
 
 
 """
@@ -1171,7 +1171,11 @@ $(TYPEDSIGNATURES)
 
 if `build=true` then gets the observation covariance matrix, blocked over the minibatch at `iteration`. `build=false` lists the `covs` for all observations. If `isnothing(iteration)` or not defined then the current iteration is used.
 """
-function get_obs_noise_cov(os::OS, iteration; build = true) where {OS <: ObservationSeries}
+function get_obs_noise_cov(
+    os::OS,
+    iteration::IorN;
+    build = true,
+) where {OS <: ObservationSeries, IorN <: Union{Int, Nothing}}
     minibatch = get_minibatch(os, iteration)
     minibatch_length = length(minibatch)
     observations_vec = get_observations(os)[minibatch] # gives observation objects
@@ -1205,7 +1209,7 @@ $(TYPEDSIGNATURES)
 
 if `build=true` then gets the observation covariance matrix, blocked over the current minibatch. `build=false` lists the `covs` for all observations 
 """
-get_obs_noise_cov(os::OS; kwargs...) = get_obs_noise_cov(os, nothing; kwargs...)
+get_obs_noise_cov(os::OS; kwargs...) where {OS <: ObservationSeries} = get_obs_noise_cov(os, nothing; kwargs...)
 
 
 """
@@ -1213,7 +1217,11 @@ $(TYPEDSIGNATURES)
 
 if `build=true` then gets the inverse of the observation covariance matrix, blocked over minibatch at `iteration`. `build=false` lists the `inv_covs` for all observations. If `isnothing(iteration)` or not defined then the current iteration is used.
 """
-function get_obs_noise_cov_inv(os::OS; build = true) where {OS <: ObservationSeries}
+function get_obs_noise_cov_inv(
+    os::OS,
+    iteration::IorN;
+    build = true,
+) where {OS <: ObservationSeries, IorN <: Union{Int, Nothing}}
     minibatch = get_minibatch(os, iteration)
     minibatch_length = length(minibatch)
     observations_vec = get_observations(os)[minibatch] # gives observation objects
@@ -1247,7 +1255,7 @@ $(TYPEDSIGNATURES)
 
 if `build=true` then gets the inverse of the observation covariance matrix, blocked over the current minibatch. `build=false` lists the `inv_covs` for all observations. 
 """
-get_obs_noise_cov_inv(os::OS; kwargs...) = get_obs_noise_cov_inv(os, nothing; kwargs...)
+get_obs_noise_cov_inv(os::OS; kwargs...) where {OS <: ObservationSeries} = get_obs_noise_cov_inv(os, nothing; kwargs...)
 
 
 get_cov_size(am::AM) where {AM <: AbstractMatrix} = size(am, 1)

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -725,8 +725,8 @@ end
         end
         push!(u_i_vec, get_u_final(ekiobj))
 
-        dt = get_Δt(ekp)
-        algtime = get_algorithm_time(ekp)
+        dt = get_Δt(ekiobj)
+        algtime = get_algorithm_time(ekiobj)
         @test algtime == [sum(dt[1:i]) for i in 1:length(dt)]
 
         @test get_u_prior(ekiobj) == u_i_vec[1]

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -626,6 +626,9 @@ end
         ## some getters in EKP
         @test get_obs(ekiobj) == y_obs
         @test get_obs_noise_cov(ekiobj) == Γy
+        @test get_obs(ekiobj, 1) == y_obs
+        @test get_obs_noise_cov(ekiobj, 1) == Γy
+        @test get_obs_noise_cov_inv(ekiobj) == get_obs_noise_cov_inv(ekiobj, 1)
 
         g_ens = G(get_ϕ_final(prior, ekiobj))
         g_ens_t = permutedims(g_ens, (2, 1))

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -725,9 +725,8 @@ end
         end
         push!(u_i_vec, get_u_final(ekiobj))
 
-        dt = get_Δt(ekiobj)
         algtime = get_algorithm_time(ekiobj)
-        @test algtime == [sum(dt[1:i]) for i in 1:length(dt)]
+        @test algtime == accumulate(+, get_Δt(ekiobj))
 
         @test get_u_prior(ekiobj) == u_i_vec[1]
         @test get_u(ekiobj) == u_i_vec

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -727,8 +727,8 @@ end
 
         dt = get_Δt(ekp)
         algtime = get_algorithm_time(ekp)
-        @test algtime == [sum(dt[1:i]) for i = 1:length(dt)]
-        
+        @test algtime == [sum(dt[1:i]) for i in 1:length(dt)]
+
         @test get_u_prior(ekiobj) == u_i_vec[1]
         @test get_u(ekiobj) == u_i_vec
         @test isequal(get_g(ekiobj), g_ens_vec)
@@ -739,8 +739,8 @@ end
         @test isequal(get_error(ekiobj), get_error_metrics(ekiobj)["loss"])
         @test isequal(get_error(ekiobj_inf), get_error_metrics(ekiobj_inf)["bayes_loss"])
 
-        
-        
+
+
         # EKI results: Test if ensemble has collapsed toward the true parameter 
         # values
         eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -725,6 +725,10 @@ end
         end
         push!(u_i_vec, get_u_final(ekiobj))
 
+        dt = get_Δt(ekp)
+        algtime = get_algorithm_time(ekp)
+        @test algtime == [sum(dt[1:i]) for i = 1:length(dt)]
+        
         @test get_u_prior(ekiobj) == u_i_vec[1]
         @test get_u(ekiobj) == u_i_vec
         @test isequal(get_g(ekiobj), g_ens_vec)
@@ -735,6 +739,8 @@ end
         @test isequal(get_error(ekiobj), get_error_metrics(ekiobj)["loss"])
         @test isequal(get_error(ekiobj_inf), get_error_metrics(ekiobj_inf)["bayes_loss"])
 
+        
+        
         # EKI results: Test if ensemble has collapsed toward the true parameter 
         # values
         eki_init_result = vec(mean(get_u_prior(ekiobj), dims = 2))


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Closes #487 


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- added optional `iteration` in getters for observation (e.g., `get_obs(ekp, iteration)` ) also for `get_obs_noise_cov` and `get_obs_noise_cov_inv`
- added some utilities such as `get_minibatch_index(observation_series, iteration)` to also get observations from `iteration`
- added `get_algorithm_time` with accumulates the `get_[\Delta]t(ekp)`
- Unit tests and API docs

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
