### PR TITLE
tsvd_cov_from_samples - type stability

### DIFF
--- a/src/Observations.jl
+++ b/src/Observations.jl
@@ -134,7 +134,7 @@ $(TYPEDSIGNATURES)
 For a given matrix `X` and rank `r`, return the truncated SVD for X as a LinearAlgebra.jl `SVD` object. Setting `return_inverse=true` also return it's psuedoinverse X⁺.
 """
 function tsvd_mat(X, r::Int; return_inverse = false, quiet = false, tsvd_kwargs...)
-  
+
     # Note, must only use tsvd approximation when rank < minimum dimension of X or you get very poor approximation.
     if isa(X, UniformScaling)
         if return_inverse


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #504 

## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- put `sqrt(N-1)` ->  `FT(sqrt(N- 1))` for inferred `FT` from eltype of input matrix
- replace `1.0 ./ A` with `1 ./ A`

## Example:

```julia
import EnsembleKalmanProcesses as EKP

samples_mat = Float32.([[1, 2, 4, 6]  [3, 4, 4, 4]])

covv, inv_covv = EKP.tsvd_cov_from_samples(samples_mat, return_inverse=true)
eltype(covv.S) == Float32 # true
eltype(covv.U) == Float32 # true
eltype(covv.V) == Float32 # true
eltype(covv.Vt) == Float32 # true

eltype(inv_covv.S) == Float32 # true
eltype(inv_covv.U) == Float32 # true
eltype(inv_covv.V) == Float32 # true
eltype(inv_covv.Vt) == Float32 # true
```

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
