### PR TITLE
[WIP] Fix vector of ParameterDistribution mean bug #494

### DIFF
--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -776,7 +776,7 @@ Returns a concatenated mean of the parameter distributions.
 mean(d::Parameterized) = mean(d.distribution)
 mean(d::Samples) = mean(d.distribution_samples, dims = 2)
 mean(d::VectorOfParameterized) = reduce(vcat, mean.(d.distribution))
-mean(pd::ParameterDistribution) = reduce(vcat, mean.(pd.distribution))
+mean(pd::ParameterDistribution) = reduce(vcat, [m[:] for m in mean.(pd.distribution)])
 
 #apply transforms
 function transform_constrained_to_unconstrained(

--- a/test/ParameterDistributions/runtests.jl
+++ b/test/ParameterDistributions/runtests.jl
@@ -489,6 +489,11 @@ using EnsembleKalmanProcesses.ParameterDistributions
         name4 = "constrained_MVsampled"
         u4 = ParameterDistribution(d4, c4, name4)
 
+        d5 = Samples(reshape([1 2 3], 3, 1))
+        c5 = [no_constraint(), no_constraint(), no_constraint()]
+        name5 = "constrained_MVsampled_K_by_1"
+        u5 = ParameterDistribution(d5, c5, name5)
+
         v = combine_distributions([u1, u2, u3, u4])
 
         # Tests for sample distribution
@@ -501,6 +506,8 @@ using EnsembleKalmanProcesses.ParameterDistributions
         sample(u3, 3)
         sample(u4)
         sample(u4, 3)
+        sample(u5)
+        sample(u5, 3)
         sample(v)
         sample(v, 3)
 
@@ -518,10 +525,12 @@ using EnsembleKalmanProcesses.ParameterDistributions
         x_in_bd = [0.0, 0.0, 0.0, 0.0]
         @test isapprox(logpdf(u1, x_in_bd) - logpdf(MvNormal(zeros(4), 0.1 * I), x_in_bd)[1], 0.0, atol = 1e-6)
         @test_throws DimensionMismatch logpdf(u1, [1])
+        # for Vector of K-by-1
+        @test Vector(mean(u5)) == [1.0, 2.0, 3.0]
         # for Parameterized Univar
-        u5 = constrained_gaussian("u5", 3.0, 1.0, -Inf, Inf)
+        u6 = constrained_gaussian("u6", 3.0, 1.0, -Inf, Inf)
         x_in_bd = 0.0
-        @test isapprox(logpdf(u5, x_in_bd) - logpdf(Normal(3.0, 1.0), x_in_bd)[1], 0.0, atol = 1e-6)
+        @test isapprox(logpdf(u6, x_in_bd) - logpdf(Normal(3.0, 1.0), x_in_bd)[1], 0.0, atol = 1e-6)
         @test_throws DimensionMismatch logpdf(u1, [1, 1])
         @test isapprox(
             logpdf(Parameterized(Normal(3.0, 1.0)), x_in_bd) - logpdf(Normal(3.0, 1.0), x_in_bd)[1],


### PR DESCRIPTION
## Purpose 
Closes #494
I have written a test that picks up the bug in issue, and a general solution to `Vector(mean(prior))` failing on K-by-1 priors.


## To-do
There is a possible extension of this fix into the `mean` definition for `VectorOfParameterized` as well.

## Content
As stated in the issue brief, this appears to have at one point affected UKI, and was addressed [the line](https://github.com/CliMA/EnsembleKalmanProcesses.jl/blob/0064442056d6e2a970bd1a308234a1ae8db1e97a/src/UnscentedKalmanInversion.jl#L212-L213)
```
    u0_mean = isa(mean(prior), AbstractVector) ? Vector(mean(prior)) : [mean(prior)] # mean of unconstrained distribution
```
I believe flattening as suggested would be more robust. However, I propose that be handled within the [`ParameterDistribution` extension of the `mean` definition](https://github.com/CliMA/EnsembleKalmanProcesses.jl/blob/0064442056d6e2a970bd1a308234a1ae8db1e97a/src/ParameterDistributions.jl#L779). This would allow expected behaviour while requiring the fewest changes, and preventing this issue being reintroduced in future development.

Note: there seems to be no dev or `upstream` branch to merge into, if there is a better branch to merge into, please let me know.

----
- [x ] I have read and checked the items on the review checklist.
