### PR TITLE
Add fallback for linear solve

### DIFF
--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -180,7 +180,8 @@ function eki_update(
 
     # N_obs × N_obs \ [N_obs × N_ens]
     # --> tmp is [N_obs × N_ens]
-    tmp = FT.(safe_linear_solve(cov_gg + obs_noise_cov_ext, y_ext - g_ext))
+    verbose = ekp.verbose
+    tmp = FT.(safe_linear_solve(cov_gg + obs_noise_cov_ext, y_ext - g_ext; verbose))
     return u + (cov_ug * tmp) # [N_par × N_ens]  
 end
 

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -178,17 +178,7 @@ function eki_update(
 
     # N_obs × N_obs \ [N_obs × N_ens]
     # --> tmp is [N_obs × N_ens]
-    tmp = try
-        FT.((cov_gg + obs_noise_cov_ext) \ (y_ext - g_ext))
-    catch e
-        if e isa SingularException
-            LHS = Matrix{BigFloat}(cov_gg + obs_noise_cov)
-            RHS = Matrix{BigFloat}(y - g)
-            FT.(LHS \ RHS)
-        else
-            rethrow(e)
-        end
-    end
+    tmp = FT.(safe_linear_solve(cov_gg + obs_noise_cov_ext, y_ext - g_ext))
     return u + (cov_ug * tmp) # [N_par × N_ens]  
 end
 

--- a/src/EnsembleKalmanInversion.jl
+++ b/src/EnsembleKalmanInversion.jl
@@ -152,6 +152,7 @@ function eki_update(
 
         cov_est = cov([u; g_ext], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
 
+        add_diagonal_regularization!(cov_est)
         # Localization - a function taking in (cov, float-type, n_par, n_obs, n_ens)
         cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u, 1), size(g_ext, 1), size(u, 2))
         cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
@@ -166,6 +167,7 @@ function eki_update(
         g_ext = g
         y_ext = y
         cov_est = cov([u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
+        add_diagonal_regularization!(cov_est)
 
         # Localization - a function taking in (cov, float-type, n_par, n_obs, n_ens)
         cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u, 1), size(g, 1), size(u, 2))

--- a/src/EnsembleKalmanProcesses.jl
+++ b/src/EnsembleKalmanProcesses.jl
@@ -7,6 +7,7 @@ include("ParameterDistributions.jl")
 include("DataContainers.jl")
 include("Observations.jl")
 include("Localizers.jl")
+include("LinearSolve.jl")
 include("TOMLInterface.jl")
 include("UpdateGroup.jl")
 # algorithmic updates

--- a/src/EnsembleKalmanSampler.jl
+++ b/src/EnsembleKalmanSampler.jl
@@ -95,8 +95,11 @@ function eks_update(
     g_mean = mean(g', dims = 2)
     # g_cov: N_obs × N_obs
     g_cov = cov(g, corrected = false)
+    add_diagonal_regularization!(g_cov)
+
     # u_cov: N_par × N_par
     u_cov = cov(u, corrected = false)
+    add_diagonal_regularization!(u_cov)
 
     # Building tmp matrices for EKS update:
     E = g' .- g_mean
@@ -140,8 +143,11 @@ function eks_update(
     g_mean = mean(g', dims = 2)
     # g_cov: N_obs × N_obs
     g_cov = cov(g, corrected = false)
+    add_diagonal_regularization!(g_cov)
+
     # u_cov: N_par × N_par
     u_cov = cov(u, corrected = false)
+    add_diagonal_regularization!(u_cov)
 
     N_ens = get_N_ens(ekp)
     dim_u = length(u_mean)

--- a/src/EnsembleKalmanSampler.jl
+++ b/src/EnsembleKalmanSampler.jl
@@ -104,16 +104,22 @@ function eks_update(
     # Building tmp matrices for EKS update:
     E = g' .- g_mean
     R = g' .- get_obs(ekp)
+    verbose = ekp.verbose
     # D: N_ens × N_ens
-    D = (1 / get_N_ens(ekp)) * (E' * (get_obs_noise_cov(ekp) \ R))
+    D = (1 / get_N_ens(ekp)) * (E' * safe_linear_solve(get_obs_noise_cov(ekp), R; verbose))
 
     # Default: Δt = 1 / (norm(D) + eps(FT))
     Δt = get_Δt(ekp)[end]
 
     noise = MvNormal(zeros(size(u_cov, 1)), I)
-    implicit =
-        (I + Δt * (process.prior_cov' \ u_cov')') \
-        (u' .- Δt * (u' .- u_mean) * D .+ Δt * u_cov * (process.prior_cov \ process.prior_mean))
+    implicit = safe_linear_solve(
+        (I + Δt * safe_linear_solve(process.prior_cov', u_cov'; verbose)'),
+        (
+            u' .- Δt * (u' .- u_mean) * D .+
+            Δt * u_cov * safe_linear_solve(process.prior_cov, process.prior_mean; verbose)
+        );
+        verbose,
+    )
 
     u = implicit' + sqrt(2 * Δt) * (sqrt(u_cov) * rand(get_rng(ekp), noise, get_N_ens(ekp)))'
 
@@ -155,16 +161,22 @@ function eks_update(
     U = u' .- u_mean
     E = g' .- g_mean
     R = g' .- get_obs(ekp)
+    verbose = ekp.verbose
     # D: N_ens × N_ens
-    D = (1 / N_ens) * (E' * (get_obs_noise_cov(ekp) \ R))
+    D = (1 / N_ens) * (E' * safe_linear_solve(get_obs_noise_cov(ekp), R; verbose))
     finite_sample_correction = (dim_u + 1) / N_ens * U
     C_sqrt = 1 / sqrt(N_ens) * U
     # Default: Δt = 1 / (norm(D) + eps(FT))
     Δt = get_Δt(ekp)[end]
 
-    implicit =
-        (I + Δt * (process.prior_cov' \ u_cov')') \
-        (u' .- Δt * U * D .+ Δt * u_cov * (process.prior_cov \ process.prior_mean) + Δt * finite_sample_correction)
+    implicit = safe_linear_solve(
+        (I + Δt * safe_linear_solve(process.prior_cov', u_cov'; verbose)'),
+        (
+            u' .- Δt * U * D .+ Δt * u_cov * safe_linear_solve(process.prior_cov, process.prior_mean; verbose) +
+            Δt * finite_sample_correction
+        );
+        verbose,
+    )
 
     u = implicit' + sqrt(2 * Δt) * (C_sqrt * randn(get_rng(ekp), (N_ens, N_ens)))' # ensemble-sqrt noise update
     return u

--- a/src/EnsembleTransformKalmanInversion.jl
+++ b/src/EnsembleTransformKalmanInversion.jl
@@ -148,6 +148,9 @@ function etki_update(
     X = FT.((u .- mean(u, dims = 2)) / sqrt(m - 1))
     Y = FT.((g_ext .- mean(g_ext, dims = 2)) / sqrt(m - 1))
 
+    # Apply diagonal regularization to prevent singular matrix issues in covariance computations
+    # This ensures numerical stability when ensemble members are similar or identical
+
     # we have three options with the buffer:
     # (1) in the first iteration, create a buffer
     # (2) if a future iteration requires a smaller buffer, use the existing tmp
@@ -179,6 +182,7 @@ function etki_update(
     for i in 1:ys2
         tmp[2][i, i] += 1.0
     end
+    add_diagonal_regularization!(tmp[2][1:ys2, 1:ys2])
     Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2)) # Ω = inv(I + Y' * Γ_inv * Y)
     w = FT.(Ω * tmp[1][1:ys2, 1:ys1] * (y_ext .- mean(g_ext, dims = 2))) #  w = Ω * Y' * Γ_inv * (y .- g_mean))
 

--- a/src/EnsembleTransformKalmanInversion.jl
+++ b/src/EnsembleTransformKalmanInversion.jl
@@ -183,7 +183,8 @@ function etki_update(
         tmp[2][i, i] += 1.0
     end
     add_diagonal_regularization!(tmp[2][1:ys2, 1:ys2])
-    Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2)) # Ω = inv(I + Y' * Γ_inv * Y)
+    verbose = ekp.verbose
+    Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2); verbose) # Ω = inv(I + Y' * Γ_inv * Y)
     w = FT.(Ω * tmp[1][1:ys2, 1:ys1] * (y_ext .- mean(g_ext, dims = 2))) #  w = Ω * Y' * Γ_inv * (y .- g_mean))
 
     return mean(u, dims = 2) .+ X * (w .+ sqrt(m - 1) * real(sqrt(Ω))) # [N_par × N_ens]

--- a/src/EnsembleTransformKalmanInversion.jl
+++ b/src/EnsembleTransformKalmanInversion.jl
@@ -179,7 +179,7 @@ function etki_update(
     for i in 1:ys2
         tmp[2][i, i] += 1.0
     end
-    Ω = inv(tmp[2][1:ys2, 1:ys2]) # Ω = inv(I + Y' * Γ_inv * Y)
+    Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2)) # Ω = inv(I + Y' * Γ_inv * Y)
     w = FT.(Ω * tmp[1][1:ys2, 1:ys1] * (y_ext .- mean(g_ext, dims = 2))) #  w = Ω * Y' * Γ_inv * (y .- g_mean))
 
     return mean(u, dims = 2) .+ X * (w .+ sqrt(m - 1) * real(sqrt(Ω))) # [N_par × N_ens]

--- a/src/GaussNewtonKalmanInversion.jl
+++ b/src/GaussNewtonKalmanInversion.jl
@@ -94,7 +94,8 @@ function gnki_update(
     m = (prior_mean .+ m_noise)
     obs_noise_cov = scaled_obs_noise_cov * Δt / 2
 
-    cov_uu_inv_m_minus_u = safe_linear_solve(cov_uu, m .- u)
+    verbose = ekp.verbose
+    cov_uu_inv_m_minus_u = safe_linear_solve(cov_uu, m .- u; verbose)
     prior_contribution = -cov_ug' * cov_uu_inv_m_minus_u
 
     data_contribution = y .- g
@@ -102,12 +103,12 @@ function gnki_update(
     # solve for P (Cᵘᵍ)ᵀ (Cᵘᵘ)⁻¹ ( (Cᵘᵍ)ᵀ(Cᵘᵘ)⁻¹ P (Cᵘᵘ)⁻¹Cᵘᵍ + Γ)⁻¹ * A
 
     # Q = (Cᵘᵍ)ᵀ(Cᵘᵘ)⁻¹ P (Cᵘᵘ)⁻¹Cᵘᵍ
-    cov_uu_inv_prior_cov = safe_linear_solve(cov_uu, prior_cov)
-    cov_uu_inv_cov_ug = safe_linear_solve(cov_uu, cov_ug)
+    cov_uu_inv_prior_cov = safe_linear_solve(cov_uu, prior_cov; verbose)
+    cov_uu_inv_cov_ug = safe_linear_solve(cov_uu, cov_ug; verbose)
     Q = cov_ug' * cov_uu_inv_prior_cov * cov_uu_inv_cov_ug
 
-    Q_plus_obs_inv_A = safe_linear_solve(Q + obs_noise_cov, A)
-    cov_uu_inv_cov_ug_Q_inv_A = safe_linear_solve(cov_uu, cov_ug * Q_plus_obs_inv_A)
+    Q_plus_obs_inv_A = safe_linear_solve(Q + obs_noise_cov, A; verbose)
+    cov_uu_inv_cov_ug_Q_inv_A = safe_linear_solve(cov_uu, cov_ug * Q_plus_obs_inv_A; verbose)
     update = prior_cov * cov_uu_inv_cov_ug_Q_inv_A
 
     return (1 - Δt) * u + Δt * (m .+ update)

--- a/src/GaussNewtonKalmanInversion.jl
+++ b/src/GaussNewtonKalmanInversion.jl
@@ -78,6 +78,8 @@ function gnki_update(
     cov_est = cov([u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
 
     cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u, 1), size(g, 1), get_N_ens(ekp))
+    add_diagonal_regularization!(cov_localized)
+
     cov_uu, cov_ug, cov_gg = get_cov_blocks(cov_localized, size(u, 1))
     process = get_process(ekp)
     prior_mean = process.prior_mean

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -1,0 +1,51 @@
+using LinearAlgebra
+
+export safe_linear_solve, safe_linear_solve!
+
+"""
+    safe_linear_solve(A, b; warn_on_singular=true)
+
+Solves the linear system Ax = b with robust handling of ill-conditioned matrices.
+
+# Arguments
+- `A`: Coefficient matrix
+- `b`: Right-hand side vector or matrix  
+- `warn_on_singular`: Whether to issue warnings when ill-conditioned matrices are detected
+
+# Algorithm
+1. **Primary**: Standard solve `A \\ b` (when matrix is well-conditioned)
+2. **Fallback**: Pseudoinverse solve using normal equations or Moore-Penrose pseudoinverse
+"""
+function safe_linear_solve(
+    A::AbstractMatrix,
+    b::AbstractVecOrMat;
+    warn_on_singular = true,
+    max_cond = 1e12,
+)
+    cond_A = cond(A)
+    is_ill_conditioned = cond_A > max_cond
+    is_ill_conditioned || return A \ b
+
+    warn_on_singular && @warn "Ill-conditioned matrix detected (cond=$cond_A). Using pseudoinverse solve."
+    return pinv(A) * b
+end
+"""
+    safe_linear_solve!(x, A, b; kwargs...)
+
+In-place version of `safe_linear_solve` that writes into `x`.
+Errors if shapes don’t match.
+"""
+function safe_linear_solve!(
+    x::AbstractVecOrMat,
+    A::AbstractMatrix,
+    b::AbstractVecOrMat;
+    kwargs...
+)
+    n = size(A, 2)
+    ncols = ndims(b) == 1 ? 1 : size(b, 2)
+    if size(x) != (n, ncols)
+        throw(DimensionMismatch("x has size $(size(x)), expected ($(n), $(ncols))"))
+    end
+    x .= safe_linear_solve(A, b; kwargs...)
+    return x
+end

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -10,15 +10,15 @@ Solves the linear system Ax = b with robust handling of ill-conditioned matrices
 # Arguments
 - `A`: Coefficient matrix
 - `b`: Right-hand side vector or matrix  
-- `warn_on_singular`: Whether to issue warnings when ill-conditioned matrices are detected
+- `verbose`: Whether to issue warnings when ill-conditioned matrices are detected
 
 """
-function safe_linear_solve(A::AbstractMatrix, b::AbstractVecOrMat; warn_on_singular = true)
+function safe_linear_solve(A::AbstractMatrix, b::AbstractVecOrMat; verbose = true)
     try
         return A \ b
     catch e
         if e isa SingularException
-            warn_on_singular && @warn "Ill-conditioned matrix detected (cond=$(cond(A))). Using pseudoinverse solve."
+            verbose && @warn "Ill-conditioned matrix detected (cond=$(cond(A))). Using pseudoinverse solve."
             return pinv(A) * b
         else
             rethrow(e)
@@ -26,18 +26,18 @@ function safe_linear_solve(A::AbstractMatrix, b::AbstractVecOrMat; warn_on_singu
     end
 end
 """
-    safe_linear_solve!(x, A, b; kwargs...)
+    safe_linear_solve!(x, A, b; verbose=true)
 
 In-place version of `safe_linear_solve` that writes into `x`.
-Errors if shapes don’t match.
+Errors if shapes don't match.
 """
-function safe_linear_solve!(x::AbstractVecOrMat, A::AbstractMatrix, b::AbstractVecOrMat; kwargs...)
+function safe_linear_solve!(x::AbstractVecOrMat, A::AbstractMatrix, b::AbstractVecOrMat; verbose = true)
     n = size(A, 2)
-    ncols = ndims(b) == 1 ? 1 : size(b, 2)
-    if size(x) != (n, ncols)
-        throw(DimensionMismatch("x has size $(size(x)), expected ($(n), $(ncols))"))
+    expected_size = ndims(b) == 1 ? (n,) : (n, size(b, 2))
+    if size(x) != expected_size
+        throw(DimensionMismatch("x has size $(size(x)), expected $(expected_size)"))
     end
-    x .= safe_linear_solve(A, b; kwargs...)
+    x .= safe_linear_solve(A, b; verbose)
     return x
 end
 

--- a/src/ParameterDistributions.jl
+++ b/src/ParameterDistributions.jl
@@ -732,7 +732,10 @@ end
 Returns a dense blocked (co)variance of the distributions.
 """
 cov(d::Parameterized) = cov(d.distribution)
-cov(d::Samples) = cov(d.distribution_samples, dims = 2) #parameters are columns
+function cov(d::Samples)
+    cov_samples = cov(d.distribution_samples, dims = 2) #parameters are columns
+    return cov_samples
+end
 function cov(d::VectorOfParameterized)
     d_dims = get_dimensions(d)
 

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -137,6 +137,7 @@ function sparse_eki_update(
 ) where {FT <: Real, CT <: Real, IT}
 
     cov_est = cov([u; g], [u; g], dims = 2, corrected = false) # [(N_par + N_obs)×(N_par + N_obs)]
+    add_diagonal_regularization!(cov_est)
     process = get_process(ekp)
     # Localization
     cov_localized = get_localizer(ekp).localize(cov_est, FT, size(u, 1), size(g, 1), get_N_ens(ekp))
@@ -213,6 +214,7 @@ function update_ensemble!(
     u = get_u_final(ekp)
     N_obs = size(g, 1)
     cov_init = cov(u, dims = 2)
+    add_diagonal_regularization!(cov_init)
     fh = get_failure_handler(ekp)
 
     # Scale noise using Δt

--- a/src/SparseEnsembleKalmanInversion.jl
+++ b/src/SparseEnsembleKalmanInversion.jl
@@ -90,9 +90,11 @@ function sparse_qp(
     H_uc::AbstractMatrix{FT} = H_u,
 ) where {FT, IT}
 
-    P = H_g' * (get_obs_noise_cov(ekp) \ H_g) + cov_vv_inv
+    obs_noise_cov_inv_H_g = safe_linear_solve(get_obs_noise_cov(ekp), H_g)
+    P = H_g' * obs_noise_cov_inv_H_g + cov_vv_inv
     P = 0.5 * (P + P')
-    q = -(cov_vv_inv * v_j + H_g' * (get_obs_noise_cov(ekp) \ y_j))
+    obs_noise_cov_inv_y_j = safe_linear_solve(get_obs_noise_cov(ekp), y_j)
+    q = -(cov_vv_inv * v_j + H_g' * obs_noise_cov_inv_y_j)
     N_params = size(H_uc)[1]
     P1 = vcat(
         hcat(P, fill(FT(0), size(P)[1], N_params)),
@@ -144,7 +146,8 @@ function sparse_eki_update(
 
     # N_obs × N_obs \ [N_obs × N_ens]
     # --> tmp is [N_obs × N_ens]
-    tmp = FT.((cov_gg + obs_noise_cov) \ (y - g))
+    tmp = safe_linear_solve(cov_gg + obs_noise_cov, y - g)
+    tmp = FT.(tmp)
     u = u + (cov_ug * tmp) # [N_par × N_ens]
 
     # Sparse EKI
@@ -154,7 +157,7 @@ function sparse_eki_update(
 
     H_uc = H_u[process.uc_idx, :]
 
-    cov_vv_inv = cov_vv \ (1.0 * I(size(cov_vv)[1]))
+    cov_vv_inv = safe_linear_solve(cov_vv, 1.0 * I(size(cov_vv)[1]))
 
     # Loop over ensemble members to impose sparsity
     Threads.@threads for j in 1:size(u, 2)

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -358,18 +358,16 @@ function FailureHandler(process::Unscented, method::SampleSuccGauss)
         cov_localized = get_localizer(uki).localize(cov_est, FT, size(u_p, 1), size(g, 1), size(u_p, 2))
         uu_p_cov, ug_cov, gg_cov = get_cov_blocks(cov_localized, size(u_p, 1))
 
+        verbose = uki.verbose
         if process.impose_prior
             ug_cov_reg = [ug_cov uu_p_cov]
-            gg_cov_reg = [
-                gg_cov ug_cov'
-                ug_cov uu_p_cov+process.prior_cov[u_idx, u_idx] / get_Δt(uki)[end]
-            ]
-            tmp = ug_cov_reg / gg_cov_reg
+            gg_cov_reg = [gg_cov ug_cov'; ug_cov uu_p_cov+process.prior_cov[u_idx, u_idx] / get_Δt(uki)[end]]
+            tmp = safe_linear_solve(gg_cov_reg', ug_cov_reg'; verbose)'
             u_mean = u_p_mean + tmp * [obs_mean - g_mean; process.prior_mean[u_idx] - u_p_mean]
             uu_cov = uu_p_cov - tmp * ug_cov_reg'
 
         else
-            tmp = ug_cov / gg_cov
+            tmp = safe_linear_solve(gg_cov', ug_cov'; verbose)'
             u_mean = u_p_mean + tmp * (obs_mean - g_mean)
             uu_cov = uu_p_cov - tmp * ug_cov'
 
@@ -770,17 +768,18 @@ function update_ensemble_analysis!(
     cov_localized = get_localizer(uki).localize(cov_est, FT, size(u_p, 1), size(g, 1), size(u_p, 2))
     uu_p_cov, ug_cov, gg_cov = get_cov_blocks(cov_localized, size(u_p)[1])
 
+    verbose = uki.verbose
     if process.impose_prior
         ug_cov_reg = [ug_cov uu_p_cov]
         gg_cov_reg = [
             gg_cov ug_cov'
             ug_cov uu_p_cov+process.prior_cov[u_idx, u_idx] / get_Δt(uki)[end]
         ]
-        tmp = ug_cov_reg / gg_cov_reg
+        tmp = safe_linear_solve(gg_cov_reg', ug_cov_reg'; verbose)'
         u_mean = u_p_mean + tmp * [obs_mean - g_mean; process.prior_mean[u_idx] - u_p_mean]
         uu_cov = uu_p_cov - tmp * ug_cov_reg'
     else
-        tmp = ug_cov / gg_cov
+        tmp = safe_linear_solve(gg_cov', ug_cov'; verbose)'
         u_mean = u_p_mean + tmp * (obs_mean - g_mean)
         uu_cov = uu_p_cov - tmp * ug_cov'
     end

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -360,7 +360,10 @@ function FailureHandler(process::Unscented, method::SampleSuccGauss)
 
         if process.impose_prior
             ug_cov_reg = [ug_cov uu_p_cov]
-            gg_cov_reg = [gg_cov ug_cov'; ug_cov uu_p_cov+process.prior_cov[u_idx, u_idx] / get_Δt(uki)[end]]
+            gg_cov_reg = [
+                gg_cov ug_cov'
+                ug_cov uu_p_cov+process.prior_cov[u_idx, u_idx] / get_Δt(uki)[end]
+            ]
             tmp = ug_cov_reg / gg_cov_reg
             u_mean = u_p_mean + tmp * [obs_mean - g_mean; process.prior_mean[u_idx] - u_p_mean]
             uu_cov = uu_p_cov - tmp * ug_cov_reg'
@@ -516,6 +519,8 @@ function construct_cov(
         for i in 1:N_ens
             xx_cov .+= cov_weights[i] * (x[:, i] - x_mean) * (x[:, i] - x_mean)'
         end
+
+        add_diagonal_regularization!(xx_cov)
     else
         @assert isa(x_mean, FT)
         N_ens = length(x)
@@ -767,7 +772,10 @@ function update_ensemble_analysis!(
 
     if process.impose_prior
         ug_cov_reg = [ug_cov uu_p_cov]
-        gg_cov_reg = [gg_cov ug_cov'; ug_cov uu_p_cov+process.prior_cov[u_idx, u_idx] / get_Δt(uki)[end]]
+        gg_cov_reg = [
+            gg_cov ug_cov'
+            ug_cov uu_p_cov+process.prior_cov[u_idx, u_idx] / get_Δt(uki)[end]
+        ]
         tmp = ug_cov_reg / gg_cov_reg
         u_mean = u_p_mean + tmp * [obs_mean - g_mean; process.prior_mean[u_idx] - u_p_mean]
         uu_cov = uu_p_cov - tmp * ug_cov_reg'

--- a/src/UnscentedTransformKalmanInversion.jl
+++ b/src/UnscentedTransformKalmanInversion.jl
@@ -190,6 +190,7 @@ function FailureHandler(process::TransformUnscented, method::SampleSuccGauss)
         for i in 1:ys2
             tmp[2][i, i] += 1.0
         end
+        add_diagonal_regularization!(tmp[2][1:ys2, 1:ys2])
 
         Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2)) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y      
         u_mean = u_p_mean + X * FT.(Ω * tmp[1][1:ys2, 1:ys1] * (y_ext .- g_mean_ext)) #  mean update = Ω * Y' * Γ_inv * (y .- g_mean))
@@ -285,6 +286,7 @@ function update_ensemble_analysis!(
     for i in 1:ys2
         tmp[2][i, i] += 1.0
     end
+    add_diagonal_regularization!(tmp[2][1:ys2, 1:ys2])
     Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2)) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y
     u_mean = u_p_mean + X * FT.(Ω * tmp[1][1:ys2, 1:ys1] * (y_ext .- g_mean_ext))
     uu_cov = X * Ω * X' # cov update 

--- a/src/UnscentedTransformKalmanInversion.jl
+++ b/src/UnscentedTransformKalmanInversion.jl
@@ -136,7 +136,8 @@ function FailureHandler(process::TransformUnscented, method::SampleSuccGauss)
 
         # update group index of y,g,u
         prior_mean = process.prior_mean[u_idx]
-        prior_cov_inv = safe_linear_solve(process.prior_cov[u_idx, u_idx], I(length(u_idx))) # take idx later
+        verbose = uki.verbose
+        prior_cov_inv = safe_linear_solve(process.prior_cov[u_idx, u_idx], I(length(u_idx)); verbose) # take idx later
         u_p = u_p_full[u_idx, :]
         y = get_obs(uki)[g_idx]
         g = g_full[g_idx, :]
@@ -192,7 +193,7 @@ function FailureHandler(process::TransformUnscented, method::SampleSuccGauss)
         end
         add_diagonal_regularization!(tmp[2][1:ys2, 1:ys2])
 
-        Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2)) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y      
+        Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2); verbose) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y      
         u_mean = u_p_mean + X * FT.(Ω * tmp[1][1:ys2, 1:ys1] * (y_ext .- g_mean_ext)) #  mean update = Ω * Y' * Γ_inv * (y .- g_mean))
         uu_cov = X * Ω * X' # cov update
 
@@ -239,7 +240,8 @@ function update_ensemble_analysis!(
 
     # update group index of y,g,u
     prior_mean = process.prior_mean[u_idx]
-    prior_cov_inv = safe_linear_solve(process.prior_cov[u_idx, u_idx], I(length(u_idx))) # take idx later
+    verbose = uki.verbose
+    prior_cov_inv = safe_linear_solve(process.prior_cov[u_idx, u_idx], I(length(u_idx)); verbose) # take idx later
     u_p = u_p_full[u_idx, :]
     y = get_obs(uki)[g_idx]
     g = g_full[g_idx, :]
@@ -287,7 +289,7 @@ function update_ensemble_analysis!(
         tmp[2][i, i] += 1.0
     end
     add_diagonal_regularization!(tmp[2][1:ys2, 1:ys2])
-    Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2)) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y
+    Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2); verbose) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y
     u_mean = u_p_mean + X * FT.(Ω * tmp[1][1:ys2, 1:ys1] * (y_ext .- g_mean_ext))
     uu_cov = X * Ω * X' # cov update 
 

--- a/src/UnscentedTransformKalmanInversion.jl
+++ b/src/UnscentedTransformKalmanInversion.jl
@@ -136,7 +136,7 @@ function FailureHandler(process::TransformUnscented, method::SampleSuccGauss)
 
         # update group index of y,g,u
         prior_mean = process.prior_mean[u_idx]
-        prior_cov_inv = inv(process.prior_cov)[u_idx, u_idx] # take idx later
+        prior_cov_inv = safe_linear_solve(process.prior_cov[u_idx, u_idx], I(length(u_idx))) # take idx later
         u_p = u_p_full[u_idx, :]
         y = get_obs(uki)[g_idx]
         g = g_full[g_idx, :]
@@ -191,7 +191,7 @@ function FailureHandler(process::TransformUnscented, method::SampleSuccGauss)
             tmp[2][i, i] += 1.0
         end
 
-        Ω = inv(tmp[2][1:ys2, 1:ys2]) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y      
+        Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2)) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y      
         u_mean = u_p_mean + X * FT.(Ω * tmp[1][1:ys2, 1:ys1] * (y_ext .- g_mean_ext)) #  mean update = Ω * Y' * Γ_inv * (y .- g_mean))
         uu_cov = X * Ω * X' # cov update
 
@@ -238,7 +238,7 @@ function update_ensemble_analysis!(
 
     # update group index of y,g,u
     prior_mean = process.prior_mean[u_idx]
-    prior_cov_inv = inv(process.prior_cov)[u_idx, u_idx] # take idx later
+    prior_cov_inv = safe_linear_solve(process.prior_cov[u_idx, u_idx], I(length(u_idx))) # take idx later
     u_p = u_p_full[u_idx, :]
     y = get_obs(uki)[g_idx]
     g = g_full[g_idx, :]
@@ -285,7 +285,7 @@ function update_ensemble_analysis!(
     for i in 1:ys2
         tmp[2][i, i] += 1.0
     end
-    Ω = inv(tmp[2][1:ys2, 1:ys2]) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y
+    Ω = safe_linear_solve(tmp[2][1:ys2, 1:ys2], I(ys2)) # Ω = (I + Y' * Γ_inv * Y)^-1 = I - Y' (Y Y' + Γ_inv)^-1 Y
     u_mean = u_p_mean + X * FT.(Ω * tmp[1][1:ys2, 1:ys1] * (y_ext .- g_mean_ext))
     uu_cov = X * Ω * X' # cov update 
 

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -1621,27 +1621,48 @@ end
     @testset "safe_linear_solve" begin
         A = randn(5, 5)
         b = randn(5)
+        B = randn(5, 3)
+
+        # safe_linear_solve with vector
         x_ref = A \ b
         x = safe_linear_solve(A, b)
         @test isapprox(x, x_ref; rtol = 1e-10, atol = 1e-12)
         @test eltype(x) == eltype(x_ref)
 
-        B = randn(5, 3)
+        # safe_linear_solve with matrix
         X_ref = A \ B
         X = safe_linear_solve(A, B)
         @test isapprox(X, X_ref; rtol = 1e-10, atol = 1e-12)
         @test eltype(X) == eltype(X_ref)
 
-        # Make a rank-deficient matrix
-        A = [
+        # safe_linear_solve! with vector
+        x_inplace = zeros(5)
+        safe_linear_solve!(x_inplace, A, b)
+        @test isapprox(x_inplace, x_ref; rtol = 1e-10, atol = 1e-12)
+
+        # safe_linear_solve! with matrix
+        X_inplace = zeros(5, 3)
+        safe_linear_solve!(X_inplace, A, B)
+        @test isapprox(X_inplace, X_ref; rtol = 1e-10, atol = 1e-12)
+
+        # dimension mismatch for safe_linear_solve!
+        X_wrong = zeros(4, 3)
+        @test_throws DimensionMismatch safe_linear_solve!(X_wrong, A, B)
+
+        # rank-deficient matrix
+        A_singular = [
             1.0 2.0
             2.0 4.0
         ]
-        b = randn(2)
-        x_pinv = pinv(A) * b
+        b_singular = randn(2)
+        x_pinv = pinv(A_singular) * b_singular
 
-        x = safe_linear_solve(A, b)
-        @test isapprox(x, x_pinv; rtol = 1e-10, atol = 1e-12)
+        x_safe = safe_linear_solve(A_singular, b_singular)
+        @test isapprox(x_safe, x_pinv; rtol = 1e-10, atol = 1e-12)
+
+        x_safe_inplace = zeros(2)
+        safe_linear_solve!(x_safe_inplace, A_singular, b_singular)
+        @test isapprox(x_safe_inplace, x_pinv; rtol = 1e-10, atol = 1e-12)
     end
 
     @testset "add_diagonal_regularization!" begin


### PR DESCRIPTION
Content 
- `safe_linear_solve(A,b)`: solves via `A\b` and falls back to `pinv(A)*b` on `SingularException`, with a warning that can be disabled
- `add_diagonal_regularization!(cov_matrix)`: Adds a `sqrt(eps(eltype(cov_matrix)))` to the input matrix's diagonal 
- Applies `add_diagonal_regularization!` and `safe_linear_solve` to the source code. I am not sure that I applied regularization everywhere it is needed.