### PR TITLE
Throw error for < 2 successful ensemble members

### DIFF
--- a/docs/src/failure_handling.md
+++ b/docs/src/failure_handling.md
@@ -48,8 +48,8 @@ ukiobj = EnsembleKalmanProcess(
 
 The user determines if a ensemble member has failed and replace the output (column) of ``\mathcal{G}(\theta)`` with `NaN`s. The `FailureHandler` takes care of the rest.
 
-!!! info "Minimum number of successful particles = 3"
-    `update_ensemble!` requires a minimum of 3 successful particles to perform an update. Below this will always throw an error. 
+!!! info "Minimum number of successful particles = 2"
+    `update_ensemble!` requires a minimum of 2 successful particles to perform an update. Below this will always throw an error. 
     
 ### Partial particle failure (a.k.a Imputation)
 

--- a/docs/src/failure_handling.md
+++ b/docs/src/failure_handling.md
@@ -48,6 +48,9 @@ ukiobj = EnsembleKalmanProcess(
 
 The user determines if a ensemble member has failed and replace the output (column) of ``\mathcal{G}(\theta)`` with `NaN`s. The `FailureHandler` takes care of the rest.
 
+!!! info "Minimum number of successful particles = 3"
+    `update_ensemble!` requires a minimum of 3 successful particles to perform an update. Below this will always throw an error. 
+    
 ### Partial particle failure (a.k.a Imputation)
 
 If there is a partial failure within an output then the user sets only failed entries within a particle to `NaN`. The user can then use two keywords to determine the imputation approach, given to `EnsembleKalmanProcess`.

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -1156,7 +1156,7 @@ Failures are defined for particles containing at least one NaN output element.
 function split_indices_by_success(g::AbstractMatrix{FT}) where {FT <: Real}
     failed_ens = [i for i = 1:size(g, 2) if any(isnan.(g[:, i]))]
     successful_ens = filter(x -> !(x in failed_ens), collect(1:size(g, 2)))
-    length(successful_ens) >= 3 || _throw_too_few_successful_members(length(successful_ens), size(g, 2))
+    length(successful_ens) >= 2 || _throw_too_few_successful_members(length(successful_ens), size(g, 2))
     if length(failed_ens) > length(successful_ens)
         @warn string(
             "More than 50% of runs produced NaNs ($(length(failed_ens))/$(size(g, 2))).",
@@ -1430,13 +1430,13 @@ end
 Too few successful ensemble members to continue the algorithm.
 
 Expected:
-    At least 3 ensemble members with finite (non-NaN) outputs.
+    At least 2 ensemble members with finite (non-NaN) outputs.
 
 Got:
     $n_successful successful out of $n_total total ensemble members.
 
 Suggestion:
-    Check the forward model for numerical instabilities. Ensure at least 3
+    Check the forward model for numerical instabilities. Ensure at least 2
     ensemble members produce finite outputs before calling update_ensemble!.
 """))
 end

--- a/src/EnsembleKalmanProcess.jl
+++ b/src/EnsembleKalmanProcess.jl
@@ -1156,6 +1156,7 @@ Failures are defined for particles containing at least one NaN output element.
 function split_indices_by_success(g::AbstractMatrix{FT}) where {FT <: Real}
     failed_ens = [i for i = 1:size(g, 2) if any(isnan.(g[:, i]))]
     successful_ens = filter(x -> !(x in failed_ens), collect(1:size(g, 2)))
+    length(successful_ens) >= 3 || _throw_too_few_successful_members(length(successful_ens), size(g, 2))
     if length(failed_ens) > length(successful_ens)
         @warn string(
             "More than 50% of runs produced NaNs ($(length(failed_ens))/$(size(g, 2))).",
@@ -1421,6 +1422,22 @@ Got:
 
 Suggestion:
     Implement `default_options_dict(process::$(typeof(process)))` in EnsembleKalmanProcess.jl.
+"""))
+end
+
+@noinline function _throw_too_few_successful_members(n_successful, n_total)
+    throw(ArgumentError("""
+Too few successful ensemble members to continue the algorithm.
+
+Expected:
+    At least 3 ensemble members with finite (non-NaN) outputs.
+
+Got:
+    $n_successful successful out of $n_total total ensemble members.
+
+Suggestion:
+    Check the forward model for numerical instabilities. Ensure at least 3
+    ensemble members produce finite outputs before calling update_ensemble!.
 """))
 end
 

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -1412,6 +1412,16 @@ end
     end
     @test_logs (:warn, r"More than 50% of runs produced NaNs") match_mode = :any split_indices_by_success(g)
 
+    # All-NaN g must throw rather than hang
+    g_all_nan = fill(NaN, n_obs, N_ens)
+    @test_throws ArgumentError split_indices_by_success(g_all_nan)
+    ekp_for_nan_test = EKP.EnsembleKalmanProcess(
+        EKP.construct_initial_ensemble(Random.MersenneTwister(0), prior, N_ens),
+        zeros(n_obs),
+        Matrix(1.0 * I, n_obs, n_obs),
+        Inversion(),
+    )
+    @test_throws ArgumentError EKP.update_ensemble!(ekp_for_nan_test, g_all_nan)
 
     rng = Random.MersenneTwister(rng_seed)
 

--- a/test/EnsembleKalmanProcess/runtests.jl
+++ b/test/EnsembleKalmanProcess/runtests.jl
@@ -1412,6 +1412,16 @@ end
     end
     @test_logs (:warn, r"More than 50% of runs produced NaNs") match_mode = :any split_indices_by_success(g)
 
+    # Exactly 2 successful members must pass (threshold is now >= 2)
+    g_two_succ = fill(NaN, 5, 10)
+    g_two_succ[:, 9:10] .= rand(5, 2)
+    @test length(first(split_indices_by_success(g_two_succ))) == 2
+
+    # Exactly 1 successful member must throw
+    g_one_succ = fill(NaN, 5, 10)
+    g_one_succ[:, 10] .= rand(5)
+    @test_throws ArgumentError split_indices_by_success(g_one_succ)
+
     # All-NaN g must throw rather than hang
     g_all_nan = fill(NaN, n_obs, N_ens)
     @test_throws ArgumentError split_indices_by_success(g_all_nan)


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
- Closes #565 


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- add error throw to `split_indices_by_success` for < 2 ensemble members
- add a test for all-NaN `g` to ensure it throws and not hangs
- add a note in the docs.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
