### PR TITLE
Add Metadata to `Observation` object

### DIFF
--- a/docs/src/API/Observations.md
+++ b/docs/src/API/Observations.md
@@ -11,6 +11,7 @@ get_covs
 get_inv_covs
 get_names
 get_indices
+get_metadata(o::OB) where {OB <: Observation}
 combine_observations
 get_obs(o::OB) where {OB <: Observation}
 get_obs_noise_cov(o::OB) where {OB <: Observation}
@@ -50,7 +51,7 @@ get_minibatches(os::OS) where {OS <: ObservationSeries}
 get_minibatch_index
 get_current_minibatch_index(os::OS) where {OS <: ObservationSeries}
 get_minibatcher(os::OS) where {OS <: ObservationSeries}
-get_metadata
+get_metadata(os::OS) where {OS <: ObservationSeries}
 update_minibatch!(os::OS) where {OS <: ObservationSeries}
 get_minibatch
 get_current_minibatch(os::OS) where {OS <: ObservationSeries}

--- a/docs/src/observations.md
+++ b/docs/src/observations.md
@@ -94,6 +94,7 @@ for k = 1:100
             "samples" => rand(MvNormal(y,cov_y)),
             "covariances" => cov_y,
             "names" => "y_$k",
+            "metadata" => "optional metadata information in any format",
         ),
     )
 
@@ -102,6 +103,7 @@ for k = 1:100
             "samples" => rand(MvNormal(z,cov_z)),
             "covariances" => cov_z,
             "names" => "z_$k",
+            "metadata" => "optional metadata information in any format",
         ),
     )
     push!(hundred_full_obs, combine_observations([y_obs,z_obs]))

--- a/docs/src/observations.md
+++ b/docs/src/observations.md
@@ -38,6 +38,7 @@ y_obs = Observation(
         "samples" => y,
         "covariances" => cov_y,
         "names" => "y",
+        "metadata" => "optional metadata information in any format",
     ),
 )
 
@@ -46,6 +47,7 @@ z_obs = Observation(
         "samples" => z,
         "covariances" => cov_z,
         "names" => "z",
+        "metadata" => "optional metadata information in any format",
     ),
 )
 
@@ -67,6 +69,10 @@ There are some other fields stored such as indices of the `y` and `z` components
 ```@example ex1
 get_indices(full_obs) # returns [1:ydim, ydim+1:ydim+zdim]
 ```
+```@example ex1
+get_metadata(full_obs) # combined metadata
+```
+
 
 ## Recommended constructor: Many stacked observations
 

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -284,6 +284,9 @@ struct Observation{
     names::AV4
     "A (vector of) indices of the contained observation blocks"
     indices::AV5
+    "Metadata of any type that the user can group with the Observation"
+    metadata::MD
+
 end
 
 """
@@ -321,7 +324,14 @@ gets the `indices` field from the `Observation` object
 """
 get_indices(o::Observation) = o.indices
 
-function Observation(obs_dict::Dict)
+"""
+$(TYPEDSIGNATURES)
+
+gets the `metadata` field from the `Observation` object
+"""
+get_metadata(o::Observation) = o.metadata
+
+function Observation(obs_dict::Dict; metadata = nothing)
     if !all(["samples", "names", "covariances"] .∈ [collect(keys(obs_dict))])
         throw(
             ArgumentError(
@@ -410,28 +420,37 @@ function Observation(obs_dict::Dict)
         end
     end
 
-    return Observation(snew, cnew, icnew, nnew, indices)
+    # metadata - if multiple provided, dict-stored > keyword
+    if "metadata" ∈ collect(keys(obs_dict))
+        mnew = obs_dict["metadata"]
+    else
+        mnew = metadata
+    end
+    
+    return Observation(snew, cnew, icnew, nnew, indices, mnew)
 
 end
 
 function Observation(
     sample::AV,
     obs_noise_cov::AMorUSorSVD,
-    name::AS,
+    name::AS;
+    kwargs...
 ) where {
     AV <: AbstractVector,
     AMorUSorSVD <: Union{AbstractMatrix, UniformScaling, SVD, SumOfCovariances},
     AS <: AbstractString,
 }
-    return Observation(Dict("samples" => sample, "covariances" => obs_noise_cov, "names" => name))
+    return Observation(Dict("samples" => sample, "covariances" => obs_noise_cov, "names" => name); kwargs...)
 end
 
 function Observation(
     samples::AV1,
     obs_noise_covs::AV2,
-    names::AV3,
+    names::AV3;
+    kwargs...
 ) where {AV1 <: AbstractVector, AV2 <: AbstractVector, AV3 <: AbstractVector}
-    return Observation(Dict("samples" => samples, "covariances" => obs_noise_covs, "names" => names))
+    return Observation(Dict("samples" => samples, "covariances" => obs_noise_covs, "names" => names), kwargs...)
 end
 
 
@@ -449,6 +468,7 @@ function combine_observations(obs_vec::AV) where {AV <: AbstractVector}
     icnew = []
     nnew = []
     inew = []
+    mnew = []
     shift = [0] # running shift to add to indexing 
     for obs in obs_vec
         @assert(nameof(typeof(obs)) == :Observation) # check it's a vector of Observations
@@ -460,6 +480,7 @@ function combine_observations(obs_vec::AV) where {AV <: AbstractVector}
         shifted_indices = [ind .+ shift[1] for ind in get_indices(obs)]
         append!(inew, shifted_indices)
         shift[1] = maximum(shifted_indices[end]) # increase the shift for the next "append"           
+        append!(mnew, get_metadata(obs))
     end
 
     #re-infer eltypes
@@ -473,8 +494,10 @@ function combine_observations(obs_vec::AV) where {AV <: AbstractVector}
     nnew2 = [convert(T, n) for n in nnew]
     T = promote_type((typeof(i) for i in inew)...)
     inew2 = [convert(T, i) for i in inew]
+    T = promote_type((typeof(i) for i in mnew)...)
+    mnew2 = [convert(T, i) for i in mnew]
 
-    return Observation(snew2, cnew2, icnew2, nnew2, inew2)
+    return Observation(snew2, cnew2, icnew2, nnew2, inew2, mnew2)
 end
 
 """

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -273,6 +273,7 @@ struct Observation{
     AV3 <: AbstractVector,
     AV4 <: AbstractVector,
     AV5 <: AbstractVector,
+    MD,
 }
     "A (vector of) observation vectors"
     samples::AV1
@@ -450,7 +451,7 @@ function Observation(
     names::AV3;
     kwargs...
 ) where {AV1 <: AbstractVector, AV2 <: AbstractVector, AV3 <: AbstractVector}
-    return Observation(Dict("samples" => samples, "covariances" => obs_noise_covs, "names" => names), kwargs...)
+    return Observation(Dict("samples" => samples, "covariances" => obs_noise_covs, "names" => names); kwargs...)
 end
 
 
@@ -480,7 +481,13 @@ function combine_observations(obs_vec::AV) where {AV <: AbstractVector}
         shifted_indices = [ind .+ shift[1] for ind in get_indices(obs)]
         append!(inew, shifted_indices)
         shift[1] = maximum(shifted_indices[end]) # increase the shift for the next "append"           
-        append!(mnew, get_metadata(obs))
+        md = get_metadata(obs)
+        if hasmethod(length, (typeof(md), ) ) # some types aren't appendable
+            append!(mnew, md) 
+        else
+            push!(mnew, md) 
+        end
+            
     end
 
     #re-infer eltypes

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -427,7 +427,7 @@ function Observation(obs_dict::Dict; metadata = nothing)
     else
         mnew = metadata
     end
-    
+
     return Observation(snew, cnew, icnew, nnew, indices, mnew)
 
 end
@@ -436,7 +436,7 @@ function Observation(
     sample::AV,
     obs_noise_cov::AMorUSorSVD,
     name::AS;
-    kwargs...
+    kwargs...,
 ) where {
     AV <: AbstractVector,
     AMorUSorSVD <: Union{AbstractMatrix, UniformScaling, SVD, SumOfCovariances},
@@ -449,7 +449,7 @@ function Observation(
     samples::AV1,
     obs_noise_covs::AV2,
     names::AV3;
-    kwargs...
+    kwargs...,
 ) where {AV1 <: AbstractVector, AV2 <: AbstractVector, AV3 <: AbstractVector}
     return Observation(Dict("samples" => samples, "covariances" => obs_noise_covs, "names" => names); kwargs...)
 end
@@ -482,12 +482,12 @@ function combine_observations(obs_vec::AV) where {AV <: AbstractVector}
         append!(inew, shifted_indices)
         shift[1] = maximum(shifted_indices[end]) # increase the shift for the next "append"           
         md = get_metadata(obs)
-        if hasmethod(length, (typeof(md), ) ) # some types aren't appendable
-            append!(mnew, md) 
+        if hasmethod(length, (typeof(md),)) # some types aren't appendable
+            append!(mnew, md)
         else
-            push!(mnew, md) 
+            push!(mnew, md)
         end
-            
+
     end
 
     #re-infer eltypes

--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -501,10 +501,8 @@ function combine_observations(obs_vec::AV) where {AV <: AbstractVector}
     nnew2 = [convert(T, n) for n in nnew]
     T = promote_type((typeof(i) for i in inew)...)
     inew2 = [convert(T, i) for i in inew]
-    T = promote_type((typeof(i) for i in mnew)...)
-    mnew2 = [convert(T, i) for i in mnew]
 
-    return Observation(snew2, cnew2, icnew2, nnew2, inew2, mnew2)
+    return Observation(snew2, cnew2, icnew2, nnew2, inew2, mnew)
 end
 
 """

--- a/test/Observations/runtests.jl
+++ b/test/Observations/runtests.jl
@@ -31,10 +31,11 @@ using EnsembleKalmanProcesses
             ic = I
         end
         push!(inv_covariances, ic)
+
         if (i==1)
-            metadata=nothing
+            push!(metadatas, nothing)
         else
-            metadata = Dict("example$i" => i)
+            push!(metadatas, Dict("example$i" => i))
         end
 
     end
@@ -55,7 +56,7 @@ using EnsembleKalmanProcesses
     @test get_covs(observation_1) == [covariances[1]]
     @test all(isapprox.(get_inv_covs(observation_1)[1], inv_covariances[1], atol = 1e-10)) # inversion approximate
     @test get_names(observation_1) == [names[1]]
-    @test get_indices(observation_1) == [indices[1]])
+    @test get_indices(observation_1) == [indices[1]]
     @test get_metadata(observation_1) == "test"
     
     # 2) via args [singleton] 

--- a/test/Observations/runtests.jl
+++ b/test/Observations/runtests.jl
@@ -13,6 +13,7 @@ using EnsembleKalmanProcesses
     samples = []
     covariances = []
     inv_covariances = []
+    metadatas = []
     for i in 1:n_samples
         push!(samples, vec(i * ones(sample_sizes[i])))
         if (i == 3)
@@ -30,6 +31,11 @@ using EnsembleKalmanProcesses
             ic = I
         end
         push!(inv_covariances, ic)
+        if (i==1)
+            metadata=nothing
+        else
+            metadata = Dict("example$i" => i)
+        end
 
     end
     names = ["d$(string(i))" for i in 1:n_samples]
@@ -44,13 +50,14 @@ using EnsembleKalmanProcesses
 
     # 1) via a dict [singleton] 
     obs_dict = Dict("samples" => samples[1], "covariances" => covariances[1], "names" => names[1])
-    observation_1 = Observation(obs_dict)
+    observation_1 = Observation(obs_dict, metadata="test")
     @test get_samples(observation_1) == [samples[1]] # all stored as a vec
     @test get_covs(observation_1) == [covariances[1]]
     @test all(isapprox.(get_inv_covs(observation_1)[1], inv_covariances[1], atol = 1e-10)) # inversion approximate
     @test get_names(observation_1) == [names[1]]
-    @test get_indices(observation_1) == [indices[1]]
-
+    @test get_indices(observation_1) == [indices[1]])
+    @test get_metadata(observation_1) == "test"
+    
     # 2) via args [singleton] 
     observation_1 = Observation(samples[1], covariances[1], names[1])
     @test get_samples(observation_1) == [samples[1]] # all stored as a vec
@@ -58,29 +65,32 @@ using EnsembleKalmanProcesses
     @test all(isapprox.(get_inv_covs(observation_1)[1], inv_covariances[1], atol = 1e-10)) # inversion approximate
     @test get_names(observation_1) == [names[1]]
     @test get_indices(observation_1) == [indices[1]]
-
+    @test isnothing(get_metadata(observation_1))
+    
     # 2) via a dict [vec], pass in inv_covs
     obs_dict = Dict(
         "samples" => samples[2:4],
         "covariances" => covariances[2:4],
         "inv_covariances" => inv_covariances[2:4],
         "names" => names[2:4],
+        "metadata" => metadatas[2:4],
     )
     observation_2_4 = Observation(obs_dict)
     @test get_samples(observation_2_4) == samples[2:4]
     @test get_covs(observation_2_4) == covariances[2:4]
     @test get_inv_covs(observation_2_4) == inv_covariances[2:4]
     @test get_names(observation_2_4) == names[2:4]
-    @test get_indices(observation_2_4) == [id .- maximum(indices[1]) for id in indices[2:4]] # shifted 
+    @test get_indices(observation_2_4) == [id .- maximum(indices[1]) for id in indices[2:4]] # shifted
+    @test get_metadata(observation_2_4) == metadatas[2:4]
 
     # 3) via a list of args  (not pass inv_covs)
-    observation_2_4_new = Observation(samples[2:4], covariances[2:4], names[2:4])
+    observation_2_4_new = Observation(samples[2:4], covariances[2:4], names[2:4], metadata=metadatas[2:4])
     @test get_samples(observation_2_4_new) == samples[2:4]
     @test get_covs(observation_2_4_new) == covariances[2:4]
     @test all(isapprox.(get_inv_covs(observation_2_4_new), inv.(covariances[2:4]), atol = 1e-10)) # inversion approximate
     @test get_names(observation_2_4_new) == names[2:4]
     @test get_indices(observation_2_4_new) == [id .- maximum(indices[1]) for id in indices[2:4]] # shifted 
-
+    @test get_metadata(observation_2_4_new) == metadatas[2:4]
 
     # 4) via combining Observations
     observation = combine_observations([observation_1, observation_2_4])
@@ -89,7 +99,8 @@ using EnsembleKalmanProcesses
     @test all(isapprox.(get_inv_covs(observation), inv_covariances, atol = 1e-10))
     @test get_names(observation) == names
     @test get_indices(observation) == indices # correctly shifted back
-
+    @test get_metadata(observation) == metadata
+    
     # get_obs 
     obs_sample = get_obs(observation, build = false)
     obs_stacked = get_obs(observation) # default build=true

--- a/test/Observations/runtests.jl
+++ b/test/Observations/runtests.jl
@@ -32,7 +32,7 @@ using EnsembleKalmanProcesses
         end
         push!(inv_covariances, ic)
 
-        if (i==1)
+        if (i == 1)
             push!(metadatas, nothing)
         else
             push!(metadatas, Dict("example$i" => i))
@@ -51,14 +51,14 @@ using EnsembleKalmanProcesses
 
     # 1) via a dict [singleton] 
     obs_dict = Dict("samples" => samples[1], "covariances" => covariances[1], "names" => names[1])
-    observation_1 = Observation(obs_dict, metadata="test")
+    observation_1 = Observation(obs_dict, metadata = "test")
     @test get_samples(observation_1) == [samples[1]] # all stored as a vec
     @test get_covs(observation_1) == [covariances[1]]
     @test all(isapprox.(get_inv_covs(observation_1)[1], inv_covariances[1], atol = 1e-10)) # inversion approximate
     @test get_names(observation_1) == [names[1]]
     @test get_indices(observation_1) == [indices[1]]
     @test get_metadata(observation_1) == "test"
-    
+
     # 2) via args [singleton] 
     observation_1 = Observation(samples[1], covariances[1], names[1])
     @test get_samples(observation_1) == [samples[1]] # all stored as a vec
@@ -67,7 +67,7 @@ using EnsembleKalmanProcesses
     @test get_names(observation_1) == [names[1]]
     @test get_indices(observation_1) == [indices[1]]
     @test isnothing(get_metadata(observation_1))
-    
+
     # 2) via a dict [vec], pass in inv_covs
     obs_dict = Dict(
         "samples" => samples[2:4],
@@ -85,7 +85,7 @@ using EnsembleKalmanProcesses
     @test get_metadata(observation_2_4) == metadatas[2:4]
 
     # 3) via a list of args  (not pass inv_covs)
-    observation_2_4_new = Observation(samples[2:4], covariances[2:4], names[2:4], metadata=metadatas[2:4])
+    observation_2_4_new = Observation(samples[2:4], covariances[2:4], names[2:4], metadata = metadatas[2:4])
     @test get_samples(observation_2_4_new) == samples[2:4]
     @test get_covs(observation_2_4_new) == covariances[2:4]
     @test all(isapprox.(get_inv_covs(observation_2_4_new), inv.(covariances[2:4]), atol = 1e-10)) # inversion approximate
@@ -101,7 +101,7 @@ using EnsembleKalmanProcesses
     @test get_names(observation) == names
     @test get_indices(observation) == indices # correctly shifted back
     @test get_metadata(observation) == metadatas # content the same
-    
+
     # get_obs 
     obs_sample = get_obs(observation, build = false)
     obs_stacked = get_obs(observation) # default build=true

--- a/test/Observations/runtests.jl
+++ b/test/Observations/runtests.jl
@@ -100,7 +100,7 @@ using EnsembleKalmanProcesses
     @test all(isapprox.(get_inv_covs(observation), inv_covariances, atol = 1e-10))
     @test get_names(observation) == names
     @test get_indices(observation) == indices # correctly shifted back
-    @test get_metadata(observation) == metadata
+    @test get_metadata(observation) == metadatas # content the same
     
     # get_obs 
     obs_sample = get_obs(observation, build = false)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Request from @nefrathenrici to extend the utility of `metadata` from `ObservationSeries` to individual `Observation` objects


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Add optional metadata object to `Observation`, set either with `metadata=...` or `Dict(...,"metadata" => ...)` when creating the `Observation`. It is value `nothing` when not set.
- metadata is stacked under `combine_observations([obs1,obs2])` and is retrieved with `get_metadata(observation)`
- API and additional note in docs provided
- unit tested

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
