### PR TITLE
Add convenience to construct UKI initial ensemble before creating EKP

### DIFF
--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -7,7 +7,7 @@ CurrentModule = EnsembleKalmanProcesses
 ## Primary objects and functions
 ```@docs
 EnsembleKalmanProcess
-construct_initial_ensemble(rng::AbstractRNG, prior::ParameterDistribution, N_ens)
+construct_initial_ensemble
 update_ensemble!
 ```
 ## Getter functions

--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -7,7 +7,7 @@ CurrentModule = EnsembleKalmanProcesses
 ## Primary objects and functions
 ```@docs
 EnsembleKalmanProcess
-construct_initial_ensemble(rng::AbstractRNG, prior::ParameterDistribution, N_ens) where {IT}
+construct_initial_ensemble(rng::AbstractRNG, prior::ParameterDistribution, N_ens)
 update_ensemble!
 ```
 ## Getter functions

--- a/docs/src/API/EnsembleKalmanProcess.md
+++ b/docs/src/API/EnsembleKalmanProcess.md
@@ -7,7 +7,7 @@ CurrentModule = EnsembleKalmanProcesses
 ## Primary objects and functions
 ```@docs
 EnsembleKalmanProcess
-construct_initial_ensemble
+construct_initial_ensemble(rng::AbstractRNG, prior::ParameterDistribution, N_ens) where {IT}
 update_ensemble!
 ```
 ## Getter functions

--- a/docs/src/API/Unscented.md
+++ b/docs/src/API/Unscented.md
@@ -11,4 +11,6 @@ construct_mean
 construct_cov
 update_ensemble_prediction!
 update_ensemble_analysis!
+construct_initial_ensemble(prior::ParameterDistribution, process::UorTU) where {UorTU <: Union{Unscented, TransformUnscented}}
+
 ```

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -873,22 +873,25 @@ function get_current_minibatch(ekp::EnsembleKalmanProcess)
 end
 
 """
-    construct_initial_ensemble(
-        rng::AbstractRNG,
-        prior::ParameterDistribution,
-        N_ens::IT
-    ) where {IT <: Int}
-    construct_initial_ensemble(prior::ParameterDistribution, N_ens::IT) where {IT <: Int}
+$(TYPEDSIGNATURES)
 
 Construct the initial parameters, by sampling `N_ens` samples from specified
-prior distribution. Returned with parameters as columns.
+prior distribution. Returned with parameters as columns in unconstrained space by default (constrain by setting `constrained=true`)
+
+Note: `Unscented` and `TransformUnscented` processes require different arguments than the other processes
+
 """
-function construct_initial_ensemble(rng::AbstractRNG, prior::ParameterDistribution, N_ens::IT) where {IT <: Int}
-    return sample(rng, prior, N_ens) #of size [dim(param space) N_ens]
+function construct_initial_ensemble(rng::AbstractRNG, prior::ParameterDistribution, N_ens::IT; constrained=false) where {IT <: Int}
+    ss =  sample(rng, prior, N_ens) #of size [dim(param space) N_ens]
+    if constrained
+        return transform_unconstrained_to_constrained(prior, ss)
+    else
+        return ss
+    end
 end
 # first arg optional; defaults to GLOBAL_RNG (as in Random, StatsBase)
-construct_initial_ensemble(prior::ParameterDistribution, N_ens::IT) where {IT <: Int} =
-    construct_initial_ensemble(Random.GLOBAL_RNG, prior, N_ens)
+construct_initial_ensemble(prior::ParameterDistribution, N_ens::IT; kwargs...) where {IT <: Int} =
+    construct_initial_ensemble(Random.GLOBAL_RNG, prior, N_ens; kwargs...)
 
 # metrics of interest
 """

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -881,8 +881,13 @@ prior distribution. Returned with parameters as columns in unconstrained space b
 Note: `Unscented` and `TransformUnscented` processes require different arguments than the other processes
 
 """
-function construct_initial_ensemble(rng::AbstractRNG, prior::ParameterDistribution, N_ens::IT; constrained=false) where {IT <: Int}
-    ss =  sample(rng, prior, N_ens) #of size [dim(param space) N_ens]
+function construct_initial_ensemble(
+    rng::AbstractRNG,
+    prior::ParameterDistribution,
+    N_ens::IT;
+    constrained = false,
+) where {IT <: Int}
+    ss = sample(rng, prior, N_ens) #of size [dim(param space) N_ens]
     if constrained
         return transform_unconstrained_to_constrained(prior, ss)
     else

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -297,7 +297,11 @@ Constructs the initial ensemble for the `Unscented` or `TransformUnscented proce
 
 NOTE: This function is created just to see what the initial `sigma_ensemble` will be without constructing the EKP object. Do not pass the initial ensemble into the `EnsembleKalmanProcess` object.
 """
-function construct_initial_ensemble(prior::ParameterDistribution, process::UorTU; constrained=false) where {UorTU <: Union{Unscented, TransformUnscented}}
+function construct_initial_ensemble(
+    prior::ParameterDistribution,
+    process::UorTU;
+    constrained = false,
+) where {UorTU <: Union{Unscented, TransformUnscented}}
     u0_mean = process.u_mean[1]
     u0u0_cov = process.uu_cov[1]
     sigmas = construct_sigma_ensemble(process, u0_mean, u0u0_cov)

--- a/src/UnscentedKalmanInversion.jl
+++ b/src/UnscentedKalmanInversion.jl
@@ -289,6 +289,26 @@ end
 get_prior_mean(process::UorTU) where {UorTU <: Union{Unscented, TransformUnscented}} = process.prior_mean
 get_prior_cov(process::UorTU) where {UorTU <: Union{Unscented, TransformUnscented}} = process.prior_cov
 
+
+"""
+$(TYPEDSIGNATURES)
+
+Constructs the initial ensemble for the `Unscented` or `TransformUnscented process.  Returned with parameters as columns in unconstrained space by default (constrain by setting `constrained=true`)
+
+NOTE: This function is created just to see what the initial `sigma_ensemble` will be without constructing the EKP object. Do not pass the initial ensemble into the `EnsembleKalmanProcess` object.
+"""
+function construct_initial_ensemble(prior::ParameterDistribution, process::UorTU; constrained=false) where {UorTU <: Union{Unscented, TransformUnscented}}
+    u0_mean = process.u_mean[1]
+    u0u0_cov = process.uu_cov[1]
+    sigmas = construct_sigma_ensemble(process, u0_mean, u0u0_cov)
+    if constrained
+        return transform_unconstrained_to_constrained(prior, sigmas)
+    else
+        return sigmas
+    end
+end
+
+
 function FailureHandler(process::Unscented, method::IgnoreFailures)
     function failsafe_update(uki, u, g, u_idx, g_idx, failed_ens)
         #perform analysis on the model runs

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -550,7 +550,7 @@ end
     @test_logs (:warn,) EKP.EnsembleKalmanProcess(initial_ensemble_small, y_obs_tmp, Γy_tmp, Inversion())
 
     initial_ensemble = EKP.construct_initial_ensemble(copy(rng), prior, N_ens)
-    initial_ensemble_constrained = EKP.construct_intial_ensemble(copy(rng), prior, N_ens, constrained = true)
+    initial_ensemble_constrained = EKP.construct_initial_ensemble(copy(rng), prior, N_ens, constrained = true)
     @test all(
         isapprox.(
             transform_unconstrained_to_constrained(prior, initial_ensemble),

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -549,8 +549,9 @@ end
     initial_ensemble_small = EKP.construct_initial_ensemble(rng, prior_60dims, 99)
     @test_logs (:warn,) EKP.EnsembleKalmanProcess(initial_ensemble_small, y_obs_tmp, Γy_tmp, Inversion())
 
-    initial_ensemble = EKP.construct_initial_ensemble(rng, prior, N_ens)
-
+    initial_ensemble = EKP.construct_initial_ensemble(copy(rng), prior, N_ens)
+    initial_ensemble_constrained = EKP.construct_intial_ensemble(copy(rng), prior, N_ens, constrained=true) 
+    @test all(isapprox.(transform_unconstrained_to_constrained(prior, initial_ensemble), initial_ensemble_constrained, atol=10*eps()))
     #
     initial_ensemble_inf = EKP.construct_initial_ensemble(copy(rng), initial_dist, N_ens) # for the _inf object initial != prior
 
@@ -640,10 +641,12 @@ end
         @test get_obs(ekiobj, 1) == y_obs
         @test get_obs_noise_cov(ekiobj, 1) == Γy
         @test get_obs_noise_cov_inv(ekiobj) == get_obs_noise_cov_inv(ekiobj, 1)
-
-        g_ens = G(get_ϕ_final(prior, ekiobj))
+        
+        params_0 = get_ϕ_final(prior, ekiobj)
+        g_ens = G(params_0)
         g_ens_t = permutedims(g_ens, (2, 1))
-
+        @test all(isapprox.(params_0, initial_ensemble_constrained, atol=10*eps()))
+              
         @test size(g_ens) == (n_obs, N_ens)
         @test get_N_ens(ekiobj) == ekiobj.N_ens
         @test get_rng(ekiobj) == ekiobj.rng
@@ -657,6 +660,7 @@ end
         for i in 1:N_iter
             # Check SampleSuccGauss handler
             params_i = get_ϕ_final(prior, ekiobj)
+            
             push!(u_i_vec, get_u_final(ekiobj))
             g_ens = G(params_i)
             # Add random failures
@@ -839,6 +843,7 @@ end
         TransformUnscented(prior; impose_prior = true),
     ]
     for (i, proc) in enumerate(proc_tmp)
+
         if i <= 2
             @test proc.uu_cov[1] == [1.0 0.0; 0.0 1.0]
             @test proc.u_mean[1] == [1.0, 1.0]
@@ -847,7 +852,6 @@ end
             @test proc.prior_mean == proc.u_mean[1]
         end
     end
-
 
     for (i_prob, inv_problem, impose_prior, update_freq) in
         zip(1:length(inv_problems), inv_problems, impose_priors, update_freqs)
@@ -871,8 +875,8 @@ end
             sigma_points = "symmetric",
             impose_prior = impose_prior,
             update_freq = update_freq,
-        )
-
+        )        
+        
         ukiobj = EKP.EnsembleKalmanProcess(
             y_obs,
             Γy,
@@ -905,6 +909,19 @@ end
             scheduler = deepcopy(scheduler),
             failure_handler_method = IgnoreFailures(),
         )
+
+        # initial ensemble builder
+        initial_ens = construct_initial_ensemble(prior, process)
+        initial_ens_cons = construct_initial_ensemble(prior, process, constrained=true)
+        @test all(isapprox.(get_u_final(prior, ukiobj), initial_ens))
+        @test all(isapprox.(get_ϕ_final(prior, ukiobj), initial_ens_cons))
+        initial_ens = construct_initial_ensemble(prior, process_t)
+        initial_ens_cons = construct_initial_ensemble(prior, process_t, constrained=true)
+        @test all(isapprox.(get_u_final(prior, ukiobj_t), initial_ens))
+        @test all(isapprox.(get_ϕ_final(prior, ukiobj_t), initial_ens_cons))
+        
+        
+        
         # test simplex sigma points
         process_simplex = Unscented(prior; sigma_points = "simplex", impose_prior = impose_prior)
         process_t_simplex = TransformUnscented(prior; sigma_points = "simplex", impose_prior = impose_prior) # run unstable code but dont compare
@@ -924,6 +941,19 @@ end
             scheduler = scheduler_simplex,
             failure_handler_method = SampleSuccGauss(),
         )
+
+        initial_ens = construct_initial_ensemble(prior, process_simplex)
+        initial_ens_cons = construct_initial_ensemble(prior, process_t_simplex, constrained=true)
+        @test all(isapprox.(get_u_final(prior, ukiobj_simplex), initial_ens))
+        @test all(isapprox.(get_ϕ_final(prior, ukiobj_simplex), initial_ens_cons))
+
+        initial_ens = construct_initial_ensemble(prior, process_t_simplex)
+        initial_ens_cons = construct_initial_ensemble(prior, process_t_simplex, constrained=true)
+        @test all(isapprox.(get_u_final(prior, ukiobj_t_simplex), initial_ens))
+        @test all(isapprox.(get_ϕ_final(prior, ukiobj_t_simplex), initial_ens_cons))
+        
+
+        
         # Test incorrect construction throws error
         @test_throws ArgumentError Unscented(prior; sigma_points = "unknowns", impose_prior = impose_prior)
         @test_throws ArgumentError TransformUnscented(prior; sigma_points = "unknowns", impose_prior = impose_prior)

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -919,11 +919,11 @@ end
         # initial ensemble builder
         initial_ens = construct_initial_ensemble(prior, process)
         initial_ens_cons = construct_initial_ensemble(prior, process, constrained = true)
-        @test all(isapprox.(get_u_final(prior, ukiobj), initial_ens))
+        @test all(isapprox.(get_u_final(ukiobj), initial_ens))
         @test all(isapprox.(get_ϕ_final(prior, ukiobj), initial_ens_cons))
         initial_ens = construct_initial_ensemble(prior, process_t)
         initial_ens_cons = construct_initial_ensemble(prior, process_t, constrained = true)
-        @test all(isapprox.(get_u_final(prior, ukiobj_t), initial_ens))
+        @test all(isapprox.(get_u_final(ukiobj_t), initial_ens))
         @test all(isapprox.(get_ϕ_final(prior, ukiobj_t), initial_ens_cons))
 
 
@@ -950,12 +950,12 @@ end
 
         initial_ens = construct_initial_ensemble(prior, process_simplex)
         initial_ens_cons = construct_initial_ensemble(prior, process_t_simplex, constrained = true)
-        @test all(isapprox.(get_u_final(prior, ukiobj_simplex), initial_ens))
+        @test all(isapprox.(get_u_final(ukiobj_simplex), initial_ens))
         @test all(isapprox.(get_ϕ_final(prior, ukiobj_simplex), initial_ens_cons))
 
         initial_ens = construct_initial_ensemble(prior, process_t_simplex)
         initial_ens_cons = construct_initial_ensemble(prior, process_t_simplex, constrained = true)
-        @test all(isapprox.(get_u_final(prior, ukiobj_t_simplex), initial_ens))
+        @test all(isapprox.(get_u_final(ukiobj_t_simplex), initial_ens))
         @test all(isapprox.(get_ϕ_final(prior, ukiobj_t_simplex), initial_ens_cons))
 
 

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -550,8 +550,14 @@ end
     @test_logs (:warn,) EKP.EnsembleKalmanProcess(initial_ensemble_small, y_obs_tmp, Γy_tmp, Inversion())
 
     initial_ensemble = EKP.construct_initial_ensemble(copy(rng), prior, N_ens)
-    initial_ensemble_constrained = EKP.construct_intial_ensemble(copy(rng), prior, N_ens, constrained=true) 
-    @test all(isapprox.(transform_unconstrained_to_constrained(prior, initial_ensemble), initial_ensemble_constrained, atol=10*eps()))
+    initial_ensemble_constrained = EKP.construct_intial_ensemble(copy(rng), prior, N_ens, constrained = true)
+    @test all(
+        isapprox.(
+            transform_unconstrained_to_constrained(prior, initial_ensemble),
+            initial_ensemble_constrained,
+            atol = 10 * eps(),
+        ),
+    )
     #
     initial_ensemble_inf = EKP.construct_initial_ensemble(copy(rng), initial_dist, N_ens) # for the _inf object initial != prior
 
@@ -641,12 +647,12 @@ end
         @test get_obs(ekiobj, 1) == y_obs
         @test get_obs_noise_cov(ekiobj, 1) == Γy
         @test get_obs_noise_cov_inv(ekiobj) == get_obs_noise_cov_inv(ekiobj, 1)
-        
+
         params_0 = get_ϕ_final(prior, ekiobj)
         g_ens = G(params_0)
         g_ens_t = permutedims(g_ens, (2, 1))
-        @test all(isapprox.(params_0, initial_ensemble_constrained, atol=10*eps()))
-              
+        @test all(isapprox.(params_0, initial_ensemble_constrained, atol = 10 * eps()))
+
         @test size(g_ens) == (n_obs, N_ens)
         @test get_N_ens(ekiobj) == ekiobj.N_ens
         @test get_rng(ekiobj) == ekiobj.rng
@@ -660,7 +666,7 @@ end
         for i in 1:N_iter
             # Check SampleSuccGauss handler
             params_i = get_ϕ_final(prior, ekiobj)
-            
+
             push!(u_i_vec, get_u_final(ekiobj))
             g_ens = G(params_i)
             # Add random failures
@@ -875,8 +881,8 @@ end
             sigma_points = "symmetric",
             impose_prior = impose_prior,
             update_freq = update_freq,
-        )        
-        
+        )
+
         ukiobj = EKP.EnsembleKalmanProcess(
             y_obs,
             Γy,
@@ -912,16 +918,16 @@ end
 
         # initial ensemble builder
         initial_ens = construct_initial_ensemble(prior, process)
-        initial_ens_cons = construct_initial_ensemble(prior, process, constrained=true)
+        initial_ens_cons = construct_initial_ensemble(prior, process, constrained = true)
         @test all(isapprox.(get_u_final(prior, ukiobj), initial_ens))
         @test all(isapprox.(get_ϕ_final(prior, ukiobj), initial_ens_cons))
         initial_ens = construct_initial_ensemble(prior, process_t)
-        initial_ens_cons = construct_initial_ensemble(prior, process_t, constrained=true)
+        initial_ens_cons = construct_initial_ensemble(prior, process_t, constrained = true)
         @test all(isapprox.(get_u_final(prior, ukiobj_t), initial_ens))
         @test all(isapprox.(get_ϕ_final(prior, ukiobj_t), initial_ens_cons))
-        
-        
-        
+
+
+
         # test simplex sigma points
         process_simplex = Unscented(prior; sigma_points = "simplex", impose_prior = impose_prior)
         process_t_simplex = TransformUnscented(prior; sigma_points = "simplex", impose_prior = impose_prior) # run unstable code but dont compare
@@ -943,17 +949,17 @@ end
         )
 
         initial_ens = construct_initial_ensemble(prior, process_simplex)
-        initial_ens_cons = construct_initial_ensemble(prior, process_t_simplex, constrained=true)
+        initial_ens_cons = construct_initial_ensemble(prior, process_t_simplex, constrained = true)
         @test all(isapprox.(get_u_final(prior, ukiobj_simplex), initial_ens))
         @test all(isapprox.(get_ϕ_final(prior, ukiobj_simplex), initial_ens_cons))
 
         initial_ens = construct_initial_ensemble(prior, process_t_simplex)
-        initial_ens_cons = construct_initial_ensemble(prior, process_t_simplex, constrained=true)
+        initial_ens_cons = construct_initial_ensemble(prior, process_t_simplex, constrained = true)
         @test all(isapprox.(get_u_final(prior, ukiobj_t_simplex), initial_ens))
         @test all(isapprox.(get_ϕ_final(prior, ukiobj_t_simplex), initial_ens_cons))
-        
 
-        
+
+
         # Test incorrect construction throws error
         @test_throws ArgumentError Unscented(prior; sigma_points = "unknowns", impose_prior = impose_prior)
         @test_throws ArgumentError TransformUnscented(prior; sigma_points = "unknowns", impose_prior = impose_prior)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Resolves #523 


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Add `construct_initial_ensemble(prior, unscented, constrained=false)` method to give the sigma ensemble of the initial ensemble in unscented (transform-unscented) processes
- Add the constrained flag to all methods of `construct_initial_ensemble(; constrained=false)` - false by default to maintain back compatability

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
